### PR TITLE
feat: detect and alert when menu bar permission is disabled (macOS 26+)

### DIFF
--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -344,6 +344,11 @@ public class SWidget {
                 self.menuBarItem?.button?.target = self
                 self.menuBarItem?.button?.action = #selector(self.togglePopup)
                 self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
+
+                // Check if menu bar item is visible (macOS 26+ permission issue)
+                if let item = self.menuBarItem {
+                    checkMenuBarItemVisibility(item)
+                }
             })
         } else if let item = self.menuBarItem {
             saveNSStatusItemPosition(id: "\(self.module)_\(self.type.rawValue)")


### PR DESCRIPTION
macOS 26 introduced a new "Allow in Menu Bar" permission in System Settings → General → Login Items & Extensions. When this is disabled for Stats, the widgets get rendered off-screen and users have no idea why nothing is showing up.

This PR detects that situation by checking if the status item's window position is way below where the menu bar should be. If so, it shows an alert explaining the issue with a button to jump straight to the right settings pane.

The check only runs once per session so it won't keep bugging the user.

**Identified and tested on:**
- macOS 26.1 (Tahoe) Build 25B78
- Stats 2.11.62

**Terminal command to check menu bar visibility:**
```bash
osascript -e '
tell application "System Events"
    tell process "Stats"
        set y to item 2 of (position of menu bar item 1 of menu bar 1)
        if y < 100 then
            return "ENABLED - Menu bar visible (y=" & y & ")"
        else
            return "DISABLED - Menu bar hidden (y=" & y & ")"
        end if
    end tell
end tell
'
```

Related: #2704, #2658, #2662