### PR TITLE
Update fan control

### DIFF
--- a/Kit/types.swift
+++ b/Kit/types.swift
@@ -272,6 +272,7 @@ public extension Notification.Name {
     static let resetTotalNetworkUsage = Notification.Name("resetTotalNetworkUsage")
     static let syncFansControl = Notification.Name("syncFansControl")
     static let fanHelperState = Notification.Name("fanHelperState")
+    static let fanControlError = Notification.Name("fanControlError")
     static let toggleOneView = Notification.Name("toggleOneView")
     static let widgetRearrange = Notification.Name("widgetRearrange")
     static let moduleRearrange = Notification.Name("moduleRearrange")

--- a/Modules/Sensors/values.swift
+++ b/Modules/Sensors/values.swift
@@ -255,10 +255,14 @@ public struct Fan: Sensor_p, Codable {
     public var mode: FanMode
     
     public var percentage: Int {
-        if self.value != 0 && self.maxSpeed != 0 && self.value != 1 && self.maxSpeed != 1 {
-            return (100*Int(self.value)) / Int(self.maxSpeed)
-        }
-        return 0
+        let speedRange = self.maxSpeed - self.minSpeed
+        guard speedRange > 0 else { return 0 }
+
+        let currentSpeed = max(self.minSpeed, min(self.value, self.maxSpeed))
+        let adjustedSpeed = currentSpeed - self.minSpeed
+        let percent = (adjustedSpeed / speedRange) * 100
+
+        return max(0, min(100, Int(round(percent))))
     }
     
     public var group: SensorGroup = .sensor

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         self.parseArguments()
         self.parseVersion()
         SMCHelper.shared.checkForUpdate()
+        SMCHelper.shared.establishConnection()
         self.setup {
             modules.reversed().forEach{ $0.mount() }
             self.settingsWindow.setModules()


### PR DESCRIPTION
Hello!

I have tried to upgrade fan control module and add some improvements.

Now it should do the following: 

### 1. Pop up some modal in case of errors
### 2. Establish a connection to SMC if it is installed (previously, it didn't do that and needed to reinstall app and helper to make it work)
### 3. Allow min value to be 0 in manual mode
### 4. Removed restore from RAM in wake up. The logic is after a sleep, the system is cooled down and it can be used in autoamtic mode
### 5. Tried to add support for single fan and 3+ fans 

All modifications are tested on local build using MacOS 26.2 and XCode 26.2.

