### PR TITLE
lang: added seconds translation without breaking interval settings

### DIFF
--- a/Modules/CPU/settings.swift
+++ b/Modules/CPU/settings.swift
@@ -128,19 +128,17 @@ internal class Settings: NSStackView, Settings_v {
     }
     
     @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateInterval", value: value)
-            self.setInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateInterval", value: value)
+        self.setInterval(value)
     }
     
     @objc private func changeUpdateTopInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateTopIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateTopInterval", value: value)
-            self.setTopInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateTopIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateTopInterval", value: value)
+        self.setTopInterval(value)
     }
     
     @objc private func changeNumberOfProcesses(_ sender: NSMenuItem) {

--- a/Modules/Disk/settings.swift
+++ b/Modules/Disk/settings.swift
@@ -137,9 +137,8 @@ internal class Settings: NSStackView, Settings_v {
         self.callback()
     }
     @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.setUpdateInterval(value: value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.setUpdateInterval(value: value)
     }
     public func setUpdateInterval(value: Int) {
         self.updateIntervalValue = value

--- a/Modules/GPU/settings.swift
+++ b/Modules/GPU/settings.swift
@@ -108,11 +108,10 @@ internal class Settings: NSStackView, Settings_v {
     }
     
     @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateInterval", value: value)
-            self.setInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateInterval", value: value)
+        self.setInterval(value)
     }
     @objc private func handleSelection(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }

--- a/Modules/RAM/settings.swift
+++ b/Modules/RAM/settings.swift
@@ -139,18 +139,16 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     }
     
     @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateInterval", value: value)
-            self.setInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateInterval", value: value)
+        self.setInterval(value)
     }
     @objc private func changeUpdateTopInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateTopIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateTopInterval", value: value)
-            self.setTopInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateTopIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateTopInterval", value: value)
+        self.setTopInterval(value)
     }
     @objc private func changeNumberOfProcesses(_ sender: NSMenuItem) {
         if let value = Int(sender.title) {

--- a/Modules/Sensors/settings.swift
+++ b/Modules/Sensors/settings.swift
@@ -169,11 +169,10 @@ internal class Settings: NSStackView, Settings_v {
         self.callback()
     }
     @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
-        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
-            self.updateIntervalValue = value
-            Store.shared.set(key: "\(self.title)_updateInterval", value: value)
-            self.setInterval(value)
-        }
+        guard let key = sender.representedObject as? String, let value = Int(key) else { return }
+        self.updateIntervalValue = value
+        Store.shared.set(key: "\(self.title)_updateInterval", value: value)
+        self.setInterval(value)
     }
     @objc private func toggleSpeedState(_ sender: NSControl) {
         self.fanSpeedState = controlState(sender)

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "إعدادات الإحصاءات";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Настройки на Stats";

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configuració de Stats";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Nastavení Stats";

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats opsætning";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats einrichten";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Εγκατάσταση Stats";

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configuración de Stats";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Seadistamine";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "نصب Stats";

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats asennus";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configuration de Stats";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "आँकड़े सेटअप";

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Postavljanje programa Stats";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "A Stats beállítása";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configurazione Stats";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats セットアップ";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats 설정";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats-oppsett";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Uruchomić";
 "Stop" = "Zatrzymać";
 "Uninstall" = "Odinstalować";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Konfiguracja Stats";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configurar Stats";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Configurações do Stats";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Setup";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Запустить";
 "Stop" = "Остановить";
 "Uninstall" = "Удалить";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Настройки Stats";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Nastavenie Stats";

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats konfigurator";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats-installation";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "การตั้งค่าสถิติ";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats Kurulumu";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Запустити";
 "Stop" = "Зупинити";
 "Uninstall" = "Видалити";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Налаштування";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Thiết lập Stats";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "运行";
 "Stop" = "停止";
 "Uninstall" = "卸载";
+"1 sec" = "1 秒";
+"2 sec" = "2 秒";
+"3 sec" = "3 秒";
+"5 sec" = "5 秒";
+"10 sec" = "10 秒";
+"15 sec" = "15 秒";
+"30 sec" = "30 秒";
+"60 sec" = "60 秒";
 
 // Setup
 "Stats Setup" = "Stats 设置";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -92,6 +92,14 @@
 "Run" = "Run";
 "Stop" = "Stop";
 "Uninstall" = "Uninstall";
+"1 sec" = "1 sec";
+"2 sec" = "2 sec";
+"3 sec" = "3 sec";
+"5 sec" = "5 sec";
+"10 sec" = "10 sec";
+"15 sec" = "15 sec";
+"30 sec" = "30 sec";
+"60 sec" = "60 sec";
 
 // Setup
 "Stats Setup" = "Stats 設定";


### PR DESCRIPTION
This PR adds seconds translation and avoids breaking interval settings(#2407) by updating setting with the key of item instead of the value. It seems to work on my machine.
Please check if the changes I made are correct.