### PR TITLE
Feat: show single row with percentage when time is not available in battery widget

### DIFF
--- a/Kit/Widgets/Battery.swift
+++ b/Kit/Widgets/Battery.swift
@@ -537,21 +537,29 @@ public class BatteryDetailsWidget: WidgetWrapper {
             if let percentage = self.percentage {
                 value = "\(Int((percentage.rounded(toPlaces: 2)) * 100))%"
             }
-            width = self.drawTwoRows(
-                first: value,
-                second: Double(self.time*60).printSecondsToHoursMinutesSeconds(short: isShortTimeFormat),
-                x: x
-            ).rounded(.up)
+            if self.time > 0 {
+                width = self.drawTwoRows(
+                    first: value,
+                    second: Double(self.time*60).printSecondsToHoursMinutesSeconds(short: isShortTimeFormat),
+                    x: x
+                ).rounded(.up)
+            } else {
+                width = self.drawOneRow(value: value, x: x).rounded(.up)
+            }
         case "timeAndPercentage":
             var value = "n/a"
             if let percentage = self.percentage {
                 value = "\(Int((percentage.rounded(toPlaces: 2)) * 100))%"
             }
-            width = self.drawTwoRows(
-                first: Double(self.time*60).printSecondsToHoursMinutesSeconds(short: isShortTimeFormat),
-                second: value,
-                x: x
-            ).rounded(.up)
+            if self.time > 0 {
+                width = self.drawTwoRows(
+                    first: Double(self.time*60).printSecondsToHoursMinutesSeconds(short: isShortTimeFormat),
+                    second: value,
+                    x: x
+                ).rounded(.up)
+            } else {
+                width = self.drawOneRow(value: value, x: x).rounded(.up)
+            }
         default: break
         }
         


### PR DESCRIPTION
Hi! This very well could be my first commit to an open source project. It may not be much, but here it is. Just a simple fix/feature, that instead of showing "n/a" for the battery menu bar when on AC power, it instead switches to show percentage only.

- Modified battery widget to show only percentage in a single row when time remaining is not available (e.g., when AC adapter is plugged in)
- Maintains two-row display with both percentage and time when running on battery with valid time information
- Improves UI by removing duplicate information and making better use of space

Tested it out, looks to be working.

On A/C power (while charging), does NOT show "n/a" anymore. Instead, only shows percentage in a single row.
<img width="178" height="79" alt="on_ac" src="https://github.com/user-attachments/assets/dd72390b-b916-4e3b-b6c1-71ffd422be54" />

Shows time correctly when on battery (unchanged)
<img width="158" height="75" alt="on_battery" src="https://github.com/user-attachments/assets/997efa19-6ad2-4083-86a7-e10f5bfde69e" />

