### PR TITLE
Re-pull PR #469 (Fix Traditional Chinese (Taiwan) Translation)

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -190,7 +190,7 @@
 "Battery" = "電池";
 "Amperage" = "電流";
 "Voltage" = "電壓";
-"Cycles" = "循環數";
+"Cycles" = "循環使用次數";
 "Temperature" = "溫度";
 "Power adapter" = "電源供應器";
 "Power" = "功率";
@@ -211,7 +211,7 @@
 "Time and percentage" = "時間和百分比";
 "Time format" = "時間格式";
 "Hide additional information when full" = "電池充飽後隱藏其他資訊";
-"Last charge" = "最後一次收費";
+"Last charge" = "最近一次充電";
 
 // Fans
 "Fans" = "風扇";


### PR DESCRIPTION
**Re-pull  PR #469**

**Fix the wrong term in Traditional Chinese (Taiwan) Translation below:
修正正體中文（臺灣）的錯誤翻譯如下：**

- "**收費**" means to **charge money**.
"**充電**" means to **charge battery**.
「收費」在英文意指「charge money」。
「充電」在英文意指「charge battery」。
- Fix the translation `"cycle"` to fit with macOS system's.
修正「`cycle`」的正體中文（臺灣）翻譯來與系統相符。

————————————————————————

You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此Pull Request：

- https://github.com/exelban/stats/pull/481

**Commit Summary
摘要**

- update and optimize Traditional Chinese (Taiwan) translation "last charge"
更新並最佳化正體中文（臺灣）的「last charge」翻譯
- Fix the translation `"cycle"` to fit with macOS system's.
修正「`cycle`」的正體中文（臺灣）翻譯來與系統相符。

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/481/files#diff-3e369a5ec4b444abd93a902a19f70e5eb31eb48566ac207fc8e536ea311ae1ca) (4)

**Patch Links:
補丁連結：**

- https://github.com/exelban/stats/pull/481.patch
- https://github.com/exelban/stats/pull/481.diff
