### PR TITLE
Updated Traditional Chinese translations

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -64,8 +64,8 @@
 "Fans" = "風扇";
 "Scaling" = "縮放";
 "Linear" = "線性";
-"Square" = "方形";
-"Cube" = "立方體";
+"Square" = "平方";
+"Cube" = "立方";
 "Logarithmic" = "對數";
 "Cores" = "核心數";
 
@@ -262,12 +262,12 @@
 // Network
 "Uploading" = "上傳";
 "Downloading" = "下載";
-"Public IP" = "公開 IP";
+"Public IP" = "公網 IP";
 "Local IP" = "區域 IP";
 "Interface" = "介面";
 "Physical address" = "實體位址";
 "Refresh" = "重新整理";
-"Click to copy public IP address" = "點按來拷貝公開 IP 位址";
+"Click to copy public IP address" = "點按來拷貝公網 IP 位址";
 "Click to copy local IP address" = "點按來拷貝區域 IP 位址";
 "Click to copy wifi name" = "點按來拷貝 Wi-Fi 名稱";
 "Click to copy mac address" = "點按來拷貝 MAC 位址";


### PR DESCRIPTION
Optimized for the same translations in Network Widget settings as Simplified Chinese

- "平方" for "Square"
- "立方" for "Cube"

Optimized a minor translation issue with terms relevant to Network

- "公網 IP" for "Public IP"
- "點按來拷貝公網 IP 位址" for "Click to copy public IP address"__