### PR TITLE
Increased DC In Voltage cutoff to match real world measurements from different MacBooks

### DIFF
--- a/Modules/Sensors/readers.swift
+++ b/Modules/Sensors/readers.swift
@@ -216,7 +216,7 @@ internal class SensorsReader: Reader<[Sensor_p]> {
         }
         
         // cut off low dc in voltage
-        if let idx = self.list.firstIndex(where: { $0.key == "VD0R" }), self.list[idx].value < 0.1 {
+        if let idx = self.list.firstIndex(where: { $0.key == "VD0R" }), self.list[idx].value < 0.4 {
             self.list[idx].value = 0
         }
         // cut off low dc in current


### PR DESCRIPTION
I made some measurements on different devices to see what values they report for [DC IN] when unplugged. I adjustet the cutoff value to cover all devices and any back EMF or residual charge.

See #1343