### PR TITLE
Update "Homebrew" installation procedure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Download the file called `Stats.dmg`. Open it and move the app to the applicatio
 ### Homebrew
 
 ```bash
-brew cask install stats
+brew install --cask stats
 ```
 
 ## Requirements


### PR DESCRIPTION
`brew cask install` is deprecated:

> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.

The *Homebrew* installation procedure thus becomes: `brew install --cask stats`