### PR TITLE
Add Taiwan Traditional Chinese Translation String

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -73,7 +73,7 @@
 "Settings" = "設定";
 "Name" = "名稱";
 "Format" = "格式";
-"Turn off" = "Turn off";
+"Turn off" = "關閉";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -296,8 +296,8 @@
 "Install fan helper" = "安裝風扇輔助程式";
 "Uninstall fan helper" = "解除安裝風扇輔助程式";
 "Fan value" = "風扇轉速值";
-"Turn off fan" = "Turn off fan";
-"You are going to turn off the fan. That is not recommended action that can broke your mac, are you sure you want to do that?" = "You are going to turn off the fan. That is not recommended action that can broke your mac, are you sure you want to do that?";
+"Turn off fan" = "關閉風扇";
+"You are going to turn off the fan. That is not recommended action that can broke your mac, are you sure you want to do that?" = "您似乎要關閉您 Mac 的風扇。這可能會造成 Mac 的損毀，不建議進行此操作，您確定仍要關閉風扇嗎？";
 
 // Network
 "Uploading" = "上傳";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1588](https://github.com/exelban/stats/pull/1588)

**Commit Summary
更新大綱**

- Translating those new-added strings below into Taiwan Traditional Chinese. 針對新增的字串加入正體中文（臺灣）的翻譯。

1. “關閉” for `Turn Off`
2. “關閉風扇” for `Turn off fan`
3. “您似乎要關閉您 Mac 的風扇。這可能會造成 Mac 的損毀，不建議進行此操作，您確定仍要關閉風扇嗎？” for `You are going to turn off the fan. That is not recommended action that can broke your mac, are you sure you want to do that?`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1588/files) (3)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1588.patch
https://github.com/exelban/stats/pull/1588.diff