### PR TITLE
Update Taiwan Traditional Chinese Localization Translate

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -48,7 +48,7 @@
 // Application settings
 "Update application" = "更新應用程式";
 "Check for updates" = "檢查更新";
-"At start" = "打開時";
+"At start" = "打開時檢查";
 "Once per day" = "每天 1 次";
 "Once per week" = "每週 1 次";
 "Once per month" = "每月 1 次";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -48,18 +48,18 @@
 // Application settings
 "Update application" = "更新應用程式";
 "Check for updates" = "檢查更新";
-"At start" = "At start";
-"Once per day" = "Once per day";
-"Once per week" = "Once per week";
-"Once per month" = "Once per month";
-"Never" = "Never";
+"At start" = "打開時";
+"Once per day" = "每天 1 次";
+"Once per week" = "每週 1 次";
+"Once per month" = "每月 1 次";
+"Never" = "從不";
 "Check for update" = "檢查更新";
 "Show icon in dock" = "在 Dock 顯示圖示";
 "Start at login" = "登入時打開";
 
 // Dashboard
-"Serial number" = "序列號";
-"Uptime" = "正常運行時間";
+"Serial number" = "序號";
+"Uptime" = "正常運作時間";
 
 // Update
 "The latest version of Stats installed" = "已安裝最新版本";


### PR DESCRIPTION
Update Taiwan TC Localization Below:
更新臺灣正體中文最佳化翻譯如下：
* "Check for Update" Options (「檢查更新」之各該選項)
* "Serial Number" & "Uptime" under the "Dashboard" (「儀表板」項下之「序號」及「正常運作時間」)