### PR TITLE
Fixed Disk Popup disk name label color

### DIFF
--- a/Modules/Disk/popup.swift
+++ b/Modules/Disk/popup.swift
@@ -435,7 +435,7 @@ internal class NameView: NSStackView {
         let nameField = NSButton()
         nameField.bezelStyle = .inline
         nameField.isBordered = false
-        nameField.contentTintColor = .darkGray
+        nameField.contentTintColor = .labelColor
         nameField.action = #selector(self.openDisk)
         nameField.target = self
         nameField.toolTip = localizedString("Control")


### PR DESCRIPTION
The recent change to the Disk Popup changed the color of the disk name label to darkGray. Changed back to labelColor.

**Old:**
<img width="270" alt="old" src="https://github.com/user-attachments/assets/159146b5-3599-4d31-8549-d3b00ec76183">

**Fixed:**
<img width="272" alt="new" src="https://github.com/user-attachments/assets/e5c201a3-fa59-4fa0-8eb3-5d3a98baa2d7">
