### PR TITLE
lang: aligned Triditional Chinese localizations with Apple terminology

### DIFF
--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "Version" = "版本";
 "Processor" = "處理器";
 "Memory" = "記憶體";
-"Graphics" = "圖形處理器";
+"Graphics" = "顯示卡";
 "Close" = "關閉";
 "Download" = "下載";
 "Install" = "安裝";


### PR DESCRIPTION
The previous Traditional Chinese localization relied heavily on colloquial expressions.
This PR standardizes the translations to align with Apple’s terminology and wording used across system interfaces.