### PR TITLE
lang: update Taiwan Traditional Chinese localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -313,10 +313,10 @@
 "Read color" = "讀取色彩";
 "Write color" = "寫入色彩";
 "Disk usage" = "磁碟使用量";
-"Total read" = "總讀取量";
-"Total written" = "總寫入量";
-"Write speed" = "Write";
-"Read speed" = "Read";
+"Total read" = "總讀取";
+"Total written" = "總寫入";
+"Write speed" = "寫入";
+"Read speed" = "讀取";
 
 // Sensors
 "Temperature unit" = "溫度單位";
@@ -379,8 +379,8 @@
 "Network activity" = "網路活動";
 "Last reset" = "上次重置於 %0 前";
 "Latency" = "延遲";
-"Upload speed" = "Upload";
-"Download speed" = "Download";
+"Upload speed" = "上傳";
+"Download speed" = "下載";
 
 // Battery
 "Level" = "電量";
@@ -428,8 +428,8 @@
 // Clock
 "Time zone" = "時區";
 "Local" = "目前位置";
-"Calendar" = "Calendar";
-"Local time" = "Local time";
+"Calendar" = "日曆";
+"Local time" = "當地時間";
 
 // Colors
 "Based on utilization" = "根據使用率";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2198](https://github.com/exelban/stats/pull/2198)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “寫入” for `Write speed`
2. “讀取” for `Read speed`
3. “上傳” for `Upload speed`
4. “下載” for `Download speed`
5. “日曆” for `Calendar`
6. “當地時間” for `Local time`

- **Optimize translating quality.
最佳化正體中文（臺灣）的翻譯品質。**

1. from “總讀取量” to “總讀取” for `Total read`
2. from “總寫入量” to “總寫入” for `Total write`

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2198/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2198.patch
https://github.com/exelban/stats/pull/2198.diff