### PR TITLE
Typo in german localization

### DIFF
--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "Status" = "Status";
 "Active" = "Aktiv";
 "Non active" = "Nicht aktiv";
-"Fan speed" = "Lüfterdrehzal";
+"Fan speed" = "Lüfterdrehzahl";
 "Core clock" = "Core Frequenz";
 "Memory clock" = "Memory Frequenz";
 "Utilization" = "Auslastung";


### PR DESCRIPTION
forgotten a h