### PR TITLE
Update macOS Name Recognition

### DIFF
--- a/StatsKit/SystemKit.swift
+++ b/StatsKit/SystemKit.swift
@@ -115,7 +115,7 @@ public class SystemKit {
             build = buildArr[1].replacingOccurrences(of: "Build ", with: "").replacingOccurrences(of: ")", with: "")
         }
         
-        let version = "\(systemVersion.majorVersion).\(systemVersion.minorVersion)"
+        let version = systemVersion.majorVersion > 10 ? "\(systemVersion.majorVersion)" : "\(systemVersion.majorVersion).\(systemVersion.minorVersion)"
         self.device.os = os_s(name: osDict[version] ?? LocalizedString("Unknown"), version: systemVersion, build: build)
         
         self.device.info.cpu = self.getCPUInfo()
@@ -467,6 +467,5 @@ let deviceDict: [String: model_s] = [
 let osDict: [String: String] = [
     "10.14": "Mojave",
     "10.15": "Catalina",
-    "11.0": "Big Sur",
-    "11.1": "Big Sur",
+    "11": "Big Sur",
 ]


### PR DESCRIPTION
macOS 11.2 was released. It seems Apple adjusted the naming of macOS version numbers to a way similar to the iOS/iPadOS, so I guess only the `majorVersion` is needed in the future.