### PR TITLE
lang: update Taiwan Traditional Chinese localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -83,10 +83,10 @@
 "10 minutes" = "10 分鐘";
 "Import" = "匯入";
 "Export" = "匯出";
-"Separator" = "Separator";
-"Read" = "Read";
-"Write" = "Write";
-"Frequency" = "Frequency";
+"Separator" = "分隔符號";
+"Read" = "讀取";
+"Write" = "寫入";
+"Frequency" = "頻率";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -127,7 +127,7 @@
 "Open application settings" = "打開應用程式設定";
 "Open dashboard" = "打開儀表板";
 "No notifications available in this module" = "沒有可用於此模組的通知";
-"Open Calendar" = "Open Calendar";
+"Open Calendar" = "打開「行事曆」";
 
 // Application settings
 "Update application" = "更新應用程式";
@@ -263,7 +263,7 @@
 "User load" = "使用者占用";
 "Efficiency cores load" = "節能核心占用";
 "Performance cores load" = "效能核心占用";
-"All cores" = "All cores";
+"All cores" = "總核心占用";
 
 // GPU
 "GPU to show" = "顯示顯示卡";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into new strings.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2310](https://github.com/exelban/stats/pull/2310)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “分隔符號” for `Separator` in line 86
2. “讀取” for `Read` in line 87
3. “寫入” for `Write` in line 88
4. “頻率” for `Frequency` in line 89
5. “打開「行事曆」” for `Open Calendar` in line 130
6. “總核心占用” for `All cores` in line 266

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2310/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2310.patch
https://github.com/exelban/stats/pull/2310.diff