### PR TITLE
lang: update Taiwan Traditional Chinese Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -88,18 +88,18 @@
 "Read" = "讀取";
 "Write" = "寫入";
 "Frequency" = "頻率";
-"Save" = "Save";
-"Run" = "Run";
-"Stop" = "Stop";
-"Uninstall" = "Uninstall";
-"1 sec" = "1 sec";
-"2 sec" = "2 sec";
-"3 sec" = "3 sec";
-"5 sec" = "5 sec";
-"10 sec" = "10 sec";
-"15 sec" = "15 sec";
-"30 sec" = "30 sec";
-"60 sec" = "60 sec";
+"Save" = "儲存";
+"Run" = "執行";
+"Stop" = "停止";
+"Uninstall" = "解除安裝";
+"1 sec" = "1 秒";
+"2 sec" = "2 秒";
+"3 sec" = "3 秒";
+"5 sec" = "5 秒";
+"10 sec" = "10 秒";
+"15 sec" = "15 秒";
+"30 sec" = "30 秒";
+"60 sec" = "60 秒";
 
 // Setup
 "Stats Setup" = "Stats 設定";
@@ -165,8 +165,8 @@
 "Combined details" = "合併詳細資訊";
 "Spacing" = "間距";
 "Share anonymous telemetry" = "分享匿名診斷資料";
-"Choose file" = "Choose file";
-"Stress tests" = "Stress tests";
+"Choose file" = "選擇檔案";
+"Stress tests" = "壓力測試";
 
 // Dashboard
 "Serial number" = "序號";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into a new string.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2465](https://github.com/exelban/stats/pull/2465)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “儲存” for `Save` in line 91
2. “執行” for `Run` in line 92
3. “停止” for `Stop` in line 93
4. “解除安裝” for `Uninstall` in line 94
5. “1 秒” for `1 sec` in line 95
6. “2 秒” for `2 sec` in line 96
7. “3 秒” for `3 sec` in line 97
8. “5 秒” for `5 sec` in line 98
9. “10 秒” for `10 sec` in line 99
10. “15 秒” for `15 sec` in line 100
11. “30 秒” for `30 secs` in line 101
12. “60 秒” for `60 sec` in line 102
13. “選擇檔案” for `Choose file` in line 168
14. “壓力測試” for `Stress tests` in line 169

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2465/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2465.patch
https://github.com/exelban/stats/pull/2465.diff