### PR TITLE
Correct device info for modelid - Mac16,8

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -697,7 +697,7 @@ let deviceDict: [String: model_s] = [
     "Mac16,5": model_s(name: "MacBook Pro 16\" (M4 Max)", year: 2024, type: .macbookPro),
     "Mac16,6": model_s(name: "MacBook Pro 14\" (M4 Max, 16 CPU/40 GPU)", year: 2024, type: .macbookPro),
     "Mac16,7": model_s(name: "MacBook Pro 16\" (M4 Pro, 14 CPU/20 GPU)", year: 2024, type: .macbookPro),
-    "Mac16,8": model_s(name: "MacBook Pro 16\" (M4 Pro)", year: 2024, type: .macbookPro)
+    "Mac16,8": model_s(name: "MacBook Pro 14\" (M4 Pro, 14 CPU/20 GPU)", year: 2024, type: .macbookPro)
 ]
 
 let osDict: [String: String] = [

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -5,6 +5,8 @@
 //  Created by Fredrik Nilsson on 27/07/2022.
 //  Using Swift 5.0.
 //  Running on macOS 12.
+//  Updated and completed by Patrik Persson on 04/01/2024
+//  Running on macOS 15
 //
 //  Copyright © 2020 Serhiy Mytrovtsiy. All rights reserved.
 //
@@ -27,7 +29,7 @@
 "Bluetooth" = "Bluetooth";
 "Open Bluetooth settings" = "Öppna bluetoothinställningar";
 "Clock" = "Clock";
-"Open Clock settings" = "Open clock settings";
+"Open Clock settings" = "Öppna klockinställningar";
 
 // Words
 "Unknown" = "Okänd";
@@ -59,59 +61,57 @@
 "Center alignment" = "Centrerad";
 "Right alignment" = "Höger";
 "Dashboard" = "Kontrollpanel";
-"Enabled" = "Enabled";
+"Enabled" = "Aktiverad";
 "Disabled" = "Inaktiverad";
 "Silent" = "Tyst";
 "Units" = "Enheter";
 "Fans" = "Fläktar";
-"Scaling" = "Scaling";
-"Linear" = "Linear";
-"Square" = "Square";
-"Cube" = "Cube";
-"Logarithmic" = "Logarithmic";
-"Fixed scale" = "Fixed";
-"Cores" = "Cores";
-"Settings" = "Settings";
-"Name" = "Name";
+"Scaling" = "Skalning";
+"Linear" = "Linjär";
+"Square" = "Kvadrat";
+"Cube" = "Kub";
+"Logarithmic" = "Logaritmiskt";
+"Fixed scale" = "Fast skala";
+"Cores" = "Kärnor";
+"Settings" = "Inställningar";
+"Name" = "Namn";
 "Format" = "Format";
-"Turn off" = "Turn off";
-"Warning" = "Warning";
-"Critical" = "Critical";
-"Usage" = "Usage";
-"2 minutes" = "2 minutes";
-"3 minutes" = "3 minutes";
-"10 minutes" = "10 minutes";
-"Import" = "Import";
-"Export" = "Export";
-"Separator" = "Separator";
-"Read" = "Read";
-"Write" = "Write";
-"Frequency" = "Frequency";
+"Turn off" = "Stäng av";
+"Warning" = "Varning";
+"Critical" = "Kritisk";
+"Usage" = "Använding";
+"2 minutes" = "2 minuter";
+"3 minutes" = "3 minuter";
+"10 minutes" = "10 minuter";
+"Import" = "Importera";
+"Export" = "Exportera";
+"Separator" = "Avgränsare";
+"Read" = "Läsa";
+"Write" = "Skriva";
+"Frequency" = "Frekvens";
 
 // Setup
-"Stats Setup" = "Stats Setup";
-"Previous" = "Previous";
-"Previous page" = "Previous page";
-"Next" = "Next";
-"Next page" = "Next page";
-"Finish" = "Finish";
-"Finish setup" = "Finish setup";
-"Welcome to Stats" = "Welcome to Stats";
-"welcome_message" = "Thanks for using Stats, a free open source macOS system monitor for your menu bar.";
-"Start the application automatically when starting your Mac" = "Start the application automatically when starting your Mac";
-"Do not start the application automatically when starting your Mac" = "Do not start the application automatically when starting your Mac";
-"Do everything silently in the background (recommended)" = "Do everything silently in the background (recommended)";
-"Check for a new version on startup" = "Check for a new version on startup";
-"Check for a new version every day (once a day)" = "Check for a new version every day (once a day)";
-"Check for a new version every week (once a week)" = "Check for a new version every week (once a week)";
-"Check for a new version every month (once a month)" = "Check for a new version every month (once a month)";
-"Never check for updates (not recommended)" = "Never check for updates (not recommended)";
-"Anonymous telemetry for better development decisions" = "Anonymous telemetry for better development decisions";
-"Share anonymous telemetry data" = "Share anonymous telemetry data";
-"Do not share anonymous telemetry data" = "Do not share anonymous telemetry data";
-"The configuration is completed" = "The configuration is completed";
-"finish_setup_message" = "Everything is set up! \n The Stats is an open source tool, it's free and always will be. \n If you enjoy it you can support a project, it's always appreciated!";
-
+"Stats Setup" = "Stats inställning";
+"Previous" = "Föregående";
+"Previous page" = "Föregående sida";
+"Next" = "Nästa";
+"Next page" = "Nästa sida";
+"Finish" = "Avsluta";
+"Finish setup" = "Avsluta inställning";
+"Welcome to Stats" = "Välkommen till Stats";
+"welcome_message" = "Tack för att du använder Stats, en gratis öppen källkod macOS-systemövervakare för din menyrad.";
+"Do not start the application automatically when starting your Mac" = "Starta inte applikationen automatiskt när du startar din Mac";
+"Do everything silently in the background (recommended)" = "Gör allt tyst i bakgrunden (rekommenderas)";
+"Check for a new version on startup" = "Kontrollera efter en ny version vid uppstart";
+"Check for a new version every day (once a day)" = "Kontrollera efter en ny version varje dag (en gång om dagen)";
+"Check for a new version every week (once a week)" = "Kontrollera efter en ny version varje vecka (en gång i veckan)";
+"Check for a new version every month (once a month)" = "Kontrollera efter en ny version varje månad (en gång i månaden)";
+"Never check for updates (not recommended)" = "Kontrollera aldrig efter uppdateringar (inte rekommenderat)";
+"Anonymous telemetry for better development decisions" = "Anonym telemetri för bättre utvecklingsbeslut";
+"Share anonymous telemetry data" = "Dela anonym telemetridata";
+"Do not share anonymous telemetry data" = "Dela inte anonym telemetridata";
+"The configuration is completed" = "Konfigurationen är slutförd";
+"finish_setup_message" = "Allt är inställt! \n Stats är ett verktyg med öppen källkod, det är gratis och kommer alltid att vara det. \n Om du gillar det kan du stödja projektet, det uppskattas alltid!";
 // Alerts
 "New version available" = "Ny version tillgänglig";
 "Click to install the new version of Stats" = "Klicka här för att installera en ny version av Stats";
@@ -126,9 +126,8 @@
 "Close application" = "Avsluta Stats";
 "Open application settings" = "Öppna programinställningar";
 "Open dashboard" = "Öppna kontrollpanelen";
-"No notifications available in this module" = "No notifications available in this module";
-"Open Calendar" = "Open Calendar";
-
+"No notifications available in this module" = "Inga notifikationer tillgängliga i denna modul";
+"Open Calendar" = "Öppna Kalender";
 // Application settings
 "Update application" = "Uppdatering tillgänglig";
 "Check for updates" = "Sök efter uppdateringar";
@@ -141,32 +140,31 @@
 "Show icon in dock" = "Visa i Dock";
 "Start at login" = "Öppna vid inloggning";
 "Build number" = "Byggnummer";
-"Import settings" = "Import settings";
-"Export settings" = "Export settings";
+"Import settings" = "Importera inställningar";
+"Export settings" = "Exportera inställningar";
 "Reset settings" = "Återställ inställningar";
-"Pause the Stats" = "Pause the Stats";
-"Resume the Stats" = "Resume the Stats";
-"Combined modules" = "Combined modules";
-"Combined details" = "Combined details";
-"Spacing" = "Spacing";
-"Share anonymous telemetry" = "Share anonymous telemetry";
+"Pause the Stats" = "Pausa Stats";
+"Resume the Stats" = "Återuppta Stats";
+"Combined modules" = "Kombinerade moduler";
+"Combined details" = "Kombinerade detaljer";
+"Spacing" = "Mellanrum";
+"Share anonymous telemetry" = "Dela anonym telemetri";
 
 // Dashboard
 "Serial number" = "Serienummer";
-"Model identifier" = "Model identifier";
-"Production year" = "Production year";
+"Model identifier" = "Modellidentifierare";
+"Production year" = "Tillverkningsår";
 "Uptime" = "Upptid";
 "Number of cores" = "%0 kärnor";
 "Number of threads" = "%0 trådar";
-"Number of e-cores" = "%0 efficiency cores";
-"Number of p-cores" = "%0 performance cores";
+"Number of e-cores" = "%0 effektivitetskärnor";
+"Number of p-cores" = "%0 prestandakärnor";
 
 // Update
 "The latest version of Stats installed" = "Du har den senaste versionen av Stats";
 "Downloading..." = "Hämtar...";
-"Current version: " = "Nuvarande version:  ";
-"Latest version: " = "Senaste version:    ";
-
+"Current version: " = "Nuvarande version: ";
+"Latest version: " = "Senaste version: ";
 // Widgets
 "Color" = "Färg";
 "Label" = "Etikett";
@@ -192,18 +190,18 @@
 "Memory widget" = "Minne";
 "Static width" = "Fast bredd";
 "Tachometer widget" = "Varvräknare";
-"State widget" = "State widget";
+"State widget" = "Statuswidget";
 "Show symbols" = "Visa symboler";
 "Label widget" = "Etikett";
 "Number of reads in the chart" = "Antal avläsningar i diagram";
 "Color of download" = "Färg för skickar";
 "Color of upload" = "Färg för tar emot";
 "Monospaced font" = "Typsnitt med monospace";
-"Reverse order" = "Reverse order";
-"Chart history" = "Chart history";
-"Default color" = "Default";
-"Transparent when no activity" = "Transparent when no activity";
-"Constant color" = "Constant";
+"Reverse order" = "Omvänd ordning";
+"Chart history" = "Diagramhistorik";
+"Default color" = "Standardfärg";
+"Transparent when no activity" = "Genomskinlig vid inaktivitet";
+"Constant color" = "Konstant färg";
 
 // Module Kit
 "Open module settings" = "Öppna modulinställningar";
@@ -222,15 +220,14 @@
 "No available widgets to configure" = "Inga tillgängliga widgetar att konfigurera";
 "No options to configure for the popup in this module" = "Inga alternativ att konfigurera för popup-fönstret i denna modul";
 "Process" = "Process";
-"Kill process" = "Kill process";
-
+"Kill process" = "Avsluta process";
 // Modules
 "Number of top processes" = "Antal topprocesser";
 "Update interval for top processes" = "Uppdateringsintervall topprocesser";
 "Notification level" = "Notisnivå";
 "Chart color" = "Diagramfärg";
-"Main chart scaling" = "Main chart scaling";
-"Scale value" = "Scale value";
+"Main chart scaling" = "Huvuddiagramskalning";
+"Scale value" = "Skalvärde";
 
 // CPU
 "CPU usage" = "CPU-användning";
@@ -243,27 +240,27 @@
 "Show hyper-threading cores" = "Visa hypertrådskärnor";
 "Split the value (System/User)" = "Visa fördelning (System/Användare)";
 "Scheduler limit" = "Gräns för schemaläggare";
-"Speed limit" = "Hatighetsbegränsning";
-"Average load" = "Gnomsnittlig last";
+"Speed limit" = "Hastighetsbegränsning";
+"Average load" = "Genomsnittlig last";
 "1 minute" = "1 minut";
 "5 minutes" = "5 minuter";
 "15 minutes" = "15 minuter";
 "CPU usage threshold" = "Tröskelvärde CPU-användning";
-"CPU usage is" = "CPU-anvädningen är %0";
-"Efficiency cores" = "Efficiency cores";
-"Performance cores" = "Performance cores";
-"System color" = "System color";
-"User color" = "User color";
-"Idle color" = "Idle color";
-"Cluster grouping" = "Cluster grouping";
-"Efficiency cores color" = "Efficiency cores color";
-"Performance cores color" = "Performance cores color";
-"Total load" = "Total load";
-"System load" = "System load";
-"User load" = "User load";
-"Efficiency cores load" = "Efficiency cores load";
-"Performance cores load" = "Performance cores load";
-"All cores" = "All cores";
+"CPU usage is" = "CPU-användningen är %0";
+"Efficiency cores" = "Effektivitetskärnor";
+"Performance cores" = "Prestandakärnor";
+"System color" = "Systemfärg";
+"User color" = "Användarfärg";
+"Idle color" = "Overksamhetsfärg";
+"Cluster grouping" = "Klustergruppering";
+"Efficiency cores color" = "Effektivitetskärnors färg";
+"Performance cores color" = "Prestandakärnors färg";
+"Total load" = "Total belastning";
+"System load" = "Systembelastning";
+"User load" = "Användarbelastning";
+"Efficiency cores load" = "Effektivitetskärnors belastning";
+"Performance cores load" = "Prestandakärnors belastning";
+"All cores" = "Alla kärnor";
 
 // GPU
 "GPU to show" = "GPU att visa";
@@ -273,7 +270,7 @@
 "GPU temperature" = "GPU-temperatur";
 "GPU utilization" = "GPU-användning";
 "Vendor" = "Tillverkare";
-"Model" = "Model";
+"Model" = "Modell";
 "Status" = "Status";
 "Active" = "Aktiv";
 "Non active" = "Inaktiv";
@@ -299,13 +296,13 @@
 "Split the value (App/Wired/Compressed)" = "Visa fördelning (App/Resident/Komprimerat)";
 "RAM utilization threshold" = "Tröskelvärde minnesanvändning";
 "RAM utilization is" = "Minnesanvändning %0";
-"App color" = "App color";
-"Wired color" = "Wired color";
-"Compressed color" = "Compressed color";
-"Free color" = "Free color";
-"Free memory (less than)" = "Free memory (less than)";
-"Swap size" = "Swap size";
-"Free RAM is" = "Free RAM is %0";
+"App color" = "Appfärg";
+"Wired color" = "Resident minnesfärg";
+"Compressed color" = "Komprimerat minnesfärg";
+"Free color" = "Ledigt minnesfärg";
+"Free memory (less than)" = "Ledigt minne (mindre än)";
+"Swap size" = "Växelfilstorlek";
+"Free RAM is" = "Ledigt RAM är %0";
 
 // Disk
 "Show removable disks" = "Visa flyttbara skivor";
@@ -316,13 +313,13 @@
 "Switch view" = "Växla vy";
 "Disk utilization threshold" = "Tröskelvärde skivanvändning";
 "Disk utilization is" = "Skivanvändning %0";
-"Read color" = "Read color";
-"Write color" = "Write color";
-"Disk usage" = "Disk usage";
-"Total read" = "Total read";
-"Total written" = "Total written";
-"Write speed" = "Write";
-"Read speed" = "Read";
+"Read color" = "Läsfärg";
+"Write color" = "Skrivfärg";
+"Disk usage" = "Diskanvändning";
+"Total read" = "Totalt läst";
+"Total written" = "Totalt skrivet";
+"Write speed" = "Skriv";
+"Read speed" = "Läs";
 
 // Sensors
 "Temperature unit" = "Temperaturenhet";
@@ -332,18 +329,18 @@
 "Fan" = "Fläkt";
 "HID sensors" = "HID-sensorer";
 "Synchronize fan's control" = "Synkronisera fläktkontroll";
-"Current" = "Current";
-"Energy" = "Energy";
-"Show unknown sensors" = "Show unknown sensors";
-"Install fan helper" = "Install fan helper";
-"Uninstall fan helper" = "Uninstall fan helper";
-"Fan value" = "Fan value";
-"Turn off fan" = "Turn off fan";
-"You are going to turn off the fan. This is not recommended action that can damage your mac, are you sure you want to do that?" = "You are going to turn off the fan. This is not recommended action that can damage your mac, are you sure you want to do that?";
-"Sensor threshold" = "Sensor threshold";
-"Left fan" = "Left";
-"Right fan" = "Right";
-"Fastest fan" = "Fastest";
+"Current" = "Ström";
+"Energy" = "Energi";
+"Show unknown sensors" = "Visa okända sensorer";
+"Install fan helper" = "Installera fläkthjälpare";
+"Uninstall fan helper" = "Avinstallera fläkthjälpare";
+"Fan value" = "Fläktvärde";
+"Turn off fan" = "Stäng av fläkt";
+"You are going to turn off the fan. This is not recommended action that can damage your mac, are you sure you want to do that?" = "Du håller på att stänga av fläkten. Detta är en inte rekommenderad åtgärd som kan skada din Mac, är du säker på att du vill göra detta?";
+"Sensor threshold" = "Sensortröskel";
+"Left fan" = "Vänster";
+"Right fan" = "Höger";
+"Fastest fan" = "Snabbaste";
 
 // Network
 "Uploading" = "Skickar";
@@ -356,7 +353,7 @@
 "Click to copy public IP address" = "Klicka för att kopiera publik IP-adress";
 "Click to copy local IP address" = "Klicka för att kopiera lokal IP-adress";
 "Click to copy wifi name" = "Klicka för att kopiera wifi-namn";
-"Click to copy mac address" = "Klicka för att kopiera Click to copy MAC-adress";
+"Click to copy mac address" = "Klicka för att kopiera MAC-adress";
 "No connection" = "Ingen anslutning";
 "Network interface" = "Nätverkskort";
 "Total download" = "Totalt mottaget";
@@ -369,24 +366,24 @@
 "Standard" = "Standard";
 "Security" = "Säkerhet";
 "Channel" = "Kanal";
-"Common scale" = "Common scale";
-"Autodetection" = "Autodetection";
-"Widget activation threshold" = "Widget activation threshold";
-"Internet connection" = "Internet connection";
-"Active state color" = "Active state color";
-"Nonactive state color" = "Nonactive state color";
-"Connectivity host (ICMP)" = "Connectivity host (ICMP)";
-"Leave empty to disable the check" = "Leave empty to disable the check";
-"Connectivity history" = "Connectivity history";
-"Auto-refresh public IP address" = "Auto-refresh public IP address";
-"Every hour" = "Every hour";
-"Every 12 hours" = "Every 12 hours";
-"Every 24 hours" = "Every 24 hours";
-"Network activity" = "Network activity";
-"Last reset" = "Last reset %0 ago";
-"Latency" = "Latency";
-"Upload speed" = "Upload";
-"Download speed" = "Download";
+"Common scale" = "Gemensam skala";
+"Autodetection" = "Autodetektering";
+"Widget activation threshold" = "Widgetaktiveringströskel";
+"Internet connection" = "Internetanslutning";
+"Active state color" = "Aktivt tillståndsfärg";
+"Nonactive state color" = "Inaktivt tillståndsfärg";
+"Connectivity host (ICMP)" = "Anslutningsvärd (ICMP)";
+"Leave empty to disable the check" = "Lämna tomt för att inaktivera kontrollen";
+"Connectivity history" = "Anslutningshistorik";
+"Auto-refresh public IP address" = "Uppdatera publik IP-adress automatiskt";
+"Every hour" = "Varje timme";
+"Every 12 hours" = "Var 12:e timme";
+"Every 24 hours" = "Var 24:e timme";
+"Network activity" = "Nätverksaktivitet";
+"Last reset" = "Senaste återställning %0 sedan";
+"Latency" = "Fördröjning";
+"Upload speed" = "Uppladdning";
+"Download speed" = "Nedladdning";
 
 // Battery
 "Level" = "Nivå";
@@ -420,27 +417,27 @@
 "Hide additional information when full" = "Göm detaljer när fulladdat";
 "Last charge" = "Senaste laddning";
 "Capacity" = "Kapacitet";
-"current / maximum / designed" = "current / nuvarande / ursprunglig";
-"Low power mode" = "Low power mode";
-"Percentage inside the icon" = "Percentage inside the icon";
-"Colorize battery" = "Colorize battery";
-"Charging current" = "Charging current";
-"Charging Voltage" = "Charging voltage";
+"current / maximum / designed" = "nuvarande / maximal / ursprunglig";
+"Low power mode" = "Lågeffektläge";
+"Percentage inside the icon" = "Procent inuti ikonen";
+"Colorize battery" = "Färglägg batteri";
+"Charging current" = "Laddningsström";
+"Charging Voltage" = "Laddningsspänning";
 
 // Bluetooth
 "Battery to show" = "Batteri att visa";
 "No Bluetooth devices are available" = "Inga bluetoothenheter tillgängliga";
 
 // Clock
-"Time zone" = "Time zone";
-"Local" = "Local";
-"Calendar" = "Calendar";
-"Local time" = "Local time";
+"Time zone" = "Tidszon";
+"Local" = "Lokal";
+"Calendar" = "Kalender";
+"Local time" = "Lokal tid";
 
 // Colors
 "Based on utilization" = "Baserat på användning";
 "Based on pressure" = "Baserat på tryck";
-"Based on cluster" = "Based on cluster";
+"Based on cluster" = "Baserat på kluster";
 "System accent" = "Systemets accent";
 "Monochrome accent" = "Svartvit accent";
 "Clear" = "Transparent";
@@ -467,5 +464,5 @@
 "Cyan" = "Cyan";
 "Magenta" = "Magenta";
 "Pink" = "Rosa";
-"Teal" = "Teal";
+"Teal" = "Turkos";
 "Indigo" = "Indigo";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -2,11 +2,9 @@
 //  Localizable.strings
 //  Stats
 //
-//  Created by Fredrik Nilsson on 27/07/2022.
+//  Created by Patrik Persson on 04/01/2025.
 //  Using Swift 5.0.
-//  Running on macOS 12.
-//  Updated and completed by Patrik Persson on 04/01/2024
-//  Running on macOS 15
+//  Running on macOS 15.
 //
 //  Copyright © 2020 Serhiy Mytrovtsiy. All rights reserved.
 //
@@ -16,10 +14,10 @@
 "Open CPU settings" = "Öppna CPU-inställningar";
 "GPU" = "GPU";
 "Open GPU settings" = "Öppna GPU-inställningar";
-"RAM" = "Minne";
-"Open RAM settings" = "Öppna minnesinställningar";
-"Disk" = "Skiva";
-"Open Disk settings" = "Öppna skivinställningar";
+"RAM" = "RAM";
+"Open RAM settings" = "Öppna RAM-inställningar";
+"Disk" = "Disk";
+"Open Disk settings" = "Öppna diskinställningar";
 "Sensors" = "Sensorer";
 "Open Sensors settings" = "Öppna sensorinställningar";
 "Network" = "Nätverk";
@@ -27,8 +25,8 @@
 "Battery" = "Batteri";
 "Open Battery settings" = "Öppna batteriinställningar";
 "Bluetooth" = "Bluetooth";
-"Open Bluetooth settings" = "Öppna bluetoothinställningar";
-"Clock" = "Clock";
+"Open Bluetooth settings" = "Öppna Bluetooth-inställningar";
+"Clock" = "Klocka";
 "Open Clock settings" = "Öppna klockinställningar";
 
 // Words
@@ -38,10 +36,10 @@
 "Memory" = "Minne";
 "Graphics" = "Grafik";
 "Close" = "Stäng";
-"Download" = "Hämta";
+"Download" = "Ladda ner";
 "Install" = "Installera";
 "Cancel" = "Avbryt";
-"Unavailable" = "Otillgänglig";
+"Unavailable" = "Ej tillgänglig";
 "Yes" = "Ja";
 "No" = "Nej";
 "Automatic" = "Automatisk";
@@ -60,7 +58,7 @@
 "Left alignment" = "Vänster";
 "Center alignment" = "Centrerad";
 "Right alignment" = "Höger";
-"Dashboard" = "Kontrollpanel";
+"Dashboard" = "Instrumentpanel";
 "Enabled" = "Aktiverad";
 "Disabled" = "Inaktiverad";
 "Silent" = "Tyst";
@@ -68,9 +66,9 @@
 "Fans" = "Fläktar";
 "Scaling" = "Skalning";
 "Linear" = "Linjär";
-"Square" = "Kvadrat";
-"Cube" = "Kub";
-"Logarithmic" = "Logaritmiskt";
+"Square" = "Kvadratisk";
+"Cube" = "Kubisk";
+"Logarithmic" = "Logaritmisk";
 "Fixed scale" = "Fast skala";
 "Cores" = "Kärnor";
 "Settings" = "Inställningar";
@@ -79,66 +77,69 @@
 "Turn off" = "Stäng av";
 "Warning" = "Varning";
 "Critical" = "Kritisk";
-"Usage" = "Använding";
+"Usage" = "Användning";
 "2 minutes" = "2 minuter";
 "3 minutes" = "3 minuter";
 "10 minutes" = "10 minuter";
 "Import" = "Importera";
 "Export" = "Exportera";
 "Separator" = "Avgränsare";
-"Read" = "Läsa";
-"Write" = "Skriva";
+"Read" = "Läs";
+"Write" = "Skriv";
 "Frequency" = "Frekvens";
 
 // Setup
-"Stats Setup" = "Stats inställning";
+"Stats Setup" = "Stats-installation";
 "Previous" = "Föregående";
 "Previous page" = "Föregående sida";
 "Next" = "Nästa";
 "Next page" = "Nästa sida";
 "Finish" = "Avsluta";
-"Finish setup" = "Avsluta inställning";
+"Finish setup" = "Avsluta installationen";
 "Welcome to Stats" = "Välkommen till Stats";
-"welcome_message" = "Tack för att du använder Stats, en gratis öppen källkod macOS-systemövervakare för din menyrad.";
+"welcome_message" = "Tack för att du använder Stats, ett gratis och öppen källkod macOS-systemövervakningsverktyg för din menyrad.";
+"Start the application automatically when starting your Mac" = "Starta applikationen automatiskt när du startar din Mac";
 "Do not start the application automatically when starting your Mac" = "Starta inte applikationen automatiskt när du startar din Mac";
 "Do everything silently in the background (recommended)" = "Gör allt tyst i bakgrunden (rekommenderas)";
 "Check for a new version on startup" = "Kontrollera efter en ny version vid uppstart";
 "Check for a new version every day (once a day)" = "Kontrollera efter en ny version varje dag (en gång om dagen)";
 "Check for a new version every week (once a week)" = "Kontrollera efter en ny version varje vecka (en gång i veckan)";
 "Check for a new version every month (once a month)" = "Kontrollera efter en ny version varje månad (en gång i månaden)";
-"Never check for updates (not recommended)" = "Kontrollera aldrig efter uppdateringar (inte rekommenderat)";
+"Never check for updates (not recommended)" = "Kontrollera aldrig efter uppdateringar (rekommenderas inte)";
 "Anonymous telemetry for better development decisions" = "Anonym telemetri för bättre utvecklingsbeslut";
 "Share anonymous telemetry data" = "Dela anonym telemetridata";
 "Do not share anonymous telemetry data" = "Dela inte anonym telemetridata";
 "The configuration is completed" = "Konfigurationen är slutförd";
 "finish_setup_message" = "Allt är inställt! \n Stats är ett verktyg med öppen källkod, det är gratis och kommer alltid att vara det. \n Om du gillar det kan du stödja projektet, det uppskattas alltid!";
+
 // Alerts
 "New version available" = "Ny version tillgänglig";
-"Click to install the new version of Stats" = "Klicka här för att installera en ny version av Stats";
+"Click to install the new version of Stats" = "Klicka för att installera den nya versionen av Stats";
 "Successfully updated" = "Uppdateringen lyckades";
-"Stats was updated to v" = "Stats uppdaterat till v%0";
-"Reset settings text" = "Alla programinställningar kommer att återställas och programmet starta om. Är du säker?";
+"Stats was updated to v" = "Stats uppdaterades till v%0";
+"Reset settings text" = "Alla programinställningar kommer att återställas och programmet startas om. Är du säker på att du vill göra detta?";
 
 // Settings
-"Open Activity Monitor" = "Öppna Aktivitetskontroll";
+"Open Activity Monitor" = "Öppna Aktivitetsövervakaren";
 "Report a bug" = "Rapportera en bugg";
 "Support the application" = "Stöd Stats";
-"Close application" = "Avsluta Stats";
-"Open application settings" = "Öppna programinställningar";
-"Open dashboard" = "Öppna kontrollpanelen";
+"Close application" = "Stäng applikationen";
+"Open application settings" = "Öppna applikationsinställningar";
+"Open dashboard" = "Öppna instrumentpanelen";
 "No notifications available in this module" = "Inga notifikationer tillgängliga i denna modul";
 "Open Calendar" = "Öppna Kalender";
+
 // Application settings
-"Update application" = "Uppdatering tillgänglig";
+"Update application" = "Uppdatera applikationen";
 "Check for updates" = "Sök efter uppdateringar";
 "At start" = "Vid start";
-"Once per day" = "Dagligen";
-"Once per week" = "Veckovis";
-"Once per month" = "Månadsvis";
+"Once per day" = "En gång per dag";
+"Once per week" = "En gång per vecka";
+"Once per month" = "En gång per månad";
 "Never" = "Aldrig";
 "Check for update" = "Sök efter uppdatering";
-"Show icon in dock" = "Visa i Dock";
-"Start at login" = "Öppna vid inloggning";
+"Show icon in dock" = "Visa ikon i Dock";
+"Start at login" = "Starta vid inloggning";
 "Build number" = "Byggnummer";
 "Import settings" = "Importera inställningar";
 "Export settings" = "Exportera inställningar";
@@ -161,10 +162,11 @@
 "Number of p-cores" = "%0 prestandakärnor";
 
 // Update
-"The latest version of Stats installed" = "Du har den senaste versionen av Stats";
-"Downloading..." = "Hämtar...";
-"Current version: " = "Nuvarande version: ";
-"Latest version: " = "Senaste version: ";
+"The latest version of Stats installed" = "Den senaste versionen av Stats är installerad";
+"Downloading..." = "Laddar ner...";
+"Current version: " = "Nuvarande version:  ";
+"Latest version: " = "Senaste version:    ";
+
 // Widgets
 "Color" = "Färg";
 "Label" = "Etikett";
@@ -173,7 +175,7 @@
 "Value" = "Värde";
 "Colorize" = "Färglägg";
 "Colorize value" = "Färglägg värde";
-"Additional information" = "Mer..";
+"Additional information" = "Mer information";
 "Reverse values order" = "Växla ordning";
 "Base" = "Enhet";
 "Display mode" = "Visningsläge";
@@ -190,13 +192,13 @@
 "Memory widget" = "Minne";
 "Static width" = "Fast bredd";
 "Tachometer widget" = "Varvräknare";
-"State widget" = "Statuswidget";
+"State widget" = "Statwidget";
 "Show symbols" = "Visa symboler";
 "Label widget" = "Etikett";
-"Number of reads in the chart" = "Antal avläsningar i diagram";
-"Color of download" = "Färg för skickar";
-"Color of upload" = "Färg för tar emot";
-"Monospaced font" = "Typsnitt med monospace";
+"Number of reads in the chart" = "Antal avläsningar i diagrammet";
+"Color of download" = "Färg för nedladdning";
+"Color of upload" = "Färg för uppladdning";
+"Monospaced font" = "Monospace-typsnitt";
 "Reverse order" = "Omvänd ordning";
 "Chart history" = "Diagramhistorik";
 "Default color" = "Standardfärg";
@@ -205,7 +207,7 @@
 
 // Module Kit
 "Open module settings" = "Öppna modulinställningar";
-"Select widget" = "Välj %0 widgeten";
+"Select widget" = "Välj %0 widget";
 "Open widget settings" = "Öppna widgetinställningar";
 "Update interval" = "Uppdateringsintervall";
 "Usage history" = "Användningshistorik";
@@ -214,16 +216,17 @@
 "Pictogram" = "Piktogram";
 "Module" = "Modul";
 "Widgets" = "Widgets";
-"Popup" = "Dyka upp";
-"Notifications" = "Aviseringar";
-"Merge widgets" = "Slå samman widgetar";
-"No available widgets to configure" = "Inga tillgängliga widgetar att konfigurera";
+"Popup" = "Popup";
+"Notifications" = "Notifikationer";
+"Merge widgets" = "Slå samman widgets";
+"No available widgets to configure" = "Inga tillgängliga widgets att konfigurera";
 "No options to configure for the popup in this module" = "Inga alternativ att konfigurera för popup-fönstret i denna modul";
 "Process" = "Process";
 "Kill process" = "Avsluta process";
+
 // Modules
 "Number of top processes" = "Antal topprocesser";
-"Update interval for top processes" = "Uppdateringsintervall topprocesser";
+"Update interval for top processes" = "Uppdateringsintervall för topprocesser";
 "Notification level" = "Notisnivå";
 "Chart color" = "Diagramfärg";
 "Main chart scaling" = "Huvuddiagramskalning";
@@ -236,16 +239,16 @@
 "System" = "System";
 "User" = "Användare";
 "Idle" = "Overksam";
-"Show usage per core" = "Visa användande per kärna";
+"Show usage per core" = "Visa användning per kärna";
 "Show hyper-threading cores" = "Visa hypertrådskärnor";
-"Split the value (System/User)" = "Visa fördelning (System/Användare)";
-"Scheduler limit" = "Gräns för schemaläggare";
+"Split the value (System/User)" = "Dela upp värdet (System/Användare)";
+"Scheduler limit" = "Schemaläggargräns";
 "Speed limit" = "Hastighetsbegränsning";
-"Average load" = "Genomsnittlig last";
+"Average load" = "Genomsnittlig belastning";
 "1 minute" = "1 minut";
 "5 minutes" = "5 minuter";
 "15 minutes" = "15 minuter";
-"CPU usage threshold" = "Tröskelvärde CPU-användning";
+"CPU usage threshold" = "Tröskelvärde för CPU-användning";
 "CPU usage is" = "CPU-användningen är %0";
 "Efficiency cores" = "Effektivitetskärnor";
 "Performance cores" = "Prestandakärnor";
@@ -275,12 +278,12 @@
 "Active" = "Aktiv";
 "Non active" = "Inaktiv";
 "Fan speed" = "Fläkthastighet";
-"Core clock" = "Klockfrekvens";
-"Memory clock" = "Minnesklockfrekvens";
+"Core clock" = "Kärnklocka";
+"Memory clock" = "Minnesklocka";
 "Utilization" = "Användning";
 "Render utilization" = "Render-användning";
 "Tiler utilization" = "Tiler-användning";
-"GPU usage threshold" = "Tröskelvärde GPU-användning";
+"GPU usage threshold" = "Tröskelvärde för GPU-användning";
 "GPU usage is" = "GPU-användningen är %0";
 
 // RAM
@@ -292,27 +295,27 @@
 "Wired" = "Resident minne";
 "Compressed" = "Komprimerat";
 "Free" = "Ledigt";
-"Swap" = "Växelfil";
-"Split the value (App/Wired/Compressed)" = "Visa fördelning (App/Resident/Komprimerat)";
-"RAM utilization threshold" = "Tröskelvärde minnesanvändning";
-"RAM utilization is" = "Minnesanvändning %0";
+"Swap" = "Växling";
+"Split the value (App/Wired/Compressed)" = "Dela upp värdet (App/Resident/Komprimerat)";
+"RAM utilization threshold" = "Tröskelvärde för minnesanvändning";
+"RAM utilization is" = "Minnesanvändningen är %0";
 "App color" = "Appfärg";
 "Wired color" = "Resident minnesfärg";
 "Compressed color" = "Komprimerat minnesfärg";
 "Free color" = "Ledigt minnesfärg";
 "Free memory (less than)" = "Ledigt minne (mindre än)";
-"Swap size" = "Växelfilstorlek";
+"Swap size" = "Växlingsstorlek";
 "Free RAM is" = "Ledigt RAM är %0";
 
 // Disk
-"Show removable disks" = "Visa flyttbara skivor";
+"Show removable disks" = "Visa flyttbara diskar";
 "Used disk memory" = "%0 av %1 används";
 "Free disk memory" = "%0 av %1 ledigt";
-"Disk to show" = "Skiva att visa";
-"Open disk" = "Öppna skiva";
+"Disk to show" = "Disk att visa";
+"Open disk" = "Öppna disk";
 "Switch view" = "Växla vy";
-"Disk utilization threshold" = "Tröskelvärde skivanvändning";
-"Disk utilization is" = "Skivanvändning %0";
+"Disk utilization threshold" = "Tröskelvärde för diskanvändning";
+"Disk utilization is" = "Diskanvändningen är %0";
 "Read color" = "Läsfärg";
 "Write color" = "Skrivfärg";
 "Disk usage" = "Diskanvändning";
@@ -343,25 +346,25 @@
 "Fastest fan" = "Snabbaste";
 
 // Network
-"Uploading" = "Skickar";
-"Downloading" = "Tar emot";
+"Uploading" = "Uppladdning";
+"Downloading" = "Nedladdning";
 "Public IP" = "Publik IP";
 "Local IP" = "Lokal IP";
 "Interface" = "Gränssnitt";
-"Physical address" = "MAC-adress";
+"Physical address" = "Fysisk adress";
 "Refresh" = "Uppdatera";
 "Click to copy public IP address" = "Klicka för att kopiera publik IP-adress";
 "Click to copy local IP address" = "Klicka för att kopiera lokal IP-adress";
 "Click to copy wifi name" = "Klicka för att kopiera wifi-namn";
 "Click to copy mac address" = "Klicka för att kopiera MAC-adress";
 "No connection" = "Ingen anslutning";
-"Network interface" = "Nätverkskort";
-"Total download" = "Totalt mottaget";
-"Total upload" = "Totalt skickat";
+"Network interface" = "Nätverksgränssnitt";
+"Total download" = "Totalt nedladdat";
+"Total upload" = "Totalt uppladdat";
 "Reader type" = "Läsartyp";
-"Interface based" = "Gränssnitt";
-"Processes based" = "Process";
-"Reset data usage" = "Nollställ användningshistorik";
+"Interface based" = "Gränssnittsbaserad";
+"Processes based" = "Processbaserad";
+"Reset data usage" = "Återställ dataanvändning";
 "VPN mode" = "VPN-läge";
 "Standard" = "Standard";
 "Security" = "Säkerhet";
@@ -387,34 +390,34 @@
 
 // Battery
 "Level" = "Nivå";
-"Source" = "Strömkälla";
-"AC Power" = "Strömadapter";
+"Source" = "Källa";
+"AC Power" = "Nätström";
 "Battery Power" = "Batteri";
 "Time" = "Tid";
 "Health" = "Hälsa";
-"Amperage" = "Ström";
+"Amperage" = "Strömstyrka";
 "Voltage" = "Spänning";
-"Cycles" = "Cykler";
+"Cycles" = "Cyklar";
 "Temperature" = "Temperatur";
 "Power adapter" = "Strömadapter";
 "Power" = "Effekt";
 "Is charging" = "Laddar";
-"Time to discharge" = "Tid till urladdat";
-"Time to charge" = "Tid till fulladdat";
+"Time to discharge" = "Tid till urladdning";
+"Time to charge" = "Tid till fulladdning";
 "Calculating" = "Beräknar";
-"Fully charged" = "Fulladdat";
+"Fully charged" = "Fulladdad";
 "Not connected" = "Ej ansluten";
-"Low level notification" = "Notis för låg nivå";
-"High level notification" = "Notis för hög nivå";
-"Low battery" = "Låg batterinivå";
-"High battery" = "Hög batterinivå";
-"Battery remaining" = "%0% återstår";
-"Battery remaining to full charge" = "%0% till fulladdat";
+"Low level notification" = "Låg nivånotis";
+"High level notification" = "Hög nivånotis";
+"Low battery" = "Lågt batteri";
+"High battery" = "Högt batteri";
+"Battery remaining" = "%0% kvar";
+"Battery remaining to full charge" = "%0% till fulladdning";
 "Percentage" = "Procent";
 "Percentage and time" = "Procent och tid";
 "Time and percentage" = "Tid och procent";
-"Time format" = "Tidformat";
-"Hide additional information when full" = "Göm detaljer när fulladdat";
+"Time format" = "Tidsformat";
+"Hide additional information when full" = "Dölj extra information när fulladdad";
 "Last charge" = "Senaste laddning";
 "Capacity" = "Kapacitet";
 "current / maximum / designed" = "nuvarande / maximal / ursprunglig";
@@ -426,7 +429,7 @@
 
 // Bluetooth
 "Battery to show" = "Batteri att visa";
-"No Bluetooth devices are available" = "Inga bluetoothenheter tillgängliga";
+"No Bluetooth devices are available" = "Inga Bluetooth-enheter tillgängliga";
 
 // Clock
 "Time zone" = "Tidszon";
@@ -440,7 +443,7 @@
 "Based on cluster" = "Baserat på kluster";
 "System accent" = "Systemets accent";
 "Monochrome accent" = "Svartvit accent";
-"Clear" = "Transparent";
+"Clear" = "Genomskinlig";
 "White" = "Vit";
 "Black" = "Svart";
 "Gray" = "Grå";


### PR DESCRIPTION
Fixed so modelid - Mac16,8 shows the correct model. 

https://appledb.dev/device/MacBook-Pro-(14-inch,-Nov-2024).html