### PR TITLE
Reduce network activity generated by Stats.app

### DIFF
--- a/Kit/plugins/Server.swift
+++ b/Kit/plugins/Server.swift
@@ -12,8 +12,6 @@
 import Foundation
 
 struct event: Codable {
-    var ID: String
-    
     var version: String
     var build: String
     var modules: [String]
@@ -28,19 +26,10 @@ struct event: Codable {
 public class Server {
     public static let shared = Server(url: URL(string: "https://api.serhiy.io/v1/stats")!)
     
-    public var ID: String {
-        get {
-            return Store.shared.string(key: "id", defaultValue: UUID().uuidString)
-        }
-    }
     private let url: URL
     
     public init(url: URL) {
         self.url = url
-        
-        if !Store.shared.exist(key: "id") {
-            Store.shared.set(key: "id", value: self.ID)
-        }
     }
     
     public func sendEvent(modules: [String], omit: Bool = false) {
@@ -49,7 +38,6 @@ public class Server {
         let systemVersion = ProcessInfo().operatingSystemVersion
         
         let e = event(
-            ID: self.ID,
             version: version ?? "unknown",
             build: build ?? "unknown",
             modules: modules,

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -208,10 +208,6 @@ internal class UsageReader: Reader<Network_Usage> {
     public func getDetails() {
         self.usage.reset()
         
-        DispatchQueue.global(qos: .background).async {
-            self.getPublicIP()
-        }
-        
         if self.interfaceID != "" {
             for interface in SCNetworkInterfaceCopyAll() as NSArray {
                 if  let bsdName = SCNetworkInterfaceGetBSDName(interface as! SCNetworkInterface),

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -59,10 +59,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         
         info("Stats started in \((startingPoint.timeIntervalSinceNow * -1).rounded(toPlaces: 4)) seconds")
         
-        Server.shared.sendEvent(
-            modules: modules.filter({ $0.enabled != false && $0.available != false }).map({ $0.config.name }),
-            omit: CommandLine.arguments.contains("--omit")
-        )
+        let currVersion = Store.shared.string(key: "version", defaultValue: "")
+        let prevVersion = Store.shared.string(key: "previous_version", defaultValue: "")
+        if (prevVersion != currVersion) {
+            Server.shared.sendEvent(
+                modules: modules.filter({ $0.enabled != false && $0.available != false }).map({ $0.config.name }),
+                omit: CommandLine.arguments.contains("--omit")
+            )
+            Store.shared.set(key: "previous_version", value: currVersion)
+        }
     }
     
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/Stats/Views/AppSettings.swift
+++ b/Stats/Views/AppSettings.swift
@@ -96,7 +96,6 @@ class ApplicationSettings: NSScrollView {
         statsName.font = NSFont.systemFont(ofSize: 20, weight: .regular)
         statsName.stringValue = "Stats"
         statsName.isSelectable = true
-        statsName.toolTip = Server.shared.ID
         
         let versionNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
         let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String

--- a/Stats/helpers.swift
+++ b/Stats/helpers.swift
@@ -104,7 +104,7 @@ extension AppDelegate {
             NSApp.setActivationPolicy(dockIconStatus)
         }
         
-        if let updateInterval = AppUpdateInterval(rawValue: Store.shared.string(key: "update-interval", defaultValue: AppUpdateInterval.silent.rawValue)) {
+        if let updateInterval = AppUpdateInterval(rawValue: Store.shared.string(key: "update-interval", defaultValue: AppUpdateInterval.never.rawValue)) {
             self.updateActivity.invalidate()
             self.updateActivity.repeats = true
             


### PR DESCRIPTION
Thank you!  I'd like to propose these changes to all users of Stats.app:

-   Disable user data collection after each launch

    Also remove per-install UUID because it is quite useless since now the data is only collected once for fresh install or each update.

-   Make default configuration network-less

    Unless there is an option for enabling/customizing the public IP query service, I just don't need it.

This is a long running system app, better be tedious than having all sorts of unknown activities going under the water.
