### PR TITLE
Correct german translation of "Power"

### DIFF
--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -235,7 +235,7 @@
 "Cycles" = "Ladezyklen";
 "Temperature" = "Temperatur";
 "Power adapter" = "Netzteil";
-"Power" = "Strom";
+"Power" = "Leistung";
 "Is charging" = "wird aufgeladen";
 "Time to discharge" = "Entladedauer";
 "Time to charge" = "Ladedauer";


### PR DESCRIPTION
The power in watts is normally referred to as "Leistung" in german. "Strom" is used as a synonym of "Stromstärke" for the amperage.