### PR TITLE
Fix "Show icon in dock" Translation

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Once per month" = "每月 1 次";
 "Never" = "從不";
 "Check for update" = "檢查更新";
-"Show icon in dock" = "在 Dock 顯示圖示";
+"Show icon in dock" = "在 Dock 上顯示圖示";
 "Start at login" = "登入時打開";
 
 // Dashboard


### PR DESCRIPTION
Fix `"Show icon in dock"` Traditional Chinese (Taiwan) Translation.
修正「`Show icon in dock`」的正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> https://github.com/exelban/stats/pull/424

**Commit Summary
更新大綱**

- Fix `"Show icon in dock"` Traditional Chinese (Taiwan) Translation.
修正「`Show icon in dock`」的正體中文（臺灣）翻譯。

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/424/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/424.patch
https://github.com/exelban/stats/pull/424.diff