### PR TITLE
Update Chinese Traditional (Taiwan) Translation File

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -196,6 +196,7 @@
 "Fully charged" = "已充飽";
 "Not connected" = "未連接";
 "Low level notification" = "低電量通知";
+"High level notification" = "高電量通知";
 "Low battery" = "低電量";
 "Battery remaining" = "剩餘 %0%";
 "Percentage" = "百分比";


### PR DESCRIPTION
### Update Chinese Traditional (Taiwan) Translation File
### 更新正體中文（臺灣）翻譯檔案

- Add "High level notification" Item with its Chinese Traditional (Taiwan) Translation "高電量通知".
新增「High level notification」項目及其正體中文（臺灣）翻譯「高電量通知」。