### PR TITLE
Fixed spanish lang, network refresh button width fix

### DIFF
--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -185,8 +185,10 @@ internal class Popup: NSStackView, Popup_p {
         
         let row: NSView = NSView(frame: NSRect(x: 0, y: 0, width: view.frame.width, height: Constants.Popup.separatorHeight))
         
+        let updatebutton_width = (LocalizedString("Refresh") as NSString).size(withAttributes: [NSAttributedString.Key.font: NSFont.systemFont(ofSize: 11, weight: .light)]).width
+        
         let button = NSButtonWithPadding()
-        button.frame = CGRect(x: view.frame.width - 44, y: 5, width: 44, height: 20)
+        button.frame = CGRect(x: view.frame.width - updatebutton_width, y: 5, width: updatebutton_width, height: 20)
         button.bezelStyle = .regularSquare
         button.isBordered = false
         button.action = #selector(self.refreshPublicIP)

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -185,16 +185,18 @@ internal class Popup: NSStackView, Popup_p {
         
         let row: NSView = NSView(frame: NSRect(x: 0, y: 0, width: view.frame.width, height: Constants.Popup.separatorHeight))
         
-        let updatebutton_width = (LocalizedString("Refresh") as NSString).size(withAttributes: [NSAttributedString.Key.font: NSFont.systemFont(ofSize: 11, weight: .light)]).width
+        let refreshString = LocalizedString("Refresh")
+        
+        let updateButtonWidth = (refreshString).size(withAttributes: [NSAttributedString.Key.font: NSFont.systemFont(ofSize: 11, weight: .light)]).width
         
         let button = NSButtonWithPadding()
-        button.frame = CGRect(x: view.frame.width - updatebutton_width, y: 5, width: updatebutton_width, height: 20)
+        button.frame = CGRect(x: view.frame.width - updateButtonWidth, y: 5, width: updateButtonWidth, height: 20)
         button.bezelStyle = .regularSquare
         button.isBordered = false
         button.action = #selector(self.refreshPublicIP)
         button.target = self
-        button.toolTip = LocalizedString("Refresh")
-        button.title = LocalizedString("Refresh")
+        button.toolTip = refreshString
+        button.title = refreshString
         button.font = NSFont.systemFont(ofSize: 11, weight: .light)
         
         row.addSubview(SeparatorView(LocalizedString("Public IP"), origin: NSPoint(x: 0, y: 0), width: self.frame.width))

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "Statistics" = "Statistics";
 "Max" = "Max";
 "Min" = "Min";
+"Refresh" = "Refresh";
 
 // Alerts
 "New version available" = "New version available";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -67,7 +67,7 @@
 "Uptime" = "Uptime";
 
 // Update
-"The latest version of Stats installed" = "The latest version of Stats installed";
+"The latest version of Stats installed" = "The latest version of Stats is installed";
 "Downloading..." = "Downloading...";
 "Current version: " = "Current version:  ";
 "Latest version: " = "Latest version:    ";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -34,6 +34,7 @@
 "Statistics" = "Estadísticas";
 "Max" = "Max";
 "Min" = "Min";
+"Refresh" = "Actualizar";
 
 // Alerts
 "New version available" = "Nueva versión disponible";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -24,6 +24,7 @@
 "Yes" = "Sí";
 "No" = "No";
 "Automatic" = "Automático";
+"Manual" = "Manual";
 "None" = "Ninguna";
 "Dots" = "Puntos";
 "Arrows" = "Flechas";
@@ -31,6 +32,8 @@
 "Short" = "Corto";
 "Long" = "Largo";
 "Statistics" = "Estadísticas";
+"Max" = "Max";
+"Min" = "Min";
 
 // Alerts
 "New version available" = "Nueva versión disponible";
@@ -49,12 +52,12 @@
 // Application settings
 "Update application" = "Actualizar la aplicación";
 "Check for updates" = "Buscar actualizaciones";
-"At start" = "At start";
-"Once per day" = "Once per day";
-"Once per week" = "Once per week";
-"Once per month" = "Once per month";
-"Never" = "Never";
-"Check for update" = "Buscar actualización";
+"At start" = "Al iniciar el sistema";
+"Once per day" = "Una vez al día";
+"Once per week" = "Una vez por semana";
+"Once per month" = "Una vez al mes";
+"Never" = "Nunca";
+"Check for update" = "Buscar actualizaciones";
 "Show icon in dock" = "Muestra el icono en el dock";
 "Start at login" = "Arrancar al iniciar sesión";
 
@@ -83,14 +86,14 @@
 "One row" = "Una fila";
 "Two rows" = "Dos filas";
 "Mini widget" = "Mini";
-"Line chart widget" = "Line chart";
-"Bar chart widget" = "Bar chart";
-"Pie chart widget" = "Pie chart";
-"Network chart widget" = "Network chart";
-"Speed widget" = "Speed";
-"Battery widget" = "Battery";
-"Text widget" = "Text";
-"Memory widget" = "Memory";
+"Line chart widget" = "Gráfico de líneas";
+"Bar chart widget" = "Gráfico de barras";
+"Pie chart widget" = "Gráfico de torta";
+"Network chart widget" = "Gráfico de redes";
+"Speed widget" = "Velocidad";
+"Battery widget" = "Batería";
+"Text widget" = "Texto";
+"Memory widget" = "Memoria";
 
 // Module Kit
 "Open module settings" = "Abrir la configruación del módulo";
@@ -99,7 +102,7 @@
 "Usage history" = "Historial de uso";
 "Details" = "Detalles";
 "Top processes" = "Procesos principales";
-"Pictogram" = "Icono";
+"Pictogram" = "Ícono";
 
 // Modules
 "Number of top processes" = "Número de procesos principales";
@@ -117,19 +120,19 @@
 // GPU
 "GPU to show" = "GPU a mostrar";
 "Show GPU type" = "Mostrar tipo de GPU";
-"GPU enabled" = "GPU enabled";
-"GPU disabled" = "GPU disabled";
+"GPU enabled" = "GPU activada";
+"GPU disabled" = "GPU desactivada";
 "GPU temperature" = "Temperatura de la GPU";
 "GPU utilization" = "Utilización de la GPU";
-"Vendor" = "Vendor";
-"Model" = "Model";
-"Status" = "Status";
-"Active" = "Active";
-"Non active" = "Non active";
-"Fan speed" = "Fan speed";
-"Core clock" = "Core clock";
-"Memory clock" = "Memory clock";
-"Utilization" = "Utilization";
+"Vendor" = "Fabricante";
+"Model" = "Modelo";
+"Status" = "Estado";
+"Active" = "Activo";
+"Non active" = "Inactivo";
+"Fan speed" = "Velocidad del ventilador";
+"Core clock" = "Reloj del núcleo";
+"Memory clock" = "Reloj de la memoria";
+"Utilization" = "Utilización";
 
 // Memory
 "Memory usage" = "Uso de la memoria";
@@ -156,8 +159,8 @@
 "Fahrenheit" = "Fahrenheit";
 
 // Network
-"Uploading" = "Cargando";
-"Downloading" = "Descargando";
+"Uploading" = "Carga";
+"Downloading" = "Descarga";
 "Public IP" = "IP Pública";
 "Local IP" = "IP Local";
 "Interface" = "Interfaz";
@@ -178,8 +181,8 @@
 // Battery
 "Level" = "Nivel";
 "Source" = "Fuente";
-"AC Power" = "AC Power";
-"Battery Power" = "Battery Power";
+"AC Power" = "Alimentación de CA";
+"Battery Power" = "Alimentado por batería";
 "Time" = "Tiempo";
 "Health" = "Salud";
 "Battery" = "Batería";
@@ -196,9 +199,9 @@
 "Fully charged" = "Completamente cargada";
 "Not connected" = "No conectado";
 "Low level notification" = "Notificación de nivel bajo";
-"High level notification" = "High level notification";
+"High level notification" = "Notificación de nivel alto";
 "Low battery" = "Batería baja";
-"High battery" = "High battery";
+"High battery" = "Batería alta";
 "Battery remaining" = "%0% restante";
 "Percentage" = "Porcentaje";
 "Percentage and time" = "Porcentaje y tiempo";

--- a/Stats/Views/Update.swift
+++ b/Stats/Views/Update.swift
@@ -147,9 +147,9 @@ private class UpdateView: NSView {
     }
     
     public func noUpdates() {
-        let view: NSView = NSView(frame: NSRect(x: 10, y: 10, width: self.frame.width - 20, height: self.frame.height - 20 - 26))
+        let view: NSView = NSView(frame: NSRect(x: 10, y: 10, width: self.frame.width - 20, height: self.frame.height - 20))
         
-        let title: NSTextField = TextView(frame: NSRect(x: 0, y: ((view.frame.height - 18)/2)+20, width: view.frame.width, height: 18))
+        let title: NSTextField = TextView(frame: NSRect(x: 0, y: ((view.frame.height - 18)/2), width: view.frame.width, height: 40))
         title.font = NSFont.systemFont(ofSize: 14, weight: .light)
         title.alignment = .center
         title.stringValue = LocalizedString("The latest version of Stats installed")


### PR DESCRIPTION
- Added missing refresh lang entry to langs.
- Refresh button now computes the width dynamically to support new languages. The fixed 44px creates visual glitches when using my Spanish translated text.
- Updated spanish localization.
- Fixed english update lang.
- Fixed vertical centering of update message, now it works with other languages (Spanish).