### PR TITLE
lang: updated french translation

### DIFF
--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -191,8 +191,8 @@
 "Pictogram" = "Pictogramme";
 "Module" = "Module";
 "Widgets" = "Widgets";
-"Popup" = "Surgir";
-"Notifications" = "Avis";
+"Popup" = "Popup";
+"Notifications" = "Notifications";
 "Merge widgets" = "Fusionner les widgets";
 "No available widgets to configure" = "Aucun widget disponible à configurer";
 "No options to configure for the popup in this module" = "Aucune option à configurer pour la fenêtre contextuelle dans ce module";


### PR DESCRIPTION
Corrected Popup translated to "surgir" which is
a verb, whereas a noun is required. "Popup" is largely accepted in french computing context.
Also kept french "Notifications" for english "Notifications" :)