### PR TITLE
Update Taiwan Traditional Chinese Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -59,7 +59,7 @@
 "Center alignment" = "置中對齊";
 "Right alignment" = "靠右對齊";
 "Dashboard" = "儀表板";
-"Disabled" = "Disabled";
+"Disabled" = "已停用";
 
 // Alerts
 "New version available" = "有新版本可用";
@@ -216,7 +216,7 @@
 "Reader type" = "讀取機類型";
 "Interface based" = "依連接埠";
 "Processes based" = "依程序";
-"Reset data usage" = "Reset data usage";
+"Reset data usage" = "重置資料用量";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
### Update Chinese Traditional (Taiwan) Translation File
### 更新正體中文（臺灣）翻譯檔案

- Add "Disabled" Item with its Chinese Traditional (Taiwan) Translation "已停用".
新增「Disabled」項目及其正體中文（臺灣）翻譯「已停用」。
- Add "Reset Data Usage" Item with its Chinese Traditional (Taiwan) Translation "重置資料用量".
新增「Reset Data Usage」項目及其正體中文（臺灣）翻譯「重置資料用量」。