### PR TITLE
fix: installation instructions via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This will download a file called `Stats.dmg`. Open it and move the app to the ap
 ### Homebrew
 To install it using Homebrew, open the Terminal app and type:
 ```bash
-brew install stats
+brew install --cask stats
 ```
 
 ### Legacy version


### PR DESCRIPTION
This is the recommended way to install Casks in Homebrew, as noted [here](https://formulae.brew.sh/cask/stats#default).