### PR TITLE
Update and Optimize Taiwan Traditional Chinese Localizable.strings

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -330,7 +330,7 @@
 "Every 12 hours" = "每 12 小時";
 "Every 24 hours" = "每 24 小時";
 "Network activity" = "網路活動";
-"Last reset" = "Last reset %0 ago";
+"Last reset" = "上次重置於 %0 前";
 
 // Battery
 "Level" = "電量";
@@ -367,7 +367,7 @@
 "current / maximum / designed" = "目前容量/最大容量/設計容量";
 "Low power mode" = "低電量模式";
 "Percentage inside the icon" = "在圖示內顯示百分比";
-"Colorize battery" = "色彩化電池顯示";
+"Colorize battery" = "啟用彩色電池圖示";
 
 // Bluetooth
 "Battery to show" = "顯示藍牙裝置的電池電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string and correcting several current translations.
對新的字串加入正體中文（臺灣）翻譯，並修正部分現有字串。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1504](https://github.com/exelban/stats/pull/1504)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “上次重置於 %0 前” for `Last reset %0 ago`

- **Correct several current translations.
修正部分現有字串的翻譯。**

1. Correct string `Colorize battery` from “色彩化電池顯示” to “啟用彩色電池圖示”

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1504/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1504.patch
https://github.com/exelban/stats/pull/1504.diff