### PR TITLE
fix: make log scale graph have better dynamic range

### DIFF
--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -45,8 +45,6 @@ internal func scaleValue(scale: Scale = .linear, value: Double, maxValue: Double
             localMaxValue = cbrt(maxValue)
         }
     case .logarithmic:
-        // Smallest value passed is 1024
-        // Setting y=0 to 256 gives a nice curve
         let zeroVal = 256.0
         if value > 0 {
             value = log(value/zeroVal)

--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -45,11 +45,14 @@ internal func scaleValue(scale: Scale = .linear, value: Double, maxValue: Double
             localMaxValue = cbrt(maxValue)
         }
     case .logarithmic:
+        // Smallest value passed is 1024
+        // Setting y=0 to 256 gives a nice curve
+        let zeroVal = 256.0
         if value > 0 {
-            value = log(value*100)
+            value = log(value/zeroVal)
         }
         if localMaxValue > 0 {
-            localMaxValue = log(maxValue*100)
+            localMaxValue = log(maxValue/zeroVal)
         }
     case .fixed:
         if value > limit {


### PR DESCRIPTION
Resolves #2088

Previously, dynamic range of log scale was bad because 0.01 Bytes/second (10e-2) was mapped to 0

Commonly found values for network speed range from 1kB/second (10e3) to 100GB/second (10e8)

As a result, half of the dynamic range was wasted as no values would ever appear between 10e-2 and 10e3.

New:

<img width="330" alt="image" src="https://github.com/user-attachments/assets/e328ee94-ac8e-4b6b-b699-5b9037176a1e">


Before:

<img width="313" alt="Stats 2024-08-25 19 21 59" src="https://github.com/user-attachments/assets/a3418dd1-9aa7-4d1c-9f0f-9242b24d8262">

