### PR TITLE
lang: fix Korean translation

### DIFF
--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "Fan" = "팬";
 "HID sensors" = "HID 센서";
 "Synchronize fan's control" = "팬 제어 동기화";
-"Current" = "현재";
+"Current" = "전류";
 "Energy" = "에너지";
 "Show unknown sensors" = "알 수 없는 센서 표시";
 "Install fan helper" = "팬 헬퍼 설치";


### PR DESCRIPTION
Fix wrong Korea translation for "current".

"Current" has two meanings: "(1) magnitude of electric flow" and "(2) now in time".
The term "Current" is used "Sensors" section, following "Voltage" in this application.
But, the Korean traslation "현재" is the Korean word for "(2) now in time".
I fixed this to the Korean word for "(1) magnitude of electric flow", "전류".

<img width="274" alt="image" src="https://github.com/user-attachments/assets/6a58c11b-b635-48df-8f06-df5c2b7ad3cb" />
