### PR TITLE
fix: correctly identify iMac 12,1 and 12,2

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -608,7 +608,8 @@ let deviceDict: [String: model_s] = [
     "Mac14,8": model_s(name: "Mac Pro (M2 Ultra)", year: 2023, type: .macPro),
     
     // iMac
-    "iMac12,1": model_s(name: "iMac 27-Inch", year: 2011, type: .iMac),
+    "iMac12,1": model_s(name: "iMac 21.5-Inch", year: 2011, type: .iMac),
+    "iMac12,2": model_s(name: "iMac 27-Inch", year: 2011, type: .iMac),
     "iMac13,1": model_s(name: "iMac 21.5-Inch", year: 2012, type: .iMac),
     "iMac13,2": model_s(name: "iMac 27-Inch", year: 2012, type: .iMac),
     "iMac14,2": model_s(name: "iMac 27-Inch", year: 2013, type: .iMac),


### PR DESCRIPTION
Stats incorrectly identifies my 21.5" Mid-2011 iMac as a 27" model. This is due to a misconfiguration in `SystemKit.swift` which this PR addresses, as well as correctly identifying the actual 27" model.

Before:
![Screenshot 2025-06-06 at 14 10 40](https://github.com/user-attachments/assets/ef30cb58-2bbd-4e27-93d4-35eb4f13200f)

After:
![Screenshot 2025-06-06 at 14 23 59](https://github.com/user-attachments/assets/ef2ba22b-9d4a-4fa6-a84b-943e919cc07b)
