### PR TITLE
Add Taiwan Traditional Chinese Translation String

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -307,7 +307,7 @@
 "Nonactive state color" = "未連線狀態色彩";
 "Connectivity host (ICMP)" = "連線主機 (ICMP)";
 "Leave empty to disable the check" = "留空來停用檢查";
-"Transparent pictogram when no activity" = "Transparent pictogram when no activity";
+"Transparent pictogram when no activity" = "未連線時隱藏標示";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1198](https://github.com/exelban/stats/pull/1198)

**Commit Summary
更新大綱**

- Translating those new added strings below into  Taiwan Traditional Chinese.
針對新增的字串加入正體中文（臺灣）的翻譯。

1. “ 未連線時隱藏標示” for `Transparent pictogram when no activity`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1198/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1198.patch
https://github.com/exelban/stats/pull/1198.diff