### PR TITLE
Updated Traditional Chinese translations

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 "Capacity" = "容量";
 "maximum / designed" = "最大容量 / 設計容量";
 "Low power mode" = "低電量模式";
-"Percentage inside the icon" = "圖示内百分比";
+"Percentage inside the icon" = "圖示內百分比";
 
 // Bluetooth
 "Battery to show" = "顯示藍牙裝置的電池電量";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -67,7 +67,7 @@
 "Square" = "方形";
 "Cube" = "立方體";
 "Logarithmic" = "對數";
-"Cores" = "Cores";
+"Cores" = "核心數";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -124,7 +124,7 @@
 "Uptime" = "開機時間";
 "Number of cores" = "%0 核心";
 "Number of threads" = "%0 執行緒";
-"Number of e-cores" = "%0 效率核心";
+"Number of e-cores" = "%0 節能核心";
 "Number of p-cores" = "%0 效能核心";
 
 // Update
@@ -200,7 +200,7 @@
 "15 minutes" = "15 分鐘";
 "CPU usage threshold" = "處理器使用率臨界點";
 "CPU usage is" = "處理器使用率為：%0";
-"Efficiency cores" = "效率核心";
+"Efficiency cores" = "節能核心";
 "Performance cores" = "效能核心";
 
 // GPU
@@ -256,8 +256,8 @@
 "Fan" = "風扇";
 "HID sensors" = "HID 感知器";
 "Synchronize fan's control" = "同步風扇控制";
-"Current" = "Current";
-"Energy" = "Energy";
+"Current" = "電流";
+"Energy" = "能耗";
 
 // Network
 "Uploading" = "上傳";
@@ -283,8 +283,8 @@
 "Standard" = "標準";
 "Security" = "安全";
 "Channel" = "通道";
-"Common scale" = "Common scale";
-"Autodetection" = "Autodetection";
+"Common scale" = "統一比例";
+"Autodetection" = "自動檢測";
 
 // Battery
 "Level" = "電量";
@@ -320,7 +320,7 @@
 "Capacity" = "容量";
 "maximum / designed" = "最大容量 / 設計容量";
 "Low power mode" = "低電量模式";
-"Percentage inside the icon" = "Percentage inside the icon";
+"Percentage inside the icon" = "圖示内百分比";
 
 // Bluetooth
 "Battery to show" = "顯示藍牙裝置的電池電量";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -285,7 +285,7 @@
 "Channel" = "通道";
 "Common scale" = "統一比例";
 "Autodetection" = "自動檢測";
-"Widget activation threshold" = "小工具啟動閥值";
+"Widget activation threshold" = "小工具啟動臨界點";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
Optimized translations based on the terms from Apple.

- "%0 節能核心" for "Number of e-cores"
- "節能核心" for "Efficiency cores"

Added new translations

- "核心數" for "Cores"
- "電流" for "Current"
- "能耗" for "Energy"
- "統一比例" for "Common scale"
- "自動檢測" for "Autodetection"
- "圖示內百分比" for "Percentage inside the icon"
- “小工具啟動臨界點“ for ”Widget activation threshold“