### PR TITLE
Fix apple m1 fan.

### DIFF
--- a/SMC/smc.swift
+++ b/SMC/smc.swift
@@ -72,7 +72,7 @@ internal struct SMCKeyData_t {
     }
     
     struct keyInfo_t {
-        var dataSize: IOByteCount = 0
+        var dataSize: IOByteCount32 = 0
         var dataType: UInt32 = 0
         var dataAttributes: UInt8 = 0
     }
@@ -509,7 +509,7 @@ public class SMC {
         
         input.key = FourCharCode(fromString: value.key)
         input.data8 = SMCKeys.WRITE_BYTES.rawValue
-        input.keyInfo.dataSize = IOByteCount(value.dataSize)
+        input.keyInfo.dataSize = IOByteCount32(value.dataSize)
         input.bytes = (value.bytes[0], value.bytes[1], value.bytes[2], value.bytes[3], value.bytes[4], value.bytes[5],
                        value.bytes[6], value.bytes[7], value.bytes[8], value.bytes[9], value.bytes[10], value.bytes[11],
                        value.bytes[12], value.bytes[13], value.bytes[14], value.bytes[15], value.bytes[16], value.bytes[17],


### PR DESCRIPTION
keyInfo_t dataSize must be 32 instead of 64 bytes.