### PR TITLE
fix: Fix GPU temperature conversion in the popup chart

### DIFF
--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -730,19 +730,31 @@ public extension UnitTemperature {
     }
 }
 
-public func temperature(_ value: Double, defaultUnit: UnitTemperature = UnitTemperature.celsius, fractionDigits: Int = 0) -> String {
-    let formatter = MeasurementFormatter()
-    formatter.locale = Locale.init(identifier: "en_US")
-    formatter.numberFormatter.maximumFractionDigits = fractionDigits
-    if fractionDigits != 0 {
-        formatter.numberFormatter.minimumFractionDigits = fractionDigits
-    }
-    formatter.unitOptions = .providedUnit
-    
-    var measurement = Measurement(value: value, unit: defaultUnit)
+public func temperature(_ value: Double, unit: UnitTemperature = UnitTemperature.celsius) -> Measurement<UnitTemperature> {
+    var measurement = Measurement(value: value, unit: unit)
     measurement.convert(to: UnitTemperature.current)
-    
-    return formatter.string(from: measurement)
+    return measurement
+}
+
+public extension Measurement<UnitTemperature> {
+    func format(_ fractionDigits: Int = 0, temperatureWithoutUnit: Bool = false) -> String {
+        let formatter = MeasurementFormatter()
+        formatter.locale = Locale.init(identifier: "en_US")
+        formatter.numberFormatter.maximumFractionDigits = fractionDigits
+        if fractionDigits != 0 {
+            formatter.numberFormatter.minimumFractionDigits = fractionDigits
+        }
+        formatter.unitOptions = .providedUnit
+
+        var result = formatter.string(from: self)
+        if temperatureWithoutUnit {
+            // This is workaround for formatting temperature without degree letter because `short` unit style or
+            // `temperatureWithoutUnit` unit options formatter settings can't produce formatted string in
+            // expected format for different locales and temperature scales.
+            result = result.replacingOccurrences(of: "C", with: "").replacingOccurrences(of: "F", with: "")
+        }
+        return result
+    }
 }
 
 public func sysctlByName(_ name: String) -> Int64 {

--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -299,7 +299,7 @@ internal class Popup: PopupWrapper {
             self.voltageField?.stringValue = "\(value.voltage.roundTo(decimalPlaces: 2)) V"
             let batteryPower = value.voltage * (Double(abs(value.amperage))/1000)
             self.batteryPowerField?.stringValue = "\(batteryPower.roundTo(decimalPlaces: 2)) W"
-            self.temperatureField?.stringValue = temperature(value.temperature)
+            self.temperatureField?.stringValue = temperature(value.temperature).format()
             
             self.powerField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\(value.ACwatts) W"
             self.chargingStateField?.stringValue = value.isCharging ? localizedString("Yes") : localizedString("No")

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -380,7 +380,7 @@ internal class Popup: PopupWrapper {
                 }
                 
                 self.temperatureCircle?.setValue(value)
-                self.temperatureCircle?.setText(temperature(value))
+                self.temperatureCircle?.setText(temperature(value).format())
                 self.initializedTemperature = true
             }
         })

--- a/Modules/Disk/popup.swift
+++ b/Modules/Disk/popup.swift
@@ -691,7 +691,7 @@ internal class TemperatureView: NSStackView {
         
         self.field.font = NSFont.systemFont(ofSize: 11, weight: .regular)
         self.field.alignment = .right
-        self.field.stringValue = "\(temperature(Double(smart.temperature)))"
+        self.field.stringValue = "\(temperature(Double(smart.temperature)).format())"
         
         self.addArrangedSubview(title)
         self.addArrangedSubview(NSView())
@@ -708,7 +708,7 @@ internal class TemperatureView: NSStackView {
     public func update(_ newValue: smart_t?) {
         if (self.window?.isVisible ?? false) || !self.initialized {
             if let newValue {
-                self.field.stringValue = "\(temperature(Double(newValue.temperature)))"
+                self.field.stringValue = "\(temperature(Double(newValue.temperature)).format())"
             } else {
                 self.field.stringValue = "-"
             }

--- a/Modules/GPU/popup.swift
+++ b/Modules/GPU/popup.swift
@@ -225,7 +225,7 @@ private class GPUView: NSStackView {
         
         if id == "temperature" {
             circle.setValue(value)
-            circle.setText(temperature(value))
+            circle.setText(temperature(value).format())
             chart.suffix = UnitTemperature.current.symbol
             
             if self.temperatureChart == nil {
@@ -269,11 +269,7 @@ private class GPUView: NSStackView {
         }
         
         if let value = gpu.temperature {
-            if let temp = Double(temperature(value/100).replacingOccurrences(of: "C", with: "").replacingOccurrences(of: "F", with: "").digits) {
-                self.temperatureChart?.addValue(temp)
-            } else {
-                self.temperatureChart?.addValue(value/100)
-            }
+            self.temperatureChart?.addValue(temperature(value).value/100)
         }
         if let value = gpu.utilization {
             self.utilizationChart?.addValue(value)
@@ -367,7 +363,7 @@ private class GPUDetails: NSView {
         }
         
         if let value = value.temperature {
-            let arr = keyValueRow("\(localizedString("Temperature")):", Kit.temperature(Double(value)))
+            let arr = keyValueRow("\(localizedString("Temperature")):", Kit.temperature(value).format())
             self.temperature = arr.last
             grid.addRow(with: arr)
             num += 1
@@ -421,7 +417,7 @@ private class GPUDetails: NSView {
         }
         
         if let value = gpu.temperature {
-            self.temperature?.stringValue = Kit.temperature(Double(value))
+            self.temperature?.stringValue = Kit.temperature(value).format()
         }
         if let value = gpu.utilization {
             self.utilization?.stringValue = "\(Int(value*100))%"

--- a/Modules/Sensors/notifications.swift
+++ b/Modules/Sensors/notifications.swift
@@ -26,7 +26,7 @@ class Notifications: NotificationsWrapper {
         super.init(module)
         for p in self.temperatureList {
             if let v = Double(p) {
-                self.temperatureLevels.append(KeyValue_t(key: p, value: temperature(v)))
+                self.temperatureLevels.append(KeyValue_t(key: p, value: temperature(v).format()))
             }
         }
     }

--- a/Modules/Sensors/values.swift
+++ b/Modules/Sensors/values.swift
@@ -156,7 +156,7 @@ public struct Sensor: Sensor_p, Codable {
     public var formattedValue: String {
         switch self.type {
         case .temperature:
-            return temperature(value)
+            return temperature(value).format()
         case .voltage:
             let val = value >= 100 ? "\(Int(value))" : String(format: "%.3f", value)
             return "\(val)\(unit)"
@@ -173,7 +173,7 @@ public struct Sensor: Sensor_p, Codable {
     public var formattedPopupValue: String {
         switch self.type {
         case .temperature:
-            return temperature(value, fractionDigits: 1)
+            return temperature(value).format(1)
         case .voltage:
             let val = value >= 100 ? "\(Int(value))" : String(format: "%.3f", value)
             return "\(val)\(unit)"
@@ -190,7 +190,7 @@ public struct Sensor: Sensor_p, Codable {
     public var formattedMiniValue: String {
         switch self.type {
         case .temperature:
-            return temperature(value).replacingOccurrences(of: "C", with: "").replacingOccurrences(of: "F", with: "")
+            return temperature(value).format(temperatureWithoutUnit: true)
         case .voltage, .power, .energy, .current:
             let val = value >= 9.95 ? "\(Int(round(value)))" : String(format: "%.1f", value)
             return "\(val)\(unit)"


### PR DESCRIPTION
This PR fixes GPU temperature conversion in the popup chart after an incorrect fix in the fb63ece commit related to the #1809 issue.

Before this fix the GPU chart show incorrect temperature value:

<img width="280" alt="Screenshot 2024-04-29 at 20 43 19" src="https://github.com/exelban/stats/assets/27208/ce28b840-3705-4aff-b5e7-7976073e0e8f">
<img width="280" alt="Screenshot 2024-04-29 at 20 43 44" src="https://github.com/exelban/stats/assets/27208/bda45cad-c568-4986-90ac-d1c21556d43f">

As you can see it shows 0C instead of 48C and 3300F instead of 118F.

After this fix it should show the correct values:

<img width="280" alt="Screenshot 2024-04-29 at 20 41 19" src="https://github.com/exelban/stats/assets/27208/3f649d39-d29d-4995-9ae8-6f47f3530fec">
<img width="280" alt="Screenshot 2024-04-29 at 20 41 53" src="https://github.com/exelban/stats/assets/27208/04f2143c-8439-48c9-8ab6-fc3b6a400063">


 