### PR TITLE
fix: added several missing localization strings

### DIFF
--- a/Modules/Disk/popup.swift
+++ b/Modules/Disk/popup.swift
@@ -39,7 +39,7 @@ internal class Popup: PopupWrapper {
     private var processes: ProcessesView? = nil
     private var processesView: NSView? = nil
     
-    private let settingsSection = PreferencesSection(label: "Drives")
+    private let settingsSection = PreferencesSection(label: localizedString("Drives"))
     private var lastList: [String] = []
     
     public init(_ module: ModuleType) {

--- a/Modules/Sensors/notifications.swift
+++ b/Modules/Sensors/notifications.swift
@@ -60,7 +60,7 @@ class Notifications: NotificationsWrapper {
                 }
             }
             
-            let section = PreferencesSection(label: typ.rawValue)
+            let section = PreferencesSection(label: localizedString(typ.rawValue))
             groups.forEach { (group: SensorGroup) in
                 filtered.filter{ $0.group == group }.forEach { (s: Sensor_p) in
                     let btn = selectView(

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -136,7 +136,7 @@ internal class Popup: PopupWrapper {
             }
             
             if !reload {
-                let section = PreferencesSection(label: typ.rawValue)
+                let section = PreferencesSection(label: localizedString(typ.rawValue))
                 section.identifier = NSUserInterfaceItemIdentifier("sensor")
                 groups.forEach { (group: SensorGroup) in
                     filtered.filter{ $0.group == group }.forEach { (s: Sensor_p) in

--- a/Modules/Sensors/settings.swift
+++ b/Modules/Sensors/settings.swift
@@ -120,7 +120,7 @@ internal class Settings: NSStackView, Settings_v {
         
         var buttonList: [KeyValue_t] = []
         types.forEach { (typ: SensorType) in
-            let section = PreferencesSection(label: typ.rawValue)
+            let section = PreferencesSection(label: localizedString(typ.rawValue))
             section.identifier = NSUserInterfaceItemIdentifier("sensor")
             
             let filtered = sensors.filter{ $0.type == typ }

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "إجمالي الكتابة";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "وحدة الحرارة";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Температурна единица";

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total escrit";
 "Write speed" = "Velocitat de escriptura";
 "Read speed" = "Velocitat de lectura";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unitat de temperatura";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Jednotka teploty";

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperaturenhed";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Insgesamt geschrieben";
 "Write speed" = "Schreiben";
 "Read speed" = "Lesen";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperatureinheit";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Μονάδα θερμοκρασίας";

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperature unit";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperature unit";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperature unit";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total escrito";
 "Write speed" = "Velocidad de escritura";
 "Read speed" = "Velocidad de lectura";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unidad de temperatura";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperatuuri ühik";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "واحد دما";

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Kirjoitettu yhteensä";
 "Write speed" = "Kirjoitusnopeus";
 "Read speed" = "Lukunopeus";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Lämpötilan yksikkö";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Écritures totales";
 "Write speed" = "Écritures";
 "Read speed" = "Lectures";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unité de température";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "יחידת טמפרטורה";

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "तापमान इकाई";

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Jedinica temperature";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Hőmérséklet mértékegysége";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unit suhu";

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Totale scritto";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unità di temperatura";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "温度単位";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "온도 단위";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperaturenhet";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperatuureenheid";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Całkowity zapis";
 "Write speed" = "Zapis";
 "Read speed" = "Odczyt";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Jednostka temperatury";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total escrito";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unidade de temperatura";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Unidade de temperatura";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperatura unității";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Всего записано";
 "Write speed" = "Запись";
 "Read speed" = "Чтение";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Единица измерения температуры";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Jednotka teploty";

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Skupaj zapisano";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Enota za temperaturo";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Totalt skrivet";
 "Write speed" = "Skriv";
 "Read speed" = "Läs";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Temperaturenhet";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Total written";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "หน่วยอุณหภูมิ";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Toplam yazma";
 "Write speed" = "Write";
 "Read speed" = "Read";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Sıcaklık birimi";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Всього записано";
 "Write speed" = "Запис";
 "Read speed" = "Зчитування";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Одиниця виміру температури";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "Tổng dữ liệu ghi";
 "Write speed" = "Tốc độ ghi";
 "Read speed" = "Tốc độ đọc";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "Đơn vị nhiệt độ";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "总写入量";
 "Write speed" = "写入速度";
 "Read speed" = "读取速度";
+"Drives" = "驱动器";
 
 // Sensors
 "Temperature unit" = "温度单位";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -323,6 +323,7 @@
 "Total written" = "總寫入";
 "Write speed" = "寫入";
 "Read speed" = "讀取";
+"Drives" = "Drives";
 
 // Sensors
 "Temperature unit" = "溫度單位";


### PR DESCRIPTION
I've added several missing localization strings, which are section labels in the settings of Disk and Sensors widgets