### PR TITLE
Added swiftlint:disable function_body_length and duplicate_conditions, added missing closing swiftlint statements

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -203,6 +203,7 @@ public class BarChart: WidgetWrapper {
         
         self.setWidth(width)
     }
+    // swiftlint:enable function_body_length
     
     public func setValue(_ value: [[ColorValue]]) {
         guard self.value != value else {

--- a/Kit/Widgets/Battery.swift
+++ b/Kit/Widgets/Battery.swift
@@ -619,3 +619,4 @@ public class BatteryDetailsWidget: WidgetWrapper {
         self.display()
     }
 }
+// swiftlint:enable function_body_length

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -234,6 +234,7 @@ public class LineChart: WidgetWrapper {
         
         self.setWidth(width)
     }
+    // swiftlint:enable function_body_length
     
     public func setValue(_ value: Double) {
         if self.value != value {

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -123,6 +123,7 @@ public class LineChart: WidgetWrapper {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // swiftlint:disable function_body_length
     public override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         

--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -11,6 +11,7 @@
 
 import Cocoa
 
+// swiftlint:disable type_body_length
 public class SpeedWidget: WidgetWrapper {
     private var icon: String = "dots"
     private var state: Bool = false

--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -601,3 +601,4 @@ public class SpeedWidget: WidgetWrapper {
         self.display()
     }
 }
+// swiftlint:enable type_body_length

--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -743,6 +743,7 @@ public func Temperature(_ value: Double, defaultUnit: UnitTemperature = UnitTemp
     
     return formatter.string(from: measurement)
 }
+// swiftlint:enable identifier_name
 
 public func sysctlByName(_ name: String) -> Int64 {
     var num: Int64 = 0

--- a/Kit/module/module.swift
+++ b/Kit/module/module.swift
@@ -143,6 +143,7 @@ open class Module: Module_p {
         } else {
             debug("Module started without widget", log: self.log)
         }
+        // swiftlint:enable empty_count
         
         self.settings = Settings(
             config: &self.config,

--- a/Kit/module/reader.swift
+++ b/Kit/module/reader.swift
@@ -119,6 +119,7 @@ open class Reader<T>: NSObject, ReaderInternal_p {
                 self.nilCallbackCounter = 0
             }
         }
+        // swiftlint:enable duplicate_conditions
         
         self.value = value
         if value != nil {

--- a/Kit/module/reader.swift
+++ b/Kit/module/reader.swift
@@ -97,6 +97,7 @@ open class Reader<T>: NSObject, ReaderInternal_p {
         }
     }
     
+    // swiftlint:disable duplicate_conditions
     public func callback(_ value: T?) {
         if !self.optional && !self.ready {
             if self.value == nil && value != nil {

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -123,6 +123,7 @@ public enum widget_t: String {
         
         return nil
     }
+    // swiftlint:enable function_body_length
     
     public func name() -> String {
         switch self {

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -27,6 +27,7 @@ public enum widget_t: String {
     case tachometer = "tachometer"
     case state = "state"
     
+    // swiftlint:disable function_body_length
     public func new(module: String, config: NSDictionary, defaultWidget: widget_t) -> Widget? {
         var image: NSImage? = nil
         var preview: widget_p? = nil

--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -216,6 +216,7 @@ public class LineChartView: NSView {
             str.draw(with: rect)
         }
     }
+    // swiftlint:enable function_body_length
     
     public override func updateTrackingAreas() {
         self.trackingAreas.forEach({ self.removeTrackingArea($0) })

--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -102,6 +102,7 @@ public class LineChartView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // swiftlint:disable function_body_length
     public override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         

--- a/Kit/types.swift
+++ b/Kit/types.swift
@@ -24,6 +24,7 @@ public struct ColorValue: Equatable {
     public static func ==(lhs: ColorValue, rhs: ColorValue) -> Bool {
         return lhs.value == rhs.value
     }
+    // swiftlint:enable operator_whitespace
 }
 
 public enum AppUpdateInterval: String {

--- a/Modules/Bluetooth/readers.swift
+++ b/Modules/Bluetooth/readers.swift
@@ -145,6 +145,7 @@ internal class DevicesReader: Reader<[BLEDevice]>, CBCentralManagerDelegate, CBP
         
         self.callback(self.devices.filter({ $0.RSSI != nil }))
     }
+    // swiftlint:enable function_body_length
     
     // MARK: - HIDDevices (connected ble peripherals to the mac: keyboard, mouse etc...)
     

--- a/Modules/Bluetooth/readers.swift
+++ b/Modules/Bluetooth/readers.swift
@@ -45,6 +45,7 @@ internal class DevicesReader: Reader<[BLEDevice]>, CBCentralManagerDelegate, CBP
         self.manager = CBCentralManager(delegate: self, queue: nil)
     }
     
+    // swiftlint:disable function_body_length
     public override func read() {
         let hid = self.HIDDevices()
         let SPB = self.profilerDevices()

--- a/Modules/CPU/main.swift
+++ b/Modules/CPU/main.swift
@@ -76,6 +76,7 @@ public class CPU: Module {
         return color.additional as! NSColor
     }
     
+    // swiftlint:disable function_body_length
     public init() {
         self.settingsView = Settings("CPU")
         self.popupView = Popup("CPU")

--- a/Modules/CPU/main.swift
+++ b/Modules/CPU/main.swift
@@ -174,6 +174,7 @@ public class CPU: Module {
             self.addReader(reader)
         }
     }
+    // swiftlint:enable function_body_length
     
     private func loadCallback(_ raw: CPU_Load?) {
         guard let value = raw, self.enabled else {

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -12,6 +12,7 @@
 import Cocoa
 import Kit
 
+// swiftlint:disable type_body_length
 internal class Popup: PopupWrapper {
     private var title: String
     

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -588,3 +588,4 @@ internal class Popup: PopupWrapper {
         self.pCoresColorView?.layer?.backgroundColor = (newValue.additional as? NSColor)?.cgColor
     }
 }
+// swiftlint:enable type_body_length

--- a/Modules/CPU/readers.swift
+++ b/Modules/CPU/readers.swift
@@ -150,6 +150,7 @@ internal class LoadReader: Reader<CPU_Load> {
         
         self.callback(self.response)
     }
+    // swiftlint:enable function_body_length
     
     private func hostCPULoadInfo() -> host_cpu_load_info? {
         let count = MemoryLayout<host_cpu_load_info>.stride/MemoryLayout<integer_t>.stride
@@ -349,6 +350,7 @@ public class FrequencyReader: Reader<Double> {
             error("failed to find PGSample_Release", log: self.log)
             return
         }
+        // swiftlint:enable identifier_name
         
         self.PG_Initialize = unsafeBitCast(PG_InitializePointer, to: PG_InitializePointerFunction.self)
         self.PG_Shutdown = unsafeBitCast(PG_ShutdownPointer, to: PG_ShutdownPointerFunction.self)

--- a/Modules/CPU/readers.swift
+++ b/Modules/CPU/readers.swift
@@ -39,6 +39,7 @@ internal class LoadReader: Reader<CPU_Load> {
         self.cores = SystemKit.shared.device.info.cpu?.cores
     }
     
+    // swiftlint:disable function_body_length
     public override func read() {
         let result: kern_return_t = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &self.numCPUsU, &self.cpuInfo, &self.numCpuInfo)
         if result == KERN_SUCCESS {

--- a/Modules/Disk/main.swift
+++ b/Modules/Disk/main.swift
@@ -54,6 +54,7 @@ public class Disks {
     public var isEmpty: Bool {
         return self.count == 0
     }
+    // swiftlint:enable empty_count
     
     public func first(where predicate: (drive) -> Bool) -> drive? {
         var result: drive?

--- a/Modules/GPU/reader.swift
+++ b/Modules/GPU/reader.swift
@@ -209,4 +209,5 @@ internal class InfoReader: Reader<GPUs> {
         self.gpus.list.sort{ !$0.state && $1.state }
         self.callback(self.gpus)
     }
+    // swiftlint:enable function_body_length
 }

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -589,6 +589,7 @@ internal class Popup: PopupWrapper {
         NotificationCenter.default.post(name: .resetTotalNetworkUsage, object: nil, userInfo: nil)
     }
 }
+// swiftlint:enable type_body_length
 
 public class NetworkProcessView: NSView {
     public var width: CGFloat {

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -12,6 +12,7 @@
 import Cocoa
 import Kit
 
+// swiftlint:disable type_body_length
 internal class Popup: PopupWrapper {
     private var title: String
     

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -94,6 +94,7 @@ extension CWChannelWidth: CustomStringConvertible {
         }
     }
 }
+// swiftlint:enable control_statement
 
 extension CWChannel {
     override public var description: String {
@@ -554,6 +555,7 @@ public class ProcessReader: Reader<[Network_Process]> {
         
         self.callback(processes.suffix(self.numberOfProcesses).reversed())
     }
+    // swiftlint:enable function_body_length
 }
 
 internal class ConnectivityReaderWrapper {

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -432,6 +432,7 @@ public class ProcessReader: Reader<[Network_Process]> {
         self.popup = true
     }
     
+    // swiftlint:disable function_body_length
     public override func read() {
         if self.numberOfProcesses == 0 {
             return

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -54,6 +54,7 @@ internal class Popup: PopupWrapper {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // swiftlint:disable function_body_length
     internal func setup(_ values: [Sensor_p]? = nil, reload: Bool = false) {
         guard let values = reload ? self.sensors : values else { return }
         let fans = values.filter({ $0.type == .fan && !$0.isComputed })

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -164,6 +164,7 @@ internal class Popup: PopupWrapper {
         }
         self.recalculateHeight()
     }
+    // swiftlint:enable function_body_length
     
     internal func usageCallback(_ values: [Sensor_p]) {
         DispatchQueue.main.async(execute: {

--- a/Modules/Sensors/readers.swift
+++ b/Modules/Sensors/readers.swift
@@ -227,6 +227,7 @@ internal class SensorsReader: Reader<[Sensor_p]> {
         
         self.callback(self.list)
     }
+    // swiftlint:enable function_body_length
     
     private func initCalculatedSensors(_ sensors: [Sensor_p]) -> [Sensor_p] {
         var list: [Sensor_p] = []

--- a/Modules/Sensors/readers.swift
+++ b/Modules/Sensors/readers.swift
@@ -125,6 +125,7 @@ internal class SensorsReader: Reader<[Sensor_p]> {
         return results
     }
     
+    // swiftlint:disable function_body_length
     public override func read() {
         for i in self.list.indices {
             guard self.list[i].group != .hid && !self.list[i].isComputed else { continue }

--- a/Modules/Sensors/settings.swift
+++ b/Modules/Sensors/settings.swift
@@ -166,6 +166,7 @@ internal class Settings: NSStackView, Settings_v {
         
         self.widgets = widgets
     }
+    // swiftlint:enable function_body_length
     
     public func setList(list: [Sensor_p]) {
         self.list = self.unknownSensorsState ? list : list.filter({ $0.group != .unknown })

--- a/Modules/Sensors/settings.swift
+++ b/Modules/Sensors/settings.swift
@@ -60,6 +60,7 @@ internal class Settings: NSStackView, Settings_v {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // swiftlint:disable function_body_length
     public func load(widgets: [widget_t]) {
         var sensors = self.list
         guard !sensors.isEmpty else {

--- a/SMC/main.swift
+++ b/SMC/main.swift
@@ -49,6 +49,7 @@ enum FlagsType: String {
     }
 }
 
+// swiftlint:disable function_body_length
 func main() {
     var args = CommandLine.arguments.dropFirst()
     let cmd = CMDType(value: args.first ?? "")

--- a/SMC/main.swift
+++ b/SMC/main.swift
@@ -154,5 +154,6 @@ func main() {
         print("  -f    list fans\n")
     }
 }
+// swiftlint:enable function_body_length
 
 main()

--- a/SMC/smc.swift
+++ b/SMC/smc.swift
@@ -42,6 +42,7 @@ internal enum SMCKeys: UInt8 {
     case READ_PLIMIT = 11
     case READ_VERS = 12
 }
+// swiftlint:enable identifier_name
 
 public enum FanMode: Int {
     case automatic = 0


### PR DESCRIPTION
Added `swiftlint:disable function_body_length` and `type_body_length` where SwiftLint would complain, to turn off those warnings.
Also added one `disable duplicate_conditions` as a temporary fix for #1386 until the duplicate conditions is resolved. This enables compatibility for the latest SwiftLint update v0.51.