### PR TITLE
Update Chinese Traditional (Taiwan) Translation

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "Open Network settings" = "打開網路設定";
 "Battery" = "電池";
 "Open Battery settings" = "打開電池設定";
-"Bluetooth" = "藍芽";
+"Bluetooth" = "藍牙";
 "Open Bluetooth settings" = "打開藍牙設定";
 
 // Words

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -238,7 +238,7 @@
 "Last charge" = "最近一次充電";
 
 // Bluetooth
-"Battery to show" = "Battery to show";
+"Battery to show" = "顯示藍牙裝置的電池電量";
 
 // Colors
 "Based on utilization" = "根據使用率";


### PR DESCRIPTION
Routine update the translation for Chinese Traditional (Taiwan).
例行性更新正體中文（臺灣）翻譯。

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/539](https://github.com/exelban/stats/pull/539)

**Commit Summary
更新大綱**

- Add the translations of `Battery to Show`.
加入 `Battery to Show` 的翻譯「顯示藍牙裝置的電池電量」。

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/539/files)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/539.patch
https://github.com/exelban/stats/pull/539.diff