### PR TITLE
Tweak GHA configs a bit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: build
 
-on: 
+on:
   push:
     branches:
       - master
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: xcodebuild -scheme Stats -destination 'platform=macOS' -configuration Release archive CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: python3 Kit/scripts/i18n.py

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -17,5 +17,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: norio-nomura/action-swiftlint@3.2.1


### PR DESCRIPTION
- Bump actions to the latest, the old ones based on Node 16 are deprecated.
- Migrate build devices to macos-latest that now based on Apple Silicon Chips, will significantly speed up builds.