### PR TITLE
Update and Optimize Taiwan Traditional Chinese Localizable.strings

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -179,7 +179,7 @@
 "Color of download" = "下載的顯示色彩";
 "Color of upload" = "上傳的顯示色彩";
 "Monospaced font" = "等寬字體";
-"Reverse order" = "Reverse order";
+"Reverse order" = 排序對調";
 
 // Module Kit
 "Open module settings" = "打開模組設定";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into a new string.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1691](https://github.com/exelban/stats/pull/1691)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “排序對調” for `Reverse order`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1691/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1691.patch
https://github.com/exelban/stats/pull/1691.diff