### PR TITLE
lang: update Taiwan Traditional Chinese localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -142,14 +142,14 @@
 "Pause the Stats" = "暫停 Stats";
 "Resume the Stats" = "恢復 Stats";
 "Combined modules" = "合併模組";
-"Combined details" = "Combined details";
+"Combined details" = "合併細節";
 "Spacing" = "間距";
 "Share anonymous telemetry" = "分享匿名診斷資料";
 
 // Dashboard
 "Serial number" = "序號";
-"Model identifier" = "Model identifier";
-"Production year" = "Production year";
+"Model identifier" = "機型識別碼";
+"Production year" = "製造年份";
 "Uptime" = "開機時間";
 "Number of cores" = "%0 核心";
 "Number of threads" = "%0 執行緒";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2013](https://github.com/exelban/stats/pull/2023)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “合併細節” for `Combined details`
2. “機型識別碼” for `Model identifier`
3. “製造年份” for `Production year`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2023/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2023.patch
https://github.com/exelban/stats/pull/2023.diff