### PR TITLE
Mac Mini detection

### DIFF
--- a/StatsKit/SystemKit.swift
+++ b/StatsKit/SystemKit.swift
@@ -337,11 +337,11 @@ public class SystemKit {
 
 let deviceDict: [String: model_s] = [
     // Mac Mini
-    "MacMini6,1": model_s(name: "Mac mini (Late 2012)", year: 2012, type: .macMini),
-    "MacMini6,2": model_s(name: "Mac mini (Late 2012)", year: 2012, type: .macMini),
-    "MacMini7,1": model_s(name: "Mac mini (Late 2014)", year: 2014, type: .macMini),
-    "MacMini8,1": model_s(name: "Mac mini (Late 2018)", year: 2018, type: .macMini),
-    "MacMini9,1": model_s(name: "Mac mini (M1, 2020)", year: 2020, type: .macMini),
+    "Macmini6,1": model_s(name: "Mac mini (Late 2012)", year: 2012, type: .macMini),
+    "Macmini6,2": model_s(name: "Mac mini (Late 2012)", year: 2012, type: .macMini),
+    "Macmini7,1": model_s(name: "Mac mini (Late 2014)", year: 2014, type: .macMini),
+    "Macmini8,1": model_s(name: "Mac mini (Late 2018)", year: 2018, type: .macMini),
+    "Macmini9,1": model_s(name: "Mac mini (M1, 2020)", year: 2020, type: .macMini),
     
     // Mac Pro
     "MacPro5,1": model_s(name: "Mac Pro (2012)", year: 2010, type: .macPro),


### PR DESCRIPTION
seems like b14436b0c3d8cbf73c05cbcbf28c1db3a5f01aa8 broke model detection for me (Mac Mini 2018) and I expect other Mac Mini's (the 2nd "m" in model identifier should be lowercase)

![image](https://user-images.githubusercontent.com/1992842/100545008-929fed80-3227-11eb-80d2-e7ea240aab73.png)

![image](https://user-images.githubusercontent.com/1992842/100545081-08a45480-3228-11eb-8693-9e9c2b1c69fe.png)

I created this PR but I couldn't actually test it because I couldn't figure out how to build it, it was complaining about a missing signing cert for the `LaunchAtLogin` module.

