### PR TITLE
Updated Simplified Chinese translations

### DIFF
--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -304,8 +304,8 @@
 "Internet connection" = "网络连接状态";
 "Active state color" = "活跃状态颜色";
 "Nonactive state color" = "非活跃状态颜色";
-"Connectivity host (ICMP)" = "Connectivity host (ICMP)";
-"Leave empty to disable the check" = "Leave empty to disable the check";
+"Connectivity host (ICMP)" = "连接Host (ICMP)";
+"Leave empty to disable the check" = "不在该选项内输入以禁用检查";
 
 // Battery
 "Level" = "电量";


### PR DESCRIPTION
Added missing translations for Simplified Chinese

- “连接Host (ICMP)” for `Connectivity host (ICMP)`
- “不在该选项内输入以禁用检查” for `Leave empty to disable check`