### PR TITLE
Add Taiwan Traditional Chinese Translation String

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -178,16 +178,16 @@
 "Pictogram" = "標示";
 "Module settings" = "模組設定";
 "Widget settings" = "小工具設定";
-"Popup settings" = "Popup settings";
+"Popup settings" = "彈出式視窗設定";
 "Merge widgets" = "整合型小工具";
 "No available widgets to configure" = "沒有可供組態設定的小工具";
-"No options to configure for the popup in this module" = "No options to configure for the popup in this module";
+"No options to configure for the popup in this module" = "此模組沒有可供彈出式視窗組態設定的選項";
 
 // Modules
 "Number of top processes" = "高能耗程序數量";
 "Update interval for top processes" = "高能耗程序更新頻率";
 "Notification level" = "通知等級";
-"Chart color" = "Chart color";
+"Chart color" = "圖表色彩";
 
 // CPU
 "CPU usage" = "處理器使用率";
@@ -209,10 +209,10 @@
 "CPU usage is" = "處理器使用率為：%0";
 "Efficiency cores" = "節能核心";
 "Performance cores" = "效能核心";
-"System color" = "System color";
-"User color" = "User color";
-"Idle color" = "Idle color";
-"Cluster grouping" = "Cluster grouping";
+"System color" = "系統色彩";
+"User color" = "使用者色彩";
+"Idle color" = "閒置時色彩";
+"Cluster grouping" = "依群集分組";
 
 // GPU
 "GPU to show" = "顯示顯示卡";
@@ -248,10 +248,10 @@
 "Split the value (App/Wired/Compressed)" = "分割值 (App/固定/壓縮)";
 "RAM utilization threshold" = "記憶體利用率臨界值";
 "RAM utilization is" = "記憶體利用率為：%0";
-"App color" = "App color";
-"Wired color" = "Wired color";
-"Compressed color" = "Compressed color";
-"Free color" = "Free color";
+"App color" = "App 色彩";
+"Wired color" = "固定記憶體色彩";
+"Compressed color" = "已壓縮色彩";
+"Free color" = "可使用記憶體色彩";
 
 // Disk
 "Show removable disks" = "顯示抽取式磁碟";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1121](https://github.com/exelban/stats/pull/1121)

**Commit Summary
更新大綱**

- Translating those new added strings below into  Taiwan Traditional Chinese.
針對新增的字串加入正體中文（臺灣）的翻譯。

1. “彈出式視窗設定” for `Popup settings`
2. “此模組沒有可供彈出式視窗組態設定的選項” for `No options to configure for the popup in this module`
3. “圖表色彩” for `Chart color`
4. “系統色彩” for `System color`
5. “使用者色彩” for `User color`
6. “閒置時色彩” for `Idle color`
7. “依群集分組” for `Cluster grouping`
8. “App 色彩” for `App color`
9. “固定記憶體色彩” for `Wired color`
10. “已壓縮色彩” for `Compressed color`
11. “可使用記憶體色彩” for `Free color`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1121/files) (6)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1121.patch
https://github.com/exelban/stats/pull/1121.diff