### PR TITLE
Corrected Italian translation

### DIFF
--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -303,7 +303,7 @@
 "Fan" = "Ventola";
 "HID sensors" = "Sensori HID";
 "Synchronize fan's control" = "Sincronizza ventole";
-"Current" = "Attuale";
+"Current" = "Corrente";
 "Energy" = "Energia";
 "Show unknown sensors" = "Mostra sensori sconosciuti";
 "Install fan helper" = "Installa estensione ventole";


### PR DESCRIPTION
Changed the translation of word "Current" from "Attuale" (which is time related) to "Corrente" (which is the electrical term, correct in this context)