### PR TITLE
Updated translation

### DIFF
--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -321,7 +321,7 @@
 "Power adapter" = "Netzteil";
 "Power" = "Leistung";
 "Is charging" = "wird aufgeladen";
-"Time to discharge" = "Entladedauer";
+"Time to discharge" = "verbleibend";
 "Time to charge" = "Ladedauer";
 "Calculating" = "Berechnen...";
 "Fully charged" = "vollständig aufgeladen";


### PR DESCRIPTION
translated "Time to discharge" with "verbleibend" as in "remaining", which is more intuitive.
This should display to the user how long will the battery hold up - like the remaining time at the current power consumption.
The phrase "Time to discharge" is literally translated to "Zeit bis zur Entladung", meaning "time until discharged" (deepl)
You should consider changing that in the English translation as well.