### PR TITLE
Bolder text for speed module menu bar item

### DIFF
--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -223,7 +223,7 @@ public class SpeedWidget: WidgetWrapper {
         let size: CGFloat = 10
         
         let downloadStringAttributes = [
-            NSAttributedString.Key.font: NSFont.systemFont(ofSize: 11, weight: .regular),
+            NSAttributedString.Key.font: NSFont.systemFont(ofSize: 11, weight: .medium),
             NSAttributedString.Key.foregroundColor: color,
             NSAttributedString.Key.paragraphStyle: style
         ]
@@ -294,7 +294,7 @@ public class SpeedWidget: WidgetWrapper {
         let rowHeight: CGFloat = self.frame.height
         let height: CGFloat = 10
         let downloadAttributes = [
-            NSAttributedString.Key.font: NSFont.systemFont(ofSize: 12, weight: .regular),
+            NSAttributedString.Key.font: NSFont.systemFont(ofSize: 12, weight: .medium),
             NSAttributedString.Key.foregroundColor: color,
             NSAttributedString.Key.paragraphStyle: NSMutableParagraphStyle()
         ]
@@ -326,12 +326,12 @@ public class SpeedWidget: WidgetWrapper {
             style.alignment = self.valueAlignment
             
             let downloadStringAttributes = [
-                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .light),
+                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .bold),
                 NSAttributedString.Key.foregroundColor: self.downloadColor(self.valueColorState),
                 NSAttributedString.Key.paragraphStyle: style
             ]
             let uploadStringAttributes = [
-                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .light),
+				NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .bold),
                 NSAttributedString.Key.foregroundColor: self.uploadColor(self.valueColorState),
                 NSAttributedString.Key.paragraphStyle: style
             ]
@@ -440,7 +440,7 @@ public class SpeedWidget: WidgetWrapper {
         
         if self.symbols.count > 1 {
             let downloadAttributes = [
-                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .regular),
+                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .medium),
                 NSAttributedString.Key.foregroundColor: self.downloadColor(self.iconColorState),
                 NSAttributedString.Key.paragraphStyle: NSMutableParagraphStyle()
             ]
@@ -451,7 +451,7 @@ public class SpeedWidget: WidgetWrapper {
         
         if !self.symbols.isEmpty {
             let uploadAttributes = [
-                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .regular),
+                NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9, weight: .medium),
                 NSAttributedString.Key.foregroundColor: self.uploadColor(self.iconColorState),
                 NSAttributedString.Key.paragraphStyle: NSMutableParagraphStyle()
             ]


### PR DESCRIPTION
- bolder text for speed module menu bar item

I guess this asks questions
- whether the same changes should be applied to all modules
-  if it should be an option

Given that it changes existing visual look and feel, perhaps a "bolder text" option could work? then each use of NSFont.Weight would need a ternary conditional and pick between two different weights. Up to you, to be discussed.

This small changes is all I needed for my local copy as I only use the speed module.

## Before
![Screen shot 2024-10-07 at 15 53 55](https://github.com/user-attachments/assets/f4ef97fe-4e4a-4ae1-a011-6c8efb41376a)


## After
![Screen shot 2024-10-07 at 15 53 31](https://github.com/user-attachments/assets/42bacd0b-a5df-4679-80db-39afd40bd837)

The 0.0 and 0.0 is iStats Menu "Font = Bold" for comparison sake.

And here's standard Stats versus iStat Menus "Font = Regular", Stats is still lighter.

![Screen shot 2024-10-07 at 15 56 32](https://github.com/user-attachments/assets/fc369c79-38be-4bb9-85ca-eec54c107df9)

In addition, the exact size and alignment of the text could be improved to minimise aliasing and increase legibility.

## Fixes
- #479 
