### PR TITLE
lang: update Taiwan Traditional Chinese localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -80,8 +80,8 @@
 "2 minutes" = "2 分鐘";
 "3 minutes" = "3 分鐘";
 "10 minutes" = "10 分鐘";
-"Import" = "Import";
-"Export" = "Export";
+"Import" = "匯入";
+"Export" = "匯出";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -300,8 +300,8 @@
 "Read color" = "讀取色彩";
 "Write color" = "寫入色彩";
 "Disk usage" = "磁碟使用量";
-"Total read" = "Total read";
-"Total written" = "Total written";
+"Total read" = "總讀取量";
+"Total written" = "總寫入量";
 
 // Sensors
 "Temperature unit" = "溫度單位";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/1872](https://github.com/exelban/stats/pull/1872)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “匯入” for `Import`
2. “匯出” for `Export`
3. “總讀取量” for `Total read`
4. “總寫入量” for `Total written`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/1872/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/1872.patch
https://github.com/exelban/stats/pull/1872.diff