### PR TITLE
Update Taiwan Traditional Chinese Localizable.strings

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -77,9 +77,9 @@
 "Warning" = "警告";
 "Critical" = "重要通知";
 "Usage" = "使用量";
-"2 minutes" = "2 minutes";
-"3 minutes" = "3 minutes";
-"10 minutes" = "10 minutes";
+"2 minutes" = "2 分鐘";
+"3 minutes" = "3 分鐘";
+"10 minutes" = "10 分鐘";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -187,7 +187,7 @@
 "Color of upload" = "上傳的顯示色彩";
 "Monospaced font" = "等寬字體";
 "Reverse order" = "排序對調";
-"Chart duration" = "Chart duration";
+"Chart duration" = "圖表顯示區間";
 
 // Module Kit
 "Open module settings" = "打開模組設定";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1843](https://github.com/exelban/stats/pull/1843)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “2分鐘” for `2 minutes`
2. “3分鐘” for `3 minutes`
3. “10分鐘” for `10 minutes`
4. “圖表顯示區間” for `Chart duration`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1843/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1843.patch
https://github.com/exelban/stats/pull/1843.diff