### PR TITLE
Update Taiwan Traditional Chinese Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -275,8 +275,8 @@
 "Current" = "電流";
 "Energy" = "能耗";
 "Show unknown sensors" = "顯示未知的感知器";
-"Install fan helper" = "Install fan helper";
-"Uninstall fan helper" = "Uninstall fan helper";
+"Install fan helper" = "安裝風扇輔助程式";
+"Uninstall fan helper" = "解除安裝風扇輔助程式";
 
 // Network
 "Uploading" = "上傳";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1238](https://github.com/exelban/stats/pull/1238)

**Commit Summary
更新大綱**

- Translating those new added strings below into  Taiwan Traditional Chinese.
針對新增的字串加入正體中文（臺灣）的翻譯。

1. “安裝風扇輔助程式” for `Install fan helper`
2. “解除安裝風扇輔助程式” for `Uninstall fan helper`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1238/files) (2)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1238.patch
https://github.com/exelban/stats/pull/1238.diff