### PR TITLE
fix(Clock): implement local caching for settings to prevent UI lag (#2840)

### DIFF
--- a/Modules/Clock/settings.swift
+++ b/Modules/Clock/settings.swift
@@ -20,17 +20,14 @@ let statusColumnID = NSUserInterfaceItemIdentifier(rawValue: "status")
 internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate {
     public var callback: (() -> Void) = {}
     
+    private var cachedList: [Clock_t] = []
     private var list: [Clock_t] {
         get {
-            if let objects = Store.shared.data(key: "\(self.title)_list") {
-                let decoder = JSONDecoder()
-                if let objectsDecoded = try? decoder.decode(Array.self, from: objects) as [Clock_t] {
-                    return objectsDecoded
-                }
-            }
-            return [Clock.local]
+            return self.cachedList
         }
         set {
+            self.cachedList = newValue
+            
             if newValue.isEmpty {
                 Store.shared.remove("\(self.title)_list")
             } else {
@@ -54,6 +51,16 @@ internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableVi
         self.title = module.stringValue
         
         super.init(frame: NSRect.zero)
+        
+        if let objects = Store.shared.data(key: "\(self.title)_list") {
+            let decoder = JSONDecoder()
+            if let objectsDecoded = try? decoder.decode(Array.self, from: objects) as [Clock_t] {
+                self.cachedList = objectsDecoded
+            }
+        }
+        if self.cachedList.isEmpty {
+            self.cachedList = [Clock.local]
+        }
         
         self.orientation = .vertical
         self.distribution = .gravityAreas


### PR DESCRIPTION
### Context
Fixes #2840.

### Problem
The [list](cci:7://file:///Users/biplavbarua/Developer/stats/exportOptions.plist:0:0-0:0) property in [Clock/settings.swift](cci:7://file:///Users/biplavbarua/Developer/stats/Modules/Clock/settings.swift:0:0-0:0) was reading/writing to UserDefaults (JSON encode/decode) on every keystroke in the settings UI. This caused performance issues and prevented users from typing custom formats smoothly.

### Solution
- Implemented a local `cachedList` in `Settings`.
- [init()](cci:1://file:///Users/biplavbarua/Developer/brew_fork/Library/Homebrew/cask/dsl.rb:127:4-178:7) : Loads from Store once.
- `get` : Reads from memory (instant).
- [set](cci:1://file:///Users/biplavbarua/Developer/brew_fork/Library/Homebrew/cask/dsl.rb:225:4-244:7) : Updates memory and persists to Store.