### PR TITLE
Update Traditional Chinese Taiwan Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -277,7 +277,7 @@
 "Show unknown sensors" = "顯示未知的感知器";
 "Install fan helper" = "安裝風扇輔助程式";
 "Uninstall fan helper" = "解除安裝風扇輔助程式";
-"Fan value" = "Fan value";
+"Fan value" = "風扇轉速值";
 
 // Network
 "Uploading" = "上傳";
@@ -345,9 +345,9 @@
 "Hide additional information when full" = "電池充飽後隱藏其他資訊";
 "Last charge" = "最近一次充電";
 "Capacity" = "容量";
-"current / maximum / designed" = "current/最大容量/設計容量";
+"current / maximum / designed" = "目前容量/最大容量/設計容量";
 "Low power mode" = "低電量模式";
-"Percentage inside the icon" = "圖示內百分比";
+"Percentage inside the icon" = "在圖示內顯示百分比";
 
 // Bluetooth
 "Battery to show" = "顯示藍牙裝置的電池電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。
Optimize some strings for its translation quality
對部分字串進行其翻譯品質的最佳化。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1248](https://github.com/exelban/stats/pull/1248)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “風扇轉速值” for `Fan value`

- **Optimize translating quality for some strings.
對部分字串進行翻譯品質最佳化**。

1. “目前容量/最大容量/設計容量” for `current / maximum / designed`
2. “圖示內百分比” update to “在圖示內顯示百分比” for `Percentage inside the icon`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1248/files) (3)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1248.patch
https://github.com/exelban/stats/pull/1248.diff