### PR TITLE
Partially fix duplicate entries in RAM module

### DIFF
--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -255,7 +255,7 @@ internal class Popup: NSView, Popup_p {
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
             if !(self.window?.isVisible ?? false) && self.processesInitialized {
-                return;
+                return
             }
             
             if list.count != self.processes.count {

--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -260,14 +260,14 @@ internal class Popup: NSView, Popup_p {
             
             if list.count != self.processes.count {
                 self.processes.forEach { processView in
-                    processView.clear();
+                    processView.clear()
                 }
             }
             
             for i in 0..<list.count {
                 let process = list[i]
                 let index = list.count-i-1
-                self.processes[index].attachProcess(process);
+                self.processes[index].attachProcess(process)
                 self.processes[index].value = "\(process.usage)%"
             }
             

--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -188,7 +188,7 @@ internal class Popup: NSView, Popup_p {
         let separator = SeparatorView(LocalizedString("Top processes"), origin: NSPoint(x: 0, y: self.processesHeight-Constants.Popup.separatorHeight), width: self.frame.width)
         let container: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: separator.frame.origin.y))
         
-        for i in 0...self.numberOfProcesses {
+        for i in 0..<self.numberOfProcesses {
             let processView = ProcessView(CGFloat(i))
             self.processes.append(processView)
             container.addSubview(processView)

--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -254,20 +254,24 @@ internal class Popup: NSView, Popup_p {
     
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
-            if (self.window?.isVisible ?? false) || !self.processesInitialized {
-                for i in 0..<list.count {
-                    let process = list[i]
-                    let index = list.count-i-1
-                    if self.processes.indices.contains(index) {
-                        self.processes[index].label = process.name != nil ? process.name! : process.command
-                        self.processes[index].value = "\(process.usage)%"
-                        self.processes[index].icon = process.icon
-                        self.processes[index].toolTip = "pid: \(process.pid)"
-                    }
-                }
-                
-                self.processesInitialized = true
+            if !(self.window?.isVisible ?? false) && self.processesInitialized {
+                return;
             }
+            
+            if list.count != self.processes.count {
+                self.processes.forEach { processView in
+                    processView.clear();
+                }
+            }
+            
+            for i in 0..<list.count {
+                let process = list[i]
+                let index = list.count-i-1
+                self.processes[index].attachProcess(process);
+                self.processes[index].value = "\(process.usage)%"
+            }
+            
+            self.processesInitialized = true
         })
     }
 }

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -242,14 +242,14 @@ internal class Popup: NSView, Popup_p {
             
             if list.count != self.processes.count {
                 self.processes.forEach { processView in
-                    processView.clear();
+                    processView.clear()
                 }
             }
             
             for i in 0..<list.count {
                 let process = list[i]
                 let index = list.count-i-1
-                self.processes[index].attachProcess(process);
+                self.processes[index].attachProcess(process)
                 self.processes[index].value = "\(process.usage)%"
             }
             

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -236,20 +236,24 @@ internal class Popup: NSView, Popup_p {
     
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
-            if (self.window?.isVisible ?? false) || !self.processesInitialized {
-                for i in 0..<list.count {
-                    let process = list[i]
-                    let index = list.count-i-1
-                    if self.processes.indices.contains(index) {
-                        self.processes[index].label = process.name != nil ? process.name! : process.command
-                        self.processes[index].value = "\(process.usage)%"
-                        self.processes[index].icon = process.icon
-                        self.processes[index].toolTip = "pid: \(process.pid)"
-                    }
-                }
-                
-                self.processesInitialized = true
+            if !(self.window?.isVisible ?? false) && self.processesInitialized {
+                return;
             }
+            
+            if list.count != self.processes.count {
+                self.processes.forEach { processView in
+                    processView.clear();
+                }
+            }
+            
+            for i in 0..<list.count {
+                let process = list[i]
+                let index = list.count-i-1
+                self.processes[index].attachProcess(process);
+                self.processes[index].value = "\(process.usage)%"
+            }
+            
+            self.processesInitialized = true
         })
     }
 }

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -237,7 +237,7 @@ internal class Popup: NSView, Popup_p {
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
             if !(self.window?.isVisible ?? false) && self.processesInitialized {
-                return;
+                return
             }
             
             if list.count != self.processes.count {

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -174,7 +174,7 @@ internal class Popup: NSView, Popup_p {
         let separator = SeparatorView(LocalizedString("Top processes"), origin: NSPoint(x: 0, y: self.processesHeight-Constants.Popup.separatorHeight), width: self.frame.width)
         let container: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: separator.frame.origin.y))
         
-        for i in 0...self.numberOfProcesses {
+        for i in 0..<self.numberOfProcesses {
             let processView = ProcessView(CGFloat(i))
             self.processes.append(processView)
             container.addSubview(processView)

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -237,14 +237,14 @@ internal class Popup: NSView, Popup_p {
             
             if list.count != self.processes.count {
                 self.processes.forEach { processView in
-                    processView.clear();
+                    processView.clear()
                 }
             }
             
             for i in 0..<list.count {
                 let process = list[i]
                 let index = list.count-i-1
-                self.processes[index].attachProcess(process);
+                self.processes[index].attachProcess(process)
                 self.processes[index].value = Units(bytes: Int64(process.usage)).getReadableMemory()
             }
             

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -232,7 +232,7 @@ internal class Popup: NSView, Popup_p {
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
             if !(self.window?.isVisible ?? false) && self.processesInitialized {
-                return;
+                return
             }
             
             if list.count != self.processes.count {

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -231,23 +231,24 @@ internal class Popup: NSView, Popup_p {
     
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
-            if (self.window?.isVisible ?? false) || !self.processesInitialized {
-                for i in 0..<self.processes.count {
-                    let listIndex = list.count-i-1
-                    
-                    if list.indices.contains(listIndex) {
-                        let process = list[listIndex]
-                        self.processes[i].label = process.name != nil ? process.name! : process.command
-                        self.processes[i].value = Units(bytes: Int64(process.usage)).getReadableMemory()
-                        self.processes[i].icon = process.icon
-                        self.processes[i].toolTip = "pid: \(process.pid)"
-                    } else {
-                        self.processes[i].clear();
-                    }
-                }
-                
-                self.processesInitialized = true
+            if !(self.window?.isVisible ?? false) && self.processesInitialized {
+                return;
             }
+            
+            if list.count != self.processes.count {
+                self.processes.forEach { processView in
+                    processView.clear();
+                }
+            }
+            
+            for i in 0..<list.count {
+                let process = list[i]
+                let index = list.count-i-1
+                self.processes[index].attachProcess(process);
+                self.processes[index].value = Units(bytes: Int64(process.usage)).getReadableMemory()
+            }
+            
+            self.processesInitialized = true
         })
     }
 }

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -170,7 +170,7 @@ internal class Popup: NSView, Popup_p {
         let separator = SeparatorView(LocalizedString("Top processes"), origin: NSPoint(x: 0, y: self.processesHeight-Constants.Popup.separatorHeight), width: self.frame.width)
         let container: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: separator.frame.origin.y))
         
-        for i in 0...self.numberOfProcesses {
+        for i in 0..<self.numberOfProcesses {
             let processView = ProcessView(CGFloat(i))
             self.processes.append(processView)
             container.addSubview(processView)

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -232,14 +232,20 @@ internal class Popup: NSView, Popup_p {
     public func processCallback(_ list: [TopProcess]) {
         DispatchQueue.main.async(execute: {
             if (self.window?.isVisible ?? false) || !self.processesInitialized {
-                for i in 0..<list.count {
-                    let process = list[i]
-                    let index = list.count-i-1
-                    if self.processes.indices.contains(index) {
-                        self.processes[index].label = process.name != nil ? process.name! : process.command
-                        self.processes[index].value = Units(bytes: Int64(process.usage)).getReadableMemory()
-                        self.processes[index].icon = process.icon
-                        self.processes[index].toolTip = "pid: \(process.pid)"
+                for i in 0..<self.processes.count {
+                    let listIndex = list.count-i-1
+                    
+                    if list.indices.contains(listIndex) {
+                        let process = list[listIndex]
+                        self.processes[i].label = process.name != nil ? process.name! : process.command
+                        self.processes[i].value = Units(bytes: Int64(process.usage)).getReadableMemory()
+                        self.processes[i].icon = process.icon
+                        self.processes[i].toolTip = "pid: \(process.pid)"
+                    } else {
+                        self.processes[i].label = ""
+                        self.processes[i].value = ""
+                        self.processes[i].icon = nil
+                        self.processes[i].toolTip = ""
                     }
                 }
                 

--- a/Modules/Memory/popup.swift
+++ b/Modules/Memory/popup.swift
@@ -242,10 +242,7 @@ internal class Popup: NSView, Popup_p {
                         self.processes[i].icon = process.icon
                         self.processes[i].toolTip = "pid: \(process.pid)"
                     } else {
-                        self.processes[i].label = ""
-                        self.processes[i].value = ""
-                        self.processes[i].icon = nil
-                        self.processes[i].toolTip = ""
+                        self.processes[i].clear();
                     }
                 }
                 

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -351,21 +351,25 @@ internal class Popup: NSView, Popup_p {
     
     public func processCallback(_ list: [Network_Process]) {
         DispatchQueue.main.async(execute: {
-            if (self.window?.isVisible ?? false) || !self.processesInitialized {
-                for i in 0..<list.count {
-                    let process = list[i]
-                    let index = list.count-i-1
-                    if self.processes.indices.contains(index) {
-                        self.processes[index].label = process.name
-                        self.processes[index].upload = Units(bytes: Int64(process.upload)).getReadableSpeed(base: DataSizeBase(rawValue: self.base) ?? .byte)
-                        self.processes[index].download = Units(bytes: Int64(process.download)).getReadableSpeed(base: DataSizeBase(rawValue: self.base) ?? .byte)
-                        self.processes[index].icon = process.icon
-                        self.processes[index].toolTip = "pid: \(process.pid)"
-                    }
-                }
-                
-                self.processesInitialized = true
+            if !(self.window?.isVisible ?? false) && self.processesInitialized {
+                return;
             }
+            
+            if list.count != self.processes.count {
+                self.processes.forEach { processView in
+                    processView.clear();
+                }
+            }
+            
+            for i in 0..<list.count {
+                let process = list[i]
+                let index = list.count-i-1
+                self.processes[index].attachProcess(process);
+                self.processes[index].upload = Units(bytes: Int64(process.upload)).getReadableSpeed(base: DataSizeBase(rawValue: self.base) ?? .byte)
+                self.processes[index].download = Units(bytes: Int64(process.download)).getReadableSpeed(base: DataSizeBase(rawValue: self.base) ?? .byte)
+            }
+            
+            self.processesInitialized = true
         })
     }
 }
@@ -468,5 +472,19 @@ public class NetworkProcessView: NSView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func attachProcess(_ process: Network_Process) {
+        self.label = process.name
+        self.icon = process.icon
+        self.toolTip = "pid: \(process.pid)"
+    }
+    
+    public func clear() {
+        self.label = ""
+        self.download = ""
+        self.upload = ""
+        self.icon = nil
+        self.toolTip = ""
     }
 }

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -352,7 +352,7 @@ internal class Popup: NSView, Popup_p {
     public func processCallback(_ list: [Network_Process]) {
         DispatchQueue.main.async(execute: {
             if !(self.window?.isVisible ?? false) && self.processesInitialized {
-                return;
+                return
             }
             
             if list.count != self.processes.count {

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -206,7 +206,7 @@ internal class Popup: NSView, Popup_p {
         let separator = SeparatorView(LocalizedString("Top processes"), origin: NSPoint(x: 0, y: self.processesHeight-Constants.Popup.separatorHeight), width: self.frame.width)
         let container: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: separator.frame.origin.y))
         
-        for i in 0...self.numberOfProcesses {
+        for i in 0..<self.numberOfProcesses {
             let processView = NetworkProcessView(CGFloat(i))
             self.processes.append(processView)
             container.addSubview(processView)

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -357,14 +357,14 @@ internal class Popup: NSView, Popup_p {
             
             if list.count != self.processes.count {
                 self.processes.forEach { processView in
-                    processView.clear();
+                    processView.clear()
                 }
             }
             
             for i in 0..<list.count {
                 let process = list[i]
                 let index = list.count-i-1
-                self.processes[index].attachProcess(process);
+                self.processes[index].attachProcess(process)
                 self.processes[index].upload = Units(bytes: Int64(process.upload)).getReadableSpeed(base: self.base)
                 self.processes[index].download = Units(bytes: Int64(process.download)).getReadableSpeed(base: self.base)
             }

--- a/StatsKit/helpers.swift
+++ b/StatsKit/helpers.swift
@@ -730,6 +730,12 @@ public class ProcessView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    public func attachProcess(_ process: TopProcess) {
+        self.label = process.name != nil ? process.name! : process.command
+        self.icon = process.icon
+        self.toolTip = "pid: \(process.pid)"
+    }
+    
     public func clear() {
         self.label = ""
         self.value = ""

--- a/StatsKit/helpers.swift
+++ b/StatsKit/helpers.swift
@@ -729,6 +729,13 @@ public class ProcessView: NSView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    public func clear() {
+        self.label = ""
+        self.value = ""
+        self.icon = nil
+        self.toolTip = ""
+    }
 }
 
 public class CAText: CATextLayer {


### PR DESCRIPTION
This is related to #169. While this PR does not fix the issue, it does prevent duplicate processes from appearing in the RAM list due to not having enough processes returned from `top`. 

Should this possibly be applied to the other modules as well?