### PR TITLE
Add Module Translation with Chinese Traditional (Taiwan)

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -10,22 +10,22 @@
 //
 
 // Modules
-"CPU" = "CPU";
-"Open CPU settings" = "Open CPU settings";
-"GPU" = "GPU";
-"Open GPU settings" = "Open GPU settings";
-"RAM" = "RAM";
-"Open RAM settings" = "Open RAM settings";
-"Disk" = "Disk";
-"Open Disk settings" = "Open disk settings";
-"Sensors" = "Sensors";
-"Open Sensors settings" = "Open sensors settings";
-"Fans" = "Fans";
-"Open Fans settings" = "Open fans settings";
-"Network" = "Network";
-"Open Network settings" = "Open network settings";
-"Battery" = "Battery";
-"Open Battery settings" = "Open battery settings";
+"CPU" = "處理器";
+"Open CPU settings" = "打開處理器設定";
+"GPU" = "顯示卡";
+"Open GPU settings" = "打開顯示卡設定";
+"RAM" = "記憶體";
+"Open RAM settings" = "打開記憶體設定";
+"Disk" = "磁碟";
+"Open Disk settings" = "打開磁碟設定";
+"Sensors" = "感知器";
+"Open Sensors settings" = "打開感知器設定";
+"Fans" = "風扇";
+"Open Fans settings" = "打開風扇設定";
+"Network" = "網路";
+"Open Network settings" = "打開網路設定";
+"Battery" = "電池";
+"Open Battery settings" = "打開電池設定";
 
 // Words
 "Unknown" = "未知";
@@ -45,18 +45,18 @@
 "None" = "無";
 "Dots" = "點";
 "Arrows" = "箭頭";
-"Characters" = "字母";
+"Characters" = "文字";
 "Short" = "短";
 "Long" = "長";
 "Statistics" = "統計資料";
 "Max" = "最大值";
 "Min" = "最小值";
 "Reset" = "重置";
-"Alignment" = "Alignment";
-"Left alignment" = "Left";
-"Center alignment" = "Center";
-"Right alignment" = "Right";
-"Dashboard" = "Dashboard";
+"Alignment" = "對齊";
+"Left alignment" = "靠左對齊";
+"Center alignment" = "置中對齊";
+"Right alignment" = "靠右對齊";
+"Dashboard" = "儀表板";
 
 // Alerts
 "New version available" = "有新版本可用";
@@ -70,7 +70,7 @@
 "Support the application" = "贊助此應用程式";
 "Close application" = "關閉應用程式";
 "Open application settings" = "打開應用程式設定";
-"Open dashboard" = "Open dashboard";
+"Open dashboard" = "打開儀表板";
 
 // Application settings
 "Update application" = "更新應用程式";
@@ -134,8 +134,8 @@
 
 // CPU
 "CPU usage" = "處理器使用率";
-"CPU temperature" = "處理器 (CPU) 溫度";
-"CPU frequency" = "處理器 (CPU) 頻率";
+"CPU temperature" = "處理器溫度";
+"CPU frequency" = "處理器頻率";
 "System" = "系統";
 "User" = "使用者";
 "Idle" = "閒置";
@@ -143,12 +143,12 @@
 "Show hyper-threading cores" = "顯示超執行緒核心";
 
 // GPU
-"GPU to show" = "顯示顯示卡 (GPU)";
-"Show GPU type" = "顯示顯示卡 (GPU) 類型";
-"GPU enabled" = "啟用顯示卡 (GPU)";
-"GPU disabled" = "停用顯示卡 (GPU)";
-"GPU temperature" = "顯示卡 (GPU) 溫度";
-"GPU utilization" = "顯示卡 (GPU) 使用率";
+"GPU to show" = "顯示顯示卡";
+"Show GPU type" = "顯示顯示卡類型";
+"GPU enabled" = "啟用顯示卡";
+"GPU disabled" = "停用顯示卡";
+"GPU temperature" = "顯示卡溫度";
+"GPU utilization" = "顯示卡使用率";
 "Vendor" = "製造商";
 "Model" = "型號";
 "Status" = "狀態";
@@ -174,7 +174,7 @@
 "Show removable disks" = "顯示抽取式磁碟";
 "Used disk memory" = "總共: %1，已用: %0";
 "Free disk memory" = "總共: %1，可用: %0";
-"Disk to show" = "顯示硬碟";
+"Disk to show" = "顯示磁碟";
 "Open disk" = "開啟磁碟";
 "Switch view" = "切換視窗";
 

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -26,6 +26,8 @@
 "Open Network settings" = "打開網路設定";
 "Battery" = "電池";
 "Open Battery settings" = "打開電池設定";
+"Bluetooth" = "藍芽";
+"Open Bluetooth settings" = "打開藍牙設定";
 
 // Words
 "Unknown" = "未知";


### PR DESCRIPTION
Add Module Translation with Chinese Traditional (Taiwan).
加入模組的正體中文（臺灣）翻譯。
Routine update the translation for Chinese Traditional (Taiwan).
例行性更新正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/531](https://github.com/exelban/stats/pull/504)

**Commit Summary
更新大綱**

- Add new translations from module items.
加入模組項目的翻譯。
- Remove character "CPU", "GPU" from some items, only reserve Chinese Characters. Specifically is changing from "`處理器 (CPU)`", "`顯示卡 (GPU)`" to "`處理器`", "`顯示卡`."
在部分項目中移除「CPU」、「GPU」等文字，僅保留中文文字。具體而言是將「`處理器 (CPU)`」、「`顯示卡 (GPU)`」變更為「`處理器`」、「`顯示卡`」。
- Optimize the translation quality of Chinese Traditional (Taiwan).
最佳化正體中文（臺灣）的翻譯品質。

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/531/files)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/531.patch
https://github.com/exelban/stats/pull/531.diff