### PR TITLE
fix: change log file directory to "Application Support"

### DIFF
--- a/Kit/plugins/Logger.swift
+++ b/Kit/plugins/Logger.swift
@@ -71,14 +71,14 @@ public class NextLog {
         case .file:
             let fm = FileManager.default
             let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            let logDirectoryURL = appSupportURL.appendingPathComponent("Stats")
+            let logDirectoryURL = appSupportURL.appendingPathComponent("Stats/Logs")
             let fileURL = logDirectoryURL.appendingPathComponent("log.txt")
             
             if !fm.fileExists(atPath: logDirectoryURL.path) {
                 do {
                     try fm.createDirectory(at: logDirectoryURL, withIntermediateDirectories: true)
                 } catch let error {
-                    print("failed to create log directory")
+                    print("failed to create log directory: \(error)")
                     self.writer = StdoutOutputStream()
                     return
                 }

--- a/Kit/plugins/Logger.swift
+++ b/Kit/plugins/Logger.swift
@@ -70,7 +70,19 @@ public class NextLog {
             self.writer = StderrOutputStream()
         case .file:
             let fm = FileManager.default
-            let fileURL = fm.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("log.txt")
+            let appSupportURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            let logDirectoryURL = appSupportURL.appendingPathComponent("Stats")
+            let fileURL = logDirectoryURL.appendingPathComponent("log.txt")
+            
+            if !fm.fileExists(atPath: logDirectoryURL.path) {
+                do {
+                    try fm.createDirectory(at: logDirectoryURL, withIntermediateDirectories: true)
+                } catch let error {
+                    print("failed to create log directory")
+                    self.writer = StdoutOutputStream()
+                    return
+                }
+            }
             
             if !fm.fileExists(atPath: fileURL.path) {
                 try? "".data(using: .utf8)?.write(to: fileURL)


### PR DESCRIPTION
Stats currently generates a `log.txt` file inside local "Documents" directory. It's not a place to store application related data.

I suggest we use the "Application Support/Stats" directory inside local "Library" for the `log.txt`.