### PR TITLE
fix: add macOS 15 (Sequoia) string

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -624,5 +624,6 @@ let osDict: [String: String] = [
     "11": "Big Sur",
     "12": "Monterey",
     "13": "Ventura",
-    "14": "Sonoma"
+    "14": "Sonoma",
+    "15": "Sequoia"
 ]


### PR DESCRIPTION
This pull request adds the string for macOS 15 (Sequoia). I'm not entirely sure if this actually works, since I've been struggling to get my Xcode working 🥴