### PR TITLE
Add Localization to the Power Source

### DIFF
--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -224,7 +224,7 @@ internal class Popup: NSView, Popup_p {
             self.dashboardBatteryView?.setValue(abs(value.level))
             
             self.levelField?.stringValue = "\(Int(abs(value.level) * 100)) %"
-            self.sourceField?.stringValue = value.powerSource
+            self.sourceField?.stringValue = "\(LocalizedString(value.powerSource))"
             self.timeField?.stringValue = ""
             
             if value.powerSource == "Battery Power" {

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -82,6 +82,15 @@
 "Display mode" = "Режим на преглед";
 "One row" = "Един ред";
 "Two rows" = "Два реда";
+"Mini widget" = "Mini";
+"Line chart widget" = "Line chart";
+"Bar chart widget" = "Bar chart";
+"Pie chart widget" = "Pie chart";
+"Network chart widget" = "Network chart";
+"Speed widget" = "Speed";
+"Battery widget" = "Battery";
+"Text widget" = "Text";
+"Memory widget" = "Memory";
 
 // Module Kit
 "Open module settings" = "Отваряне на настройките на модула";
@@ -169,6 +178,8 @@
 // Battery
 "Level" = "Ниво";
 "Source" = "Източник";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Време";
 "Health" = "Здраве";
 "Battery" = "Батерия";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Úroveň";
 "Source" = "Zdroj";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Čas";
 "Health" = "Zdraví";
 "Battery" = "Baterie";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Ladezustand";
 "Source" = "Quelle";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Zeit";
 "Health" = "Gesundheit";
 "Battery" = "Akku";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Level";
 "Source" = "Source";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Time";
 "Health" = "Health";
 "Battery" = "Battery";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Nivel";
 "Source" = "Fuente";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Tiempo";
 "Health" = "Salud";
 "Battery" = "Batería";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Niveau";
 "Source" = "Source";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Temps";
 "Health" = "Santé";
 "Battery" = "Batterie";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Töltöttségi szint";
 "Source" = "Forrás";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Időtartam";
 "Health" = "Állapot";
 "Battery" = "Akkumulátor";

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Livello";
 "Source" = "Sorgente";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Tempo";
 "Health" = "Vita";
 "Battery" = "Batteria";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "充電残量";
 "Source" = "電源";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "バッテリー残り時間";
 "Health" = "状態";
 "Battery" = "バッテリー";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "잔량";
 "Source" = "공급원";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "시간";
 "Health" = "상태";
 "Battery" = "배터리";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Nivå";
 "Source" = "Kilde";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Tid";
 "Health" = "Helse";
 "Battery" = "Batteri";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Poziom naładowania";
 "Source" = "Źródło";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Czas";
 "Health" = "Zdrowie";
 "Battery" = "Bateria";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Nível";
 "Source" = "Fonte";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Tempo";
 "Health" = "Saúde";
 "Battery" = "Bateria";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Nível";
 "Source" = "Fonte";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Tempo";
 "Health" = "Saúde";
 "Battery" = "Bateria";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -82,6 +82,15 @@
 "Display mode" = "Modul de vizualizare";
 "One row" = "Un rând";
 "Two rows" = "Două rânduri";
+"Mini widget" = "Mini";
+"Line chart widget" = "Line chart";
+"Bar chart widget" = "Bar chart";
+"Pie chart widget" = "Pie chart";
+"Network chart widget" = "Network chart";
+"Speed widget" = "Speed";
+"Battery widget" = "Battery";
+"Text widget" = "Text";
+"Memory widget" = "Memory";
 
 // Module Kit
 "Open module settings" = "Deschide setăriile modulului";
@@ -169,6 +178,8 @@
 // Battery
 "Level" = "Nivel";
 "Source" = "Sursă";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Timp";
 "Health" = "Sănătate";
 "Battery" = "Baterie";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Уровень заряда";
 "Source" = "Источник";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Время";
 "Health" = "Состояние аккумулятора";
 "Battery" = "Аккумулятор";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Doluluk";
 "Source" = "Kaynak";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Süre";
 "Health" = "Sağlık";
 "Battery" = "Batarya";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Рівень заряду";
 "Source" = "Джерело";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Час";
 "Health" = "Стан акумулятора";
 "Battery" = "Акумулятор";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "Dung lượng Pin";
 "Source" = "Nguồn";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "Thời gian";
 "Health" = "Sức khoẻ";
 "Battery" = "PIN";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "电量";
 "Source" = "电源";
+"AC Power" = "交流电";
+"Battery Power" = "电池";
 "Time" = "时间";
 "Health" = "健康度";
 "Battery" = "电池";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -178,6 +178,8 @@
 // Battery
 "Level" = "電量";
 "Source" = "電源";
+"AC Power" = "AC Power";
+"Battery Power" = "Battery Power";
 "Time" = "時間";
 "Health" = "健康度";
 "Battery" = "電池";


### PR DESCRIPTION
Add two terms to all the languages and add localizations of widgets to Bulgarian and Romanian.

Before localization: <img width="271" alt="before" src="https://user-images.githubusercontent.com/21986946/107206459-08031800-6a3a-11eb-8f68-f82703f7478d.png">

After localization: <img width="273" alt="after" src="https://user-images.githubusercontent.com/21986946/107206464-09ccdb80-6a3a-11eb-8c73-8ece6b1c2510.png">

