### PR TITLE
fix: add missing NetworkChart restoreGState & correct CombinedView separators

### DIFF
--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -205,6 +205,7 @@ public class NetworkChart: WidgetWrapper {
         bottomLinePath.lineWidth = lineWidth
         bottomLinePath.stroke()
         
+        context.restoreGState()
         context.saveGState()
         
         var underLinePath = topLinePath.copy() as! NSBezierPath

--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -120,7 +120,7 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
             w += m.menuBar.view.frame.width + self.spacing
             i += 1
             
-            if self.separator && i < self.activeModules.count {
+            if self.separator && i < 2 * self.activeModules.count - 1 {
                 let separator = NSView(frame: NSRect(x: w, y: 3, width: 1, height: Constants.Widget.height-6))
                 separator.wantsLayer = true
                 separator.layer?.backgroundColor = (separator.isDarkMode ? NSColor.black : NSColor.white).cgColor


### PR DESCRIPTION
Two very simple changes that fix the annoying issue of missing components on non-focused displays.

- Adding the missing `context.restoreGState()` in `NetworkChart` (fixes #2200)
- Correct separator drawing in `CombinedView` (fixes a wrong end condition on variable `i`)