### PR TITLE
Determine the CPU chip type at runtime.

### DIFF
--- a/Kit/types.swift
+++ b/Kit/types.swift
@@ -221,11 +221,13 @@ public extension Notification.Name {
 
 public var isARM: Bool {
     get {
-        var value = false
-        #if arch(arm64)
-        value = true
-        #endif
-        return value
+        var size: Int = 0
+        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: Int(size))
+        sysctlbyname("machdep.cpu.brand_string", &machine, &size, nil, 0)
+        let cpuInfo: String = String(cString:machine)
+        
+        return cpuInfo.contains("Apple")
     }
 }
 


### PR DESCRIPTION
CPU chip type detection should be at **runtime** not compile time. 
If you use the macro, the value of `isARM` has been determined at compile time.

Here is a scenario:
Someone builds the app on an Intel Mac with no Apple Silicon arch and this app can still work on Apple Silicon Mac using Rosetta 2. 
It does run on an ARM Mac. but, the value of `isARM` is FALSE, not TRUE.

We should better determine the CPU chip type at runtime.