### PR TITLE
Broken line breaks and missing whitespace in french wording

### DIFF
--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Successfully updated" = "Mise à jour effectuée avec succès";
 "Stats was updated to v" = "Stats a été mis à jour en version %0";
 "Reset settings text" = "Tous les paramètres de l'application seront réinitialisés et l'application redémarrera. Êtes-vous sûr de vouloir continuer ?";
-"Support text" = "Merci d'utiliser Stats!\NLa maintenance et l'amélioration de ce projet open-source nécessitent du temps et des ressources. Votre soutien nous aide à continuer à fournir une application gratuite et fiable pour tout le monde.\NSi vous trouvez Stats utile, veuillez envisager de faire une contribution. Chaque petit geste compte!";
+"Support text" = "Merci d'utiliser Stats!\nLa maintenance et l'amélioration de ce projet open-source nécessitent du temps et des ressources. Votre soutien nous aide à continuer à fournir une application gratuite et fiable pour tout le monde.\nSi vous trouvez Stats utile, veuillez envisager de faire une contribution. Chaque petit geste compte !";
 
 // Settings
 "Open Activity Monitor" = "Ouvrir le Moniteur d'activité";


### PR DESCRIPTION
This pull request brings a fix on french wording (key *Support text*) for the sponshorship popup.
Line breaks have been fixed and a whitespace has been added.

Closes #2414