### PR TITLE
feat: add M2 MacBooks to the device list

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -423,6 +423,7 @@ let deviceDict: [String: model_s] = [
     "MacBookAir8,2": model_s(name: "MacBook Air 13\"", year: 2019, type: .macbookAir),
     "MacBookAir9,1": model_s(name: "MacBook Air 13\"", year: 2020, type: .macbookAir),
     "MacBookAir10,1": model_s(name: "MacBook Air 13\" (M1)", year: 2020, type: .macbookAir),
+    "Mac14,2": model_s(name: "MacBook Air 13\" (M2)", year: 2022, type: .macbookAir),
     
     // MacBook Pro
     "MacBookPro9,1": model_s(name: "MacBook Pro 15\"", year: 2012, type: .macbookPro),
@@ -452,7 +453,8 @@ let deviceDict: [String: model_s] = [
     "MacBookPro18,1": model_s(name: "MacBook Pro 16\" (M1 Pro)", year: 2021, type: .macbookPro),
     "MacBookPro18,2": model_s(name: "MacBook Pro 16\" (M1 Max)", year: 2021, type: .macbookPro),
     "MacBookPro18,3": model_s(name: "MacBook Pro 14\" (M1 Pro)", year: 2021, type: .macbookPro),
-    "MacBookPro18,4": model_s(name: "MacBook Pro 14\" (M1 Max)", year: 2021, type: .macbookPro)
+    "MacBookPro18,4": model_s(name: "MacBook Pro 14\" (M1 Max)", year: 2021, type: .macbookPro),
+    "Mac14,7": model_s(name: "MacBook Pro 13\" (M2)", year: 2022, type: .macbookPro)
 ]
 
 let osDict: [String: String] = [


### PR DESCRIPTION
Add M2 MacBook Air and M2 MacBook Pro model identifiers to the device list.

Tested on M2 MacBook Air (was showing `Unknown` before the change):

<img width="720" alt="dash" src="https://user-images.githubusercontent.com/10822203/179883976-c3e726cb-c744-4fab-af5b-e67d0a04bb86.png">

<img width="586" alt="about" src="https://user-images.githubusercontent.com/10822203/179883983-b3cbd928-f29e-454b-bbb9-dcc4a254d9f7.png">

M2 MacBook Pro model identifier can be found on the wiki: https://www.theiphonewiki.com/wiki/List_of_Mac_Laptops_with_Apple_Silicon#MacBook_Pro_.2813-inch.2C_M2.2C_2022.29

It would be great if someone with a M2 MacBook Pro can confirm that as well. :)