### PR TITLE
lang: update Taiwan Traditional Chinese localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -197,8 +197,8 @@
 "Reverse order" = "排序對調";
 "Chart history" = "圖表顯示區間";
 "Default color" = "Default";
-"Transparent when no activity" = "Transparent when no activity";
-"Constant color" = "Constant";
+"Transparent when no activity" = "沒有活動時維持透明顯示";
+"Constant color" = "恆定色彩";
 
 // Module Kit
 "Open module settings" = "打開模組設定";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2144](https://github.com/exelban/stats/pull/2144)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “沒有活動時維持透明顯示” for `Transparent when no activity`
2. “恆定色彩” for `Constant color`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2144/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2144.patch
https://github.com/exelban/stats/pull/2144.diff