### PR TITLE
Update Taiwan Traditional Chinese Localizable.strings

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -92,9 +92,9 @@
 "Check for a new version every week (once a week)" = "每週檢查是否有新版本 (1 週 1 次)";
 "Check for a new version every month (once a month)" = "每月檢查是否有新版本 (1 個月 1 次)";
 "Never check for updates (not recommended)" = "不要檢查更新 (不建議）";
-"Anonymous telemetry for better development decisions" = "Anonymous telemetry for better development decisions";
-"Share anonymous telemetry data" = "Share anonymous telemetry data";
-"Do not share anonymous telemetry data" = "Do not share anonymous telemetry data";
+"Anonymous telemetry for better development decisions" = "匿名診斷資料將用於改善開發決策";
+"Share anonymous telemetry data" = "分享匿名診斷資料";
+"Do not share anonymous telemetry data" = "不同意分享診斷資料";
 "The configuration is completed" = "組態設定完成！";
 "finish_setup_message" = "所有設定均已大功告成！\n Stats 是一款開源且永久免費的工具程式。\n 由衷地感謝您喜歡與愛用 Stats，也歡迎您支持這個專案！";
 
@@ -130,7 +130,7 @@
 "Resume the Stats" = "恢復 Stats";
 "Combined modules" = "合併模組";
 "Spacing" = "間距";
-"Share anonymous telemetry" = "Share anonymous telemetry";
+"Share anonymous telemetry" = "分享匿名診斷資料";
 
 // Dashboard
 "Serial number" = "序號";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "Network chart widget" = "網狀圖";
 "Speed widget" = "讀寫速度";
 "Battery widget" = "電池";
-"Stack widget" = "Stack";
+"Stack widget" = "疊放";
 "Memory widget" = "容量";
 "Static width" = "靜態寬度";
 "Tachometer widget" = "轉速計";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new string
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1531](https://github.com/exelban/stats/pull/1531)

**Commit Summary
更新大綱**

- **Add new translations for strings which has not translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “疊放” for `Stack`

- **Add new translations for new strings which has not translated yet in a supplementary update.
在補充更新中對尚未翻譯的字串加入正體中文（臺灣）的翻譯。
Thanks @Jerry23011**

1. “匿名診斷資料將用於改善開發決策” for `Anonymous telemetry for better development decisions`
2. “分享匿名診斷資料” for `Share anonymous telemetry data`
3. “不分享匿名診斷資料” for `Do not share anonymous telemetry data`
4. “分享匿名診斷資料” for `Share anonymous telemetry`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1531/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1531.patch
https://github.com/exelban/stats/pull/1531.diff