### PR TITLE
Add Taiwan Traditional Chinese Translation String

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -160,7 +160,7 @@
 "Memory widget" = "容量";
 "Static width" = "靜態寬度";
 "Tachometer widget" = "轉速計";
-"State widget" = "State widget";
+"State widget" = "State 小工具";
 "Show symbols" = "顯示符號";
 "Label widget" = "標籤";
 "Number of reads in the chart" = "圖表中的未讀計數";
@@ -289,9 +289,9 @@
 "Common scale" = "統一比例";
 "Autodetection" = "自動檢測";
 "Widget activation threshold" = "小工具啟動臨界點";
-"Internet connection" = "Internet connection";
-"Active state color" = "Active state color";
-"Nonactive state color" = "Nonactive state color";
+"Internet connection" = "網際網路連線";
+"Active state color" = "啟用狀態色彩";
+"Nonactive state color" = "未啟用狀態色彩";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1100](https://github.com/exelban/stats/pull/1100)

**Commit Summary
更新大綱**

- Translating those new added strings below into  Taiwan Traditional Chinese.
針對新增的字串加入正體中文（臺灣）的翻譯。

1. `State widget` for “State 小工具” 
2. `Internet connection` for “網際網路連線” 
3. `Active state color` for “啟用狀態色彩”
4. `Nonactive state color` for “未啟用狀態色彩”

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1100/files) (4)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1100.patch
https://github.com/exelban/stats/pull/1100.diff