### PR TITLE
Updated Simplified Chinese translations

### DIFF
--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -178,16 +178,16 @@
 "Pictogram" = "标识";
 "Module settings" = "模块设置";
 "Widget settings" = "小组件设置";
-"Popup settings" = "Popup settings";
+"Popup settings" = "弹出窗口设置";
 "Merge widgets" = "合并组件";
 "No available widgets to configure" = "没有可配置的小组件";
-"No options to configure for the popup in this module" = "No options to configure for the popup in this module";
+"No options to configure for the popup in this module" = "该组件没有可配置的选项";
 
 // Modules
 "Number of top processes" = "高占用进程数";
 "Update interval for top processes" = "高占用进程的更新间隔";
 "Notification level" = "通知级别";
-"Chart color" = "Chart color";
+"Chart color" = "图表颜色";
 
 // CPU
 "CPU usage" = "CPU 占用";
@@ -209,10 +209,10 @@
 "CPU usage is" = "CPU 利用率是 %0";
 "Efficiency cores" = "能效核心";
 "Performance cores" = "性能核心";
-"System color" = "System color";
-"User color" = "User color";
-"Idle color" = "Idle color";
-"Cluster grouping" = "Cluster grouping";
+"System color" = "系统占用颜色";
+"User color" = "用户占用颜色";
+"Idle color" = "闲置颜色";
+"Cluster grouping" = "按集群分组";
 
 // GPU
 "GPU to show" = "显示的 GPU";
@@ -248,10 +248,10 @@
 "Split the value (App/Wired/Compressed)" = "柱状图区分显示（App 内存/联动内存/被压缩）";
 "RAM utilization threshold" = "RAM 占用阈值";
 "RAM utilization is" = "RAM 利用率是 %0";
-"App color" = "App color";
-"Wired color" = "Wired color";
-"Compressed color" = "Compressed color";
-"Free color" = "Free color";
+"App color" = "App 内存颜色";
+"Wired color" = "联动内存颜色";
+"Compressed color" = "被压缩颜色";
+"Free color" = "可用颜色";
 
 // Disk
 "Show removable disks" = "显示可移动磁盘";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -250,8 +250,8 @@
 "RAM utilization is" = "RAM 利用率是 %0";
 "App color" = "App 内存颜色";
 "Wired color" = "联动内存颜色";
-"Compressed color" = "被压缩颜色";
-"Free color" = "可用颜色";
+"Compressed color" = "被压缩内存颜色";
+"Free color" = "可用内存颜色";
 
 // Disk
 "Show removable disks" = "显示可移动磁盘";


### PR DESCRIPTION
## New Simplified Chinese translations
- `弹出窗口设置` for "Popup settings"
- `该组件没有可配置的选项` for "No options to configure for the popup in this module"
- `图表颜色` for "Chart color"
- `系统占用颜色` for "System color"
- `用户占用颜色` for "User color"
- `闲置颜色` for "Idle color"
- `按集群分组` for "Cluster grouping"
- `App 内存颜色` for "App color"
- `联动内存颜色` for "Wired color"
- `被压缩内存颜色` for "Compressed color"
- `可用内存颜色` for "Free color"