### PR TITLE
Updated Simplified Chinese translations

### DIFF
--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "Color of download" = "下载的颜色";
 "Color of upload" = "上传的颜色";
 "Merge widgets" = "合并组件";
-"No available widgets to configure" = "No available widgets to configure";
+"No available widgets to configure" = "没有可配置的小组件";
 
 // Module Kit
 "Open module settings" = "打开模块设置";
@@ -337,7 +337,7 @@
 // Colors
 "Based on utilization" = "基于利用率";
 "Based on pressure" = "基于压力";
-"Based on cluster" = "Based on cluster";
+"Based on cluster" = "基于集群";
 "System accent" = "系统强调色";
 "Monochrome accent" = "黑白";
 "Clear" = "透明";


### PR DESCRIPTION
Added missing translations
- "没有可配置的小组件" for "No available widgets to configure"
- "基于集群" for "Based on cluster"