### PR TITLE
Update Taiwan Traditional Chinese Localizable

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -26,8 +26,8 @@
 "Open Battery settings" = "打開電池設定";
 "Bluetooth" = "藍牙";
 "Open Bluetooth settings" = "打開藍牙設定";
-"Clock" = "Clock";
-"Open Clock settings" = "Open clock settings";
+"Clock" = "時鐘";
+"Open Clock settings" = "打開時鐘設定";
 
 // Words
 "Unknown" = "未知";
@@ -71,8 +71,8 @@
 "Logarithmic" = "對數";
 "Cores" = "核心數";
 "Settings" = "設定";
-"Name" = "Name";
-"Format" = "Format";
+"Name" = "名稱";
+"Format" = "格式";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -274,7 +274,7 @@
 "Disk utilization is" = "磁碟利用率為：%0";
 "Read color" = "讀取色彩";
 "Write color" = "寫入色彩";
-"Disk usage" = "Disk usage";
+"Disk usage" = "磁碟使用率";
 
 // Sensors
 "Temperature unit" = "溫度單位";
@@ -325,11 +325,11 @@
 "Leave empty to disable the check" = "留空來停用檢查";
 "Transparent pictogram when no activity" = "未連線時隱藏標示";
 "Connectivity history" = "連線歷程紀錄";
-"Auto-refresh public IP address" = "Auto-refresh public IP address";
-"Every hour" = "Every hour";
-"Every 12 hours" = "Every 12 hours";
-"Every 24 hours" = "Every 24 hours";
-"Network activity" = "Network activity";
+"Auto-refresh public IP address" = "自動重新整理公用 IP 位址";
+"Every hour" = "每小時";
+"Every 12 hours" = "每 12 小時";
+"Every 24 hours" = "每 24 小時";
+"Network activity" = "網路活動";
 
 // Battery
 "Level" = "電量";
@@ -366,15 +366,15 @@
 "current / maximum / designed" = "目前容量/最大容量/設計容量";
 "Low power mode" = "低電量模式";
 "Percentage inside the icon" = "在圖示內顯示百分比";
-"Colorize battery" = "Colorize battery";
+"Colorize battery" = "色彩化電池顯示";
 
 // Bluetooth
 "Battery to show" = "顯示藍牙裝置的電池電量";
 "No Bluetooth devices are available" = "沒有可用的藍牙裝置";
 
 // Clock
-"Time zone" = "Time zone";
-"Local" = "Local";
+"Time zone" = "時區";
+"Local" = "當地";
 
 // Colors
 "Based on utilization" = "根據使用率";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1486](https://github.com/exelban/stats/pull/1486)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “時鐘” for `Clock`
2. “打開時鐘設定” for `Open clock settings`
3. “名稱” for `Name`
4. “格式” for `Format`
5. “磁碟使用率” for `Disk usage`
6. “自動重新整理公用 IP 位址” for `Auto-refresh public IP address`
7. “每小時” for `Every hour`
8. “每 12 小時” for `Every 12 hour`
9. “每 24 小時” for `Every 24 hour`
10. “網路活動” for `Network activity`
11. “色彩化電池顯示” for `Colorize battery`
12. “時區” for `Time zone`
13. “當地” for `Local`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1486/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1486.patch
https://github.com/exelban/stats/pull/1486.diff