### PR TITLE
lang: update Taiwan Traditional Chinese Localization

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -416,12 +416,12 @@
 "Download speed" = "下載";
 "Address" = "位址";
 "WiFi network" = "Wi-Fi 網路";
-"Local IP changed" = "Local IP has changed";
-"Public IP changed" = "Public IP has changed";
-"Previous IP" = "Previous IP: %0";
-"New IP" = "New IP: %0";
-"Internet connection lost" = "Internet connection lost";
-"Internet connection established" = "Internet connection established";
+"Local IP changed" = "區域 IP 已變更";
+"Public IP changed" = "公用 IP 已變更";
+"Previous IP" = "舊 IP：%0";
+"New IP" = "新 IP：%0";
+"Internet connection lost" = "網際網路連線已遺失";
+"Internet connection established" = "網際網路連線已建立";
 
 // Battery
 "Level" = "電量";


### PR DESCRIPTION
Add new Taiwan Traditional Chinese translating into a new string.
對新的字串加入正體中文（臺灣）翻譯。

———————————————————————

**You can view, comment on, or merge this pull request online at:
您可以在以下連結檢視、留言或線上合併此更新請求：**

> [https://github.com/exelban/stats/pull/2809](https://github.com/exelban/stats/pull/2809)

**Commit Summary
更新大綱**

- **Add new translations for strings that have not been translated yet.
對尚未翻譯的字串加入正體中文（臺灣）的翻譯。**

1. “區域 IP 已變更” for `Local IP changed` in line 419
2. “公用 IP 已變更” for `Public IP changed` in line 420
3. “舊 IP：%0” for `Previous IP` in line 421
4. “新 IP：%0” for `New IP` in line 422
5. “網際網路連線已遺失” for `Internet connection lost` in line 423
6. “網際網路連線已建立” for `Internet connection established` in line 424

**File Changes
檔案變更**

- **M** [Stats/Supporting Files/zh-Hant.lproj/Localizable.strings](https://github.com/exelban/stats/pull/2809/files) (1)

**Patch Links:
補丁連結:**

https://github.com/exelban/stats/pull/2809.patch
https://github.com/exelban/stats/pull/2809.diff