### PR TITLE
feat: Add Ports module for monitoring active network ports

### DIFF
--- a/Kit/constants.swift
+++ b/Kit/constants.swift
@@ -66,6 +66,7 @@ public enum ModuleType: Int {
     case battery
     case bluetooth
     case clock
+    case Ports
     
     case combined
     
@@ -80,6 +81,7 @@ public enum ModuleType: Int {
         case .battery: return "Battery"
         case .bluetooth: return "Bluetooth"
         case .clock: return "Clock"
+        case .Ports: return "Ports"
         case .combined: return ""
         }
     }

--- a/Modules/Ports/Info.plist
+++ b/Modules/Ports/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025 Serhiy Mytrovtsiy. All rights reserved.</string>
+</dict>
+</plist>

--- a/Modules/Ports/config.plist
+++ b/Modules/Ports/config.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Name</key>
+	<string>Ports</string>
+	<key>State</key>
+	<true/>
+	<key>Symbol</key>
+	<string>network</string>
+	<key>Widgets</key>
+	<dict>
+		<key>mini</key>
+		<dict>
+			<key>Default</key>
+			<true/>
+			<key>Order</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>Settings</key>
+	<dict>
+		<key>popup</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Modules/Ports/main.swift
+++ b/Modules/Ports/main.swift
@@ -1,0 +1,45 @@
+//
+//  main.swift
+//  Ports
+//
+//  Created by Dogukan Akin on 05/10/2025.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2025 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+import Cocoa
+import Kit
+
+public class Ports: Module {
+    private let popupView: Popup
+    private let settingsView: Settings
+    
+    private var portsReader: PortsReader? = nil
+    
+    public init() {
+        self.settingsView = Settings(.Ports)
+        self.popupView = Popup(.Ports)
+        
+        super.init(
+            moduleType: .Ports,
+            popup: self.popupView,
+            settings: self.settingsView
+        )
+        guard self.available else { return }
+        
+        self.settingsView.setInterval = { [weak self] value in
+            self?.portsReader?.setInterval(value)
+        }
+        
+        self.portsReader = PortsReader(.Ports) { [weak self] value in
+            if let ports = value {
+                self?.popupView.portsCallback(ports)
+            }
+        }
+        
+        self.popupView.setReader(self.portsReader!)
+        self.setReaders([self.portsReader])
+    }
+}

--- a/Modules/Ports/popup.swift
+++ b/Modules/Ports/popup.swift
@@ -1,0 +1,218 @@
+//
+//  popup.swift
+//  Ports
+//
+//  Created by Dogukan Akin on 05/10/2025.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2025 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+import Cocoa
+import Kit
+
+internal class Popup: PopupWrapper {
+    private var tableView: NSTableView?
+    private var scrollView: NSScrollView?
+    private var ports: [PortInfo] = []
+    private var reader: PortsReader?
+    
+    private let headerHeight: CGFloat = 50
+    private let rowHeight: CGFloat = 30
+    private let maxVisibleRows: Int = 15
+    
+    public init(_ module: ModuleType) {
+        super.init(module, frame: NSRect(
+            x: 0,
+            y: 0,
+            width: Constants.Popup.width + 100,
+            height: 400
+        ))
+        
+        self.addSubview(self.initContent())
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func initContent() -> NSView {
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height))
+        
+        // Header
+        let headerView = NSView(frame: NSRect(x: 0, y: self.frame.height - headerHeight, width: self.frame.width, height: headerHeight))
+        
+        let titleLabel = NSTextField(frame: NSRect(x: 15, y: 20, width: 200, height: 20))
+        titleLabel.stringValue = localizedString("Active Ports")
+        titleLabel.isEditable = false
+        titleLabel.isBordered = false
+        titleLabel.drawsBackground = false
+        titleLabel.font = NSFont.systemFont(ofSize: 14, weight: .semibold)
+        titleLabel.textColor = .labelColor
+        headerView.addSubview(titleLabel)
+        
+        let refreshButton = NSButton(frame: NSRect(x: self.frame.width - 80, y: 15, width: 65, height: 25))
+        refreshButton.title = localizedString("Refresh")
+        refreshButton.bezelStyle = .rounded
+        refreshButton.target = self
+        refreshButton.action = #selector(refreshPorts)
+        headerView.addSubview(refreshButton)
+        
+        view.addSubview(headerView)
+        
+        // Table view
+        let tableFrame = NSRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height - headerHeight)
+        scrollView = NSScrollView(frame: tableFrame)
+        scrollView?.hasVerticalScroller = true
+        scrollView?.hasHorizontalScroller = false
+        scrollView?.autohidesScrollers = true
+        scrollView?.backgroundColor = .clear
+        
+        tableView = NSTableView(frame: scrollView!.bounds)
+        tableView?.headerView = NSTableHeaderView()
+        tableView?.backgroundColor = .clear
+        tableView?.rowHeight = rowHeight
+        tableView?.intercellSpacing = NSSize(width: 0, height: 4)
+        tableView?.delegate = self
+        tableView?.dataSource = self
+        
+        // Columns
+        let portColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("port"))
+        portColumn.title = localizedString("Port")
+        portColumn.width = 60
+        tableView?.addTableColumn(portColumn)
+        
+        let processColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("process"))
+        processColumn.title = localizedString("Process")
+        processColumn.width = 150
+        tableView?.addTableColumn(processColumn)
+        
+        let pidColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("pid"))
+        pidColumn.title = "PID"
+        pidColumn.width = 60
+        tableView?.addTableColumn(pidColumn)
+        
+        let actionColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("action"))
+        actionColumn.title = localizedString("Action")
+        actionColumn.width = 70
+        tableView?.addTableColumn(actionColumn)
+        
+        scrollView?.documentView = tableView
+        view.addSubview(scrollView!)
+        
+        return view
+    }
+    
+    @objc private func refreshPorts() {
+        reader?.read()
+    }
+    
+    public func setReader(_ reader: PortsReader) {
+        self.reader = reader
+    }
+    
+    public func portsCallback(_ ports: [PortInfo]) {
+        self.ports = ports
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.tableView?.reloadData()
+        }
+    }
+    
+    @objc private func killButtonClicked(_ sender: NSButton) {
+        let row = sender.tag
+        guard row < ports.count else { return }
+        
+        let port = ports[row]
+        
+        let alert = NSAlert()
+        alert.messageText = localizedString("Kill Process")
+        alert.informativeText = String(format: localizedString("Are you sure you want to kill process '%@' (PID: %d) on port %d?"), port.processName, port.pid, port.port)
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: localizedString("Kill"))
+        alert.addButton(withTitle: localizedString("Cancel"))
+        
+        if alert.runModal() == .alertFirstButtonReturn {
+            if reader?.killProcess(pid: port.pid) == true {
+                // Wait a moment and refresh
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.refreshPorts()
+                }
+            } else {
+                let errorAlert = NSAlert()
+                errorAlert.messageText = localizedString("Error")
+                errorAlert.informativeText = localizedString("Failed to kill process. You may need administrator privileges.")
+                errorAlert.alertStyle = .critical
+                errorAlert.runModal()
+            }
+        }
+    }
+}
+
+extension Popup: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        return ports.count
+    }
+}
+
+extension Popup: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < ports.count else { return nil }
+        let port = ports[row]
+        
+        let cellView = NSView(frame: NSRect(x: 0, y: 0, width: tableColumn?.width ?? 0, height: rowHeight))
+        
+        switch tableColumn?.identifier.rawValue {
+        case "port":
+            let textField = NSTextField(frame: NSRect(x: 5, y: 5, width: (tableColumn?.width ?? 0) - 10, height: 20))
+            textField.stringValue = "\(port.port)"
+            textField.isEditable = false
+            textField.isBordered = false
+            textField.drawsBackground = false
+            textField.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+            textField.textColor = .labelColor
+            cellView.addSubview(textField)
+            
+        case "process":
+            let textField = NSTextField(frame: NSRect(x: 5, y: 5, width: (tableColumn?.width ?? 0) - 10, height: 20))
+            textField.stringValue = port.processName
+            textField.isEditable = false
+            textField.isBordered = false
+            textField.drawsBackground = false
+            textField.font = NSFont.systemFont(ofSize: 11)
+            textField.textColor = .labelColor
+            textField.lineBreakMode = .byTruncatingTail
+            cellView.addSubview(textField)
+            
+        case "pid":
+            let textField = NSTextField(frame: NSRect(x: 5, y: 5, width: (tableColumn?.width ?? 0) - 10, height: 20))
+            textField.stringValue = "\(port.pid)"
+            textField.isEditable = false
+            textField.isBordered = false
+            textField.drawsBackground = false
+            textField.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+            textField.textColor = .secondaryLabelColor
+            cellView.addSubview(textField)
+            
+        case "action":
+            let button = NSButton(frame: NSRect(x: 5, y: 2, width: 60, height: 24))
+            button.title = localizedString("Kill")
+            button.bezelStyle = .rounded
+            button.font = NSFont.systemFont(ofSize: 11)
+            button.tag = row
+            button.target = self
+            button.action = #selector(killButtonClicked(_:))
+            cellView.addSubview(button)
+            
+        default:
+            break
+        }
+        
+        return cellView
+    }
+    
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        return rowHeight
+    }
+}

--- a/Modules/Ports/readers.swift
+++ b/Modules/Ports/readers.swift
@@ -1,0 +1,112 @@
+//
+//  readers.swift
+//  Ports
+//
+//  Created by Dogukan Akin on 05/10/2025.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2025 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+import Cocoa
+import Kit
+
+public struct PortInfo: Codable {
+    let port: Int
+    let pid: Int
+    let processName: String
+    let `protocol`: String
+    let state: String
+}
+
+internal class PortsReader: Reader<[PortInfo]> {
+    private let title: String = "Ports"
+    
+    public override func setup() {
+        self.popup = true
+        self.setInterval(Store.shared.int(key: "\(self.title)_updateInterval", defaultValue: 3))
+    }
+    
+    public override func read() {
+        let task = Process()
+        task.launchPath = "/usr/sbin/lsof"
+        task.arguments = ["-iTCP", "-sTCP:LISTEN", "-P", "-n"]
+        
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        
+        defer {
+            outputPipe.fileHandleForReading.closeFile()
+            errorPipe.fileHandleForReading.closeFile()
+        }
+        
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+        
+        do {
+            try task.run()
+        } catch let err {
+            error("lsof(): \(err.localizedDescription)", log: self.log)
+            return
+        }
+        
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)
+        guard let output, !output.isEmpty else { return }
+        
+        var ports: [PortInfo] = []
+        var seenPorts: Set<Int> = []
+        
+        output.enumerateLines { (line, _) in
+            // Skip header line
+            if line.hasPrefix("COMMAND") {
+                return
+            }
+            
+            let components = line.split(separator: " ", omittingEmptySubsequences: true)
+            if components.count >= 9 {
+                let processName = String(components[0])
+                let pidString = String(components[1])
+                let proto = String(components[7])
+                
+                // Extract port from address (format: *:PORT or IP:PORT)
+                let address = String(components[8])
+                if let colonIndex = address.lastIndex(of: ":") {
+                    let portString = String(address[address.index(after: colonIndex)...])
+                    if let port = Int(portString), let pid = Int(pidString) {
+                        // Only add unique ports
+                        if !seenPorts.contains(port) {
+                            seenPorts.insert(port)
+                            ports.append(PortInfo(
+                                port: port,
+                                pid: pid,
+                                processName: processName,
+                                protocol: proto,
+                                state: "LISTEN"
+                            ))
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Sort by port number
+        ports.sort { $0.port < $1.port }
+        self.callback(ports)
+    }
+    
+    public func killProcess(pid: Int) -> Bool {
+        let task = Process()
+        task.launchPath = "/bin/kill"
+        task.arguments = ["-9", "\(pid)"]
+        
+        do {
+            try task.run()
+            task.waitUntilExit()
+            return task.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}

--- a/Modules/Ports/settings.swift
+++ b/Modules/Ports/settings.swift
@@ -1,0 +1,73 @@
+//
+//  settings.swift
+//  Ports
+//
+//  Created by Dogukan Akin on 05/10/2025.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2025 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+import Cocoa
+import Kit
+
+internal class Settings: SettingsWrapper {
+    private var updateIntervalValue: Int = 3
+    
+    public var callback: (() -> Void) = {}
+    public var setInterval: ((_ value: Int) -> Void) = {_ in }
+    
+    public init(_ module: ModuleType) {
+        self.updateIntervalValue = Store.shared.int(key: "\(module.rawValue)_updateInterval", defaultValue: self.updateIntervalValue)
+        
+        super.init(module, frame: CGRect(
+            x: 0,
+            y: 0,
+            width: Constants.Settings.width - (Constants.Settings.margin*2),
+            height: 0
+        ))
+        
+        self.canDrawConcurrently = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func load(widgets: [widget_t]) {
+        self.subviews.forEach{ $0.removeFromSuperview() }
+        
+        let rowHeight: CGFloat = 30
+        let height: CGFloat = ((rowHeight + Constants.Settings.margin) * 2) + Constants.Settings.margin
+        
+        self.addSubview(selectSettingsRowV1(
+            title: localizedString("Update interval"),
+            action: #selector(changeUpdateInterval),
+            items: ReaderUpdateIntervals.map{ "\($0) sec" },
+            selected: "\(self.updateIntervalValue) sec"
+        ))
+        
+        self.addSubview(selectSettingsRowV1(
+            title: localizedString("Widget"),
+            action: #selector(toggleWidget),
+            items: widgets.map{ $0.rawValue },
+            selected: widgets.first{ $0.isActive }?.rawValue ?? ""
+        ))
+        
+        self.setFrameSize(NSSize(width: self.frame.width, height: height))
+    }
+    
+    @objc private func changeUpdateInterval(_ sender: NSMenuItem) {
+        if let value = Int(sender.title.replacingOccurrences(of: " sec", with: "")) {
+            self.updateIntervalValue = value
+            Store.shared.set(key: "\(self.title)_updateInterval", value: value)
+            self.setInterval(value)
+        }
+    }
+    
+    @objc private func toggleWidget(_ sender: NSMenuItem) {
+        guard let widget = widget_t.fromString(sender.title) else { return }
+        self.toggleWidget(widget)
+    }
+}

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -28,6 +28,8 @@
 "Open Bluetooth settings" = "Open bluetooth settings";
 "Clock" = "Clock";
 "Open Clock settings" = "Open clock settings";
+"Ports" = "Ports";
+"Open Ports settings" = "Open ports settings";
 
 // Words
 "Unknown" = "Unknown";
@@ -501,3 +503,15 @@
 "Pink" = "Pink";
 "Teal" = "Teal";
 "Indigo" = "Indigo";
+
+// Ports
+"Active Ports" = "Active Ports";
+"Port" = "Port";
+"Process" = "Process";
+"Action" = "Action";
+"Kill" = "Kill";
+"Refresh" = "Refresh";
+"Kill Process" = "Kill Process";
+"Are you sure you want to kill process '%@' (PID: %d) on port %d?" = "Are you sure you want to kill process '%@' (PID: %d) on port %d?";
+"Error" = "Error";
+"Failed to kill process. You may need administrator privileges." = "Failed to kill process. You may need administrator privileges.";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -28,6 +28,8 @@
 "Open Bluetooth settings" = "Bluetooth ayarlarını aç";
 "Clock" = "Saat";
 "Open Clock settings" = "Saat ayarlarını aç";
+"Ports" = "Portlar";
+"Open Ports settings" = "Port ayarlarını aç";
 
 // Words
 "Unknown" = "Bilinmeyen";
@@ -501,3 +503,15 @@
 "Pink" = "Pembe";
 "Teal" = "Camgöbeği";
 "Indigo" = "Çivit";
+
+// Ports
+"Active Ports" = "Aktif Portlar";
+"Port" = "Port";
+"Process" = "İşlem";
+"Action" = "Eylem";
+"Kill" = "Kapat";
+"Refresh" = "Yenile";
+"Kill Process" = "İşlemi Kapat";
+"Are you sure you want to kill process '%@' (PID: %d) on port %d?" = "'%@' işlemini (PID: %d) port %d üzerinde kapatmak istediğinizden emin misiniz?";
+"Error" = "Hata";
+"Failed to kill process. You may need administrator privileges." = "İşlem kapatılamadı. Yönetici yetkilerine ihtiyacınız olabilir.";


### PR DESCRIPTION
- Add new Ports module to monitor active TCP ports
- Display port number, process name, and PID
- Add kill functionality with confirmation dialog
- Support for Turkish and English localization
- Add ModuleType.Ports to constants
- Include popup UI with port list and kill buttons
- Add settings page for update interval configuration

This feature allows users to:
- View all active TCP ports on their system
- See which processes are using each port
- Kill processes safely with confirmation dialog
- Refresh port list manually

This feature will be particularly useful for developers and system administrators who need to monitor and manage network ports on their Mac.