### PR TITLE
Update Taiwan Traditional  Chinese for Average Load

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -147,10 +147,10 @@
 "Split the value (System/User)" = "分割值 (系統/使用者)";
 "Scheduler limit" = "排程限制";
 "Speed limit" = "速度限制";
-"Average load" = "Average load";
-"1 minute" = "1 minute";
-"5 minutes" = "5 minutes";
-"15 minutes" = "15 minutes";
+"Average load" = "平均負載";
+"1 minute" = "1 分鐘";
+"5 minutes" = "5 分鐘";
+"15 minutes" = "15 分鐘";
 
 // GPU
 "GPU to show" = "顯示顯示卡";


### PR DESCRIPTION
Add Taiwan Traditional Chinese Translation for String "Average Load".
針對「Average Load」進行正體中文（臺灣）翻譯的更新。

————————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/621](https://github.com/exelban/stats/pull/621)

**Commit Summary
更新大綱**

- Update Localizable.strings
更新 Localizable.strings 檔案

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/621/files) (4)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/621.patch
https://github.com/exelban/stats/pull/621.diff