### PR TITLE
Add Taiwan Traditional Chinese Translation String

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -160,7 +160,7 @@
 "Memory widget" = "容量";
 "Static width" = "靜態寬度";
 "Tachometer widget" = "轉速計";
-"State widget" = "State widget";
+"State widget" = "State 小工具";
 "Show symbols" = "顯示符號";
 "Label widget" = "標籤";
 "Number of reads in the chart" = "圖表中的未讀計數";
@@ -179,7 +179,7 @@
 "Module settings" = "模組設定";
 "Widget settings" = "小工具設定";
 "Merge widgets" = "整合型小工具";
-"No available widgets to configure" = "No available widgets to configure";
+"No available widgets to configure" = "沒有可供組態設定的小工具";
 
 // Modules
 "Number of top processes" = "高能耗程序數量";
@@ -290,9 +290,9 @@
 "Common scale" = "統一比例";
 "Autodetection" = "自動檢測";
 "Widget activation threshold" = "小工具啟動臨界點";
-"Internet connection" = "Internet connection";
-"Active state color" = "Active state color";
-"Nonactive state color" = "Nonactive state color";
+"Internet connection" = "網際網路連線裝態";
+"Active state color" = "已連線狀態色彩";
+"Nonactive state color" = "未連線狀態色彩";
 
 // Battery
 "Level" = "電量";
@@ -337,7 +337,7 @@
 // Colors
 "Based on utilization" = "根據使用率";
 "Based on pressure" = "根據壓力";
-"Based on cluster" = "Based on cluster";
+"Based on cluster" = "根據群集";
 "System accent" = "系統強調色";
 "Monochrome accent" = "黑白";
 "Clear" = "透明";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1103](https://github.com/exelban/stats/pull/1103)

**Commit Summary
更新大綱**

- Translating those new added strings below into  Taiwan Traditional Chinese.
針對新增的字串加入正體中文（臺灣）的翻譯。

1. “State 小工具” for `State widget`
2. “沒有可供組態設定的小工具” for `No available widgets to configure`
3. “網際網路連線狀態” for `Internet connection`
4. “已連線狀態色彩” for `Active state color`
5. “未連線狀態色彩” for `Nonactive state color`
6. “根據群集” for `Based on cluster`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1103/files) (6)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1103.patch
https://github.com/exelban/stats/pull/1103.diff