### PR TITLE
Electrical current is translated as "Strom" in German.

### DIFF
--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -348,7 +348,7 @@
 "Fan" = "Lüfter";
 "HID sensors" = "HID Sensoren";
 "Synchronize fan's control" = "Lüfter synchronisieren";
-"Current" = "Aktuell";
+"Current" = "Strom";
 "Energy" = "Energie";
 "Show unknown sensors" = "Unbekannte Sensoren anzeigen";
 "Install fan helper" = "Lüftersteuerung installieren";


### PR DESCRIPTION
The pull request just fixes the translation of one word in the sensor drop-down.