### PR TITLE
Fix: Usage gets accumulated

### DIFF
--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -93,8 +93,10 @@ internal class UsageReader: Reader<Network_Usage> {
         }
         freeifaddrs(interfaceAddresses)
         
-        if self.usage.upload != 0 && self.usage.download != 0 {
+        if self.usage.upload != 0 {
             self.usage.upload = upload - self.usage.upload
+        }
+        if self.usage.download != 0 {
             self.usage.download = download - self.usage.download
         }
         


### PR DESCRIPTION
#### Summery
- If upload or download metric is zero, the other metric usage gets accumulated.
- This PR should fix this issue by decoupling related logic.
- Related issue: https://github.com/exelban/stats/issues/118 .