### PR TITLE
Update Traditional Chinese Taiwan Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -169,7 +169,7 @@
 "Number of reads in the chart" = "圖表中的未讀計數";
 "Color of download" = "下載的顯示色彩";
 "Color of upload" = "上傳的顯示色彩";
-"Monospaced font" = "Monospaced font";
+"Monospaced font" = "等寬字體";
 
 // Module Kit
 "Open module settings" = "打開模組設定";
@@ -319,7 +319,7 @@
 "Connectivity host (ICMP)" = "連線主機 (ICMP)";
 "Leave empty to disable the check" = "留空來停用檢查";
 "Transparent pictogram when no activity" = "未連線時隱藏標示";
-"Connectivity history" = "Connectivity history";
+"Connectivity history" = "連線歷程紀錄";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1415](https://github.com/exelban/stats/pull/1415)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “等寬字體” for `Monospaced font`
2. “連線歷程紀錄” for `Connectivity history`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1415/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1415.patch
https://github.com/exelban/stats/pull/1415.diff