### PR TITLE
Change "Model id" string to "Model identifier"

### DIFF
--- a/Stats/Views/Dashboard.swift
+++ b/Stats/Views/Dashboard.swift
@@ -180,7 +180,7 @@ class Dashboard: NSStackView {
         ]))
         
         scrollView.stackView.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Model id"), component: textView(SystemKit.shared.device.model.id)),
+            PreferencesRow(localizedString("Model identifier"), component: textView(SystemKit.shared.device.model.id)),
             PreferencesRow(localizedString("Production year"), component: textView("\(SystemKit.shared.device.model.year)")),
             PreferencesRow(localizedString("Serial number"), component: textView(SystemKit.shared.device.serialNumber ?? localizedString("Unknown")))
         ]))


### PR DESCRIPTION
Updated the "Model id" localized string to "Model identifier". Apple officially uses the term model identifier so it makes sense to have the app reflect this.