### PR TITLE
battery: Add "Low Power Mode" to popup

### DIFF
--- a/Modules/Battery/main.swift
+++ b/Modules/Battery/main.swift
@@ -20,6 +20,7 @@ struct Battery_Usage: value_t, Codable {
     var isCharging: Bool = false
     var isBatteryPowered: Bool = false
     var optimizedChargingEngaged: Bool = false
+    var lowPowerMode: Bool = false
     var level: Double = 0
     var cycles: Int = 0
     var health: Int = 0

--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -34,6 +34,7 @@ internal class Popup: PopupWrapper {
     
     private var levelField: NSTextField? = nil
     private var sourceField: NSTextField? = nil
+    private var lowPowerModeField: NSTextField? = nil
     private var timeLabelField: NSTextField? = nil
     private var timeField: NSTextField? = nil
     private var healthField: NSTextField? = nil
@@ -155,6 +156,7 @@ internal class Popup: PopupWrapper {
         
         self.levelField = popupRow(container, title: "\(localizedString("Level")):", value: "").1
         self.sourceField = popupRow(container, title: "\(localizedString("Source")):", value: "").1
+        self.lowPowerModeField = popupRow(container, title: "\(localizedString("Low Power Mode")):", value: "Off").1
         self.healthField = popupRow(container, title: "\(localizedString("Health")):", value: "").1
         self.capacityField = popupRow(container, title: "\(localizedString("Capacity")):", value: "").1
         self.capacityField?.toolTip = localizedString("current / maximum / designed")
@@ -249,6 +251,12 @@ internal class Popup: PopupWrapper {
             self.sourceField?.stringValue = localizedString(value.powerSource)
             self.timeField?.stringValue = ""
             
+            if value.lowPowerMode {
+                self.lowPowerModeField?.stringValue = localizedString("On")
+            } else {
+                self.lowPowerModeField?.stringValue = localizedString("Off")
+            }
+
             if value.isBatteryPowered {
                 self.timeLabelField?.stringValue = "\(localizedString("Time to discharge")):"
                 if value.timeToEmpty != -1 && value.timeToEmpty != 0 {

--- a/Modules/Battery/readers.swift
+++ b/Modules/Battery/readers.swift
@@ -67,6 +67,10 @@ internal class UsageReader: Reader<Battery_Usage> {
                 self.usage.optimizedChargingEngaged = list["Optimized Battery Charging Engaged"] as? Int == 1
                 self.usage.level = Double(list[kIOPSCurrentCapacityKey] as? Int ?? 0) / 100
                 
+                if #available(macOS 12.0, *) {
+                    self.usage.lowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+                }
+
                 if let time = list[kIOPSTimeToEmptyKey] as? Int {
                     self.usage.timeToEmpty = Int(time)
                 }


### PR DESCRIPTION
Hi,

I really enjoy using the Stats app but one of the only things it's missing for me is the low power mode status. I've added the code where I thought it makes sense (I'm not a Swift programmer) and it seems to work for me, but happy to make changes if you're willing to merge.

