### PR TITLE
Update AppDelegate.swift = Fix for hang on RAM or CPU popup. macOS 10.13.6 

### DIFF
--- a/Kit/Widgets/Sensors.swift
+++ b/Kit/Widgets/Sensors.swift
@@ -180,7 +180,7 @@ public class SensorsWidget: WidgetWrapper {
         
         view.addArrangedSubview(selectSettingsRow(
             title: localizedString("Display mode"),
-            action: #selector(changeMode),
+            action: #selector(changeDisplayMode),
             items: SensorsWidgetMode,
             selected: self.modeState
         ))
@@ -194,7 +194,7 @@ public class SensorsWidget: WidgetWrapper {
         return view
     }
     
-    @objc private func changeMode(_ sender: NSMenuItem) {
+    @objc private func changeDisplayMode(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else {
             return
         }

--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -18,7 +18,7 @@ public struct LaunchAtLogin {
     
     public static var isEnabled: Bool {
         get {
-            guard let jobs = (SMCopyAllJobDictionaries(kSMDomainUserLaunchd).takeRetainedValue() as? [[String: AnyObject]]) else {
+                guard let jobs = (LaunchAtLogin.self as DeprecationWarningWorkaround.Type).jobsDict else {
                 return false
             }
             
@@ -29,6 +29,19 @@ public struct LaunchAtLogin {
         set {
             SMLoginItemSetEnabled(id as CFString, newValue)
         }
+    }
+}
+
+private protocol DeprecationWarningWorkaround {
+    static var jobsDict: [[String: AnyObject]]? { get }
+}
+
+extension LaunchAtLogin: DeprecationWarningWorkaround {
+    // Workaround to silence "'SMCopyAllJobDictionaries' was deprecated in OS X 10.10" warning
+    // Radar: https://openradar.appspot.com/radar?id=5033815495933952
+    @available(*, deprecated)
+    static var jobsDict: [[String: AnyObject]]? {
+        SMCopyAllJobDictionaries(kSMDomainUserLaunchd)?.takeRetainedValue() as? [[String: AnyObject]]
     }
 }
 

--- a/Kit/module/settings.swift
+++ b/Kit/module/settings.swift
@@ -118,7 +118,7 @@ open class Settings: NSStackView, Settings_p {
             button.title = ""
             button.action = #selector(self.toggleEnable)
             button.isBordered = false
-            button.isTransparent = true
+            button.isTransparent = false
             button.target = self
             
             toggleBtn = button

--- a/Modules/Sensors/bridge.h
+++ b/Modules/Sensors/bridge.h
@@ -34,7 +34,7 @@ typedef enum AppleSiliconSensorType: NSUInteger {
 IOHIDEventSystemClientRef IOHIDEventSystemClientCreate(CFAllocatorRef allocator);
 int IOHIDEventSystemClientSetMatching(IOHIDEventSystemClientRef client, CFDictionaryRef match);
 IOHIDEventRef IOHIDServiceClientCopyEvent(IOHIDServiceClientRef, int64_t , int32_t, int64_t);
-CFStringRef IOHIDServiceClientCopyProperty(IOHIDServiceClientRef service, CFStringRef property);
+CFTypeRef IOHIDServiceClientCopyProperty(IOHIDServiceClientRef service, CFStringRef property);
 IOHIDFloat IOHIDEventGetFloatValue(IOHIDEventRef event, int32_t field);
 
 NSDictionary*AppleSiliconSensors(int page, int usage, int32_t type);

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -41,9 +41,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     private let updateActivity = NSBackgroundActivityScheduler(identifier: "eu.exelban.Stats.updateCheck")
     
     static func main() {
+        let app = NSApplication.shared
         let delegate = AppDelegate()
-        NSApplication.shared.delegate = delegate
-        NSApplication.shared.run()
+        app.delegate = delegate
+        app.run()
     }
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/Stats/Views/AppSettings.swift
+++ b/Stats/Views/AppSettings.swift
@@ -241,7 +241,7 @@ class ApplicationSettings: NSScrollView {
             button.title = ""
             button.action = action
             button.isBordered = false
-            button.isTransparent = true
+            button.isTransparent = false
             button.target = self
             
             toggle = button


### PR DESCRIPTION
See Issue #721
On macOS 10.13.6 only, mousedown in either RAM or CPU areas of menubar causes 100% repeatable hang.

The fix applied to AppDelegate.swift is subtle difference in the order of construction of the AppDelegate and NSApplication objects. 

The bug arose in 2.6.3 (by regression testing of all release dmgs), when the code base changed to support Swift 5.3,
specifically the new @main to describe app entry point. The order of object construction changed:
The 2.6.2 code has app ctr then delegate ctr. The 2.6.3+ code has delegate ctr then app ctr.

This definitely fixes the 10.13.6 CPU/RAM popup hang for no obvious explanation.
 **Why? and How? ¯\\(ツ)/¯**
