### PR TITLE
Update Taiwan Traditional Chinese Localizable.strings

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -74,9 +74,9 @@
 "Name" = "名稱";
 "Format" = "格式";
 "Turn off" = "關閉";
-"Warning" = "Warning";
-"Critical" = "Critical";
-"Usage" = "Usage";
+"Warning" = "警告";
+"Critical" = "重要通知";
+"Usage" = "使用量";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -233,11 +233,11 @@
 "Cluster grouping" = "依群集分組";
 "Efficiency cores color" = "節能核心色彩";
 "Performance cores color" = "效能核心色彩";
-"Total load" = "Total load";
-"System load" = "System load";
-"User load" = "User load";
-"Efficiency cores load" = "Efficiency cores load";
-"Performance cores load" = "Performance cores load";
+"Total load" = "總占用";
+"System load" = "系統占用";
+"User load" = "使用者占用";
+"Efficiency cores load" = "節能核心占用";
+"Performance cores load" = "效能核心占用";
 
 // GPU
 "GPU to show" = "顯示顯示卡";
@@ -269,7 +269,7 @@
 "Wired" = "固定";
 "Compressed" = "已壓縮";
 "Free" = "可使用";
-"Swap" = "調換區";
+"Swap" = "調換";
 "Split the value (App/Wired/Compressed)" = "分割值 (App/固定/壓縮)";
 "RAM utilization threshold" = "記憶體利用率臨界值";
 "RAM utilization is" = "記憶體利用率為：%0";
@@ -277,9 +277,9 @@
 "Wired color" = "固定記憶體色彩";
 "Compressed color" = "已壓縮色彩";
 "Free color" = "可使用記憶體色彩";
-"Free memory (less than)" = "Free memory (less than)";
-"Swap size" = "Swap size";
-"Free RAM is" = "Free RAM is %0";
+"Free memory (less than)" = "可用記憶體 (小於)";
+"Swap size" = "已使用調換";
+"Free RAM is" = "可用記憶體剩餘 %0";
 
 // Disk
 "Show removable disks" = "顯示抽取式磁碟";
@@ -310,7 +310,7 @@
 "Fan value" = "風扇轉速值";
 "Turn off fan" = "關閉風扇";
 "You are going to turn off the fan. This is not recommended action that can damage your mac, are you sure you want to do that?" = "您似乎要關閉您 Mac 的風扇。這可能會造成 Mac 的損毀，不建議進行此操作，您確定仍要關閉風扇嗎？";
-"Sensor threshold" = "Sensor threshold";
+"Sensor threshold" = "感知器臨界值";
 
 // Network
 "Uploading" = "上傳";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into a new string, and changing translation for some strings.
對新的字串加入正體中文（臺灣）翻譯，並變更部份字串的譯文。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1740](https://github.com/exelban/stats/pull/1740)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “警告” for `Warning`
2. “重要通知” for `Critical`
3. “使用量” for `Usage`
4. “總占用” for `Total load`
5. “系統占用” for `System load`
6. “使用者占用” for `User load`
7. “節能核心占用” for `Efficiency cores load`
8. “效能核心占用” for `Performance cores load`
9. “可用記憶體 (小於)” for `Free memory (less than)`
10. “已使用調換” for `Swap size`
11. “可用記憶體剩餘 %0” for `Free RAM is %0`
12. “感知器臨界值” for `Sensor threshold`

- **Changing translation for some strings.
變更部份字串的譯文。**

1. “調換” for `Swap`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1740/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1740.patch
https://github.com/exelban/stats/pull/1740.diff