### PR TITLE
Issue #2008 Display Charging Percentage Instead of Power Icon

### DIFF
--- a/Modules/Battery/main.swift
+++ b/Modules/Battery/main.swift
@@ -119,9 +119,9 @@ public class Battery: Module {
                 widget.setValue([[ColorValue(value.level)]])
                 widget.setColorZones((0.15, 0.3))
             case let widget as BatteryWidget:
-                widget.setValue(
+                 widget.setValue(
                     percentage: value.level,
-                    ACStatus: !value.isBatteryPowered,
+                    ACStatus: false,  // Always false to avoid showing the power icon
                     isCharging: value.isCharging,
                     optimizedCharging: value.optimizedChargingEngaged,
                     time: value.timeToEmpty == 0 && value.timeToCharge != 0 ? value.timeToCharge : value.timeToEmpty


### PR DESCRIPTION
This pull request resolves Issue #2008, where the power icon was displayed when the device was connected to power. The modification ensures that the charging percentage is shown instead of the power icon when the device is plugged in.