### PR TITLE
Restore button for resetting total network usage

### DIFF
--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -233,7 +233,22 @@ internal class Popup: PopupWrapper {
         let view = NSStackView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: 0))
         view.orientation = .vertical
         view.spacing = 0
-        view.addArrangedSubview(separatorView(localizedString("Details"), width: self.frame.width))
+        
+        let row: NSView = NSView(frame: NSRect(x: 0, y: 0, width: view.frame.width, height: Constants.Popup.separatorHeight))
+        row.heightAnchor.constraint(equalToConstant: Constants.Popup.separatorHeight).isActive = true
+        let button = NSButtonWithPadding()
+        button.frame = CGRect(x: view.frame.width - 18, y: 6, width: 18, height: 18)
+        button.bezelStyle = .regularSquare
+        button.isBordered = false
+        button.imageScaling = NSImageScaling.scaleAxesIndependently
+        button.contentTintColor = .lightGray
+        button.action = #selector(self.resetTotalNetworkUsage)
+        button.target = self
+        button.toolTip = localizedString("Reset")
+        button.image = Bundle(for: Module.self).image(forResource: "refresh")!
+        row.addSubview(separatorView(localizedString("Details"), width: self.frame.width))
+        row.addSubview(button)
+        view.addArrangedSubview(row)
         
         let totalUpload = popupWithColorRow(view, color: self.uploadColor, title: "\(localizedString("Total upload")):", value: "0")
         let totalDownload = popupWithColorRow(view, color: self.downloadColor, title: "\(localizedString("Total download")):", value: "0")


### PR DESCRIPTION
https://github.com/exelban/stats/commit/14d177fdc0e0250313231e038dc223cb19331fed: removed the button to reset network usage. I was surprised to see this button gone.

This PR restores it. The observer and callback were left over so I'm assuming it was unintentional? I used the same structure that the "refreshPublicIP" button uses.

# Before
<img width="284" alt="image" src="https://github.com/user-attachments/assets/3e2fa5b7-57e0-42de-8d6d-95a1c2c57960">

# After
<img width="281" alt="image" src="https://github.com/user-attachments/assets/1eb6be41-0acc-4fda-8f73-2138a10bee44">