### PR TITLE
Update Traditional Chinese Taiwan Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -121,7 +121,7 @@
 "Reset settings" = "重置設定";
 "Pause the Stats" = "暫停 Stats";
 "Resume the Stats" = "恢復 Stats";
-"Combined modules" = "Combined modules";
+"Combined modules" = "合併模組";
 
 // Dashboard
 "Serial number" = "序號";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。
Optimize some strings for its translation quality
對部分字串進行其翻譯品質的最佳化。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1303](https://github.com/exelban/stats/pull/1303)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “合併模組” for `Combined modules`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1303/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1303.patch
https://github.com/exelban/stats/pull/1303.diff