### PR TITLE
feat: added right click for menu + allowed higher number of top processes to be picked

### DIFF
--- a/Kit/constants.swift
+++ b/Kit/constants.swift
@@ -14,6 +14,7 @@ import Cocoa
 public struct Popup_c_s {
     public let width: CGFloat = 264
     public let height: CGFloat = 300
+    public let maxHeight: CGFloat = 850
     public let margins: CGFloat = 8
     public let spacing: CGFloat = 2
     public let headerHeight: CGFloat = 42

--- a/Kit/module/popup.swift
+++ b/Kit/module/popup.swift
@@ -225,8 +225,9 @@ internal class PopupView: NSView {
         
         self.windowHeight = NSScreen.main?.visibleFrame.height // for height recalculate when appear/disappear
         self.containerHeight = self.body.documentView?.frame.height // for scroll diff calculation
-        if let screenHeight = NSScreen.main?.visibleFrame.height, size.height > screenHeight {
-            size.height = screenHeight - Constants.Widget.height
+        let maxAllowedHeight = min(NSScreen.main?.visibleFrame.height ?? Constants.Popup.maxHeight, Constants.Popup.maxHeight)
+        if size.height > maxAllowedHeight {
+            size.height = maxAllowedHeight - Constants.Widget.height
             isScrollVisible = true
         }
         if let screenWidth = NSScreen.main?.visibleFrame.width, size.width > screenWidth {
@@ -289,8 +290,9 @@ internal class PopupView: NSView {
         
         self.windowHeight = NSScreen.main?.visibleFrame.height // for height recalculate when appear/disappear
         self.containerHeight = self.body.documentView?.frame.height // for scroll diff calculation
-        if let screenHeight = NSScreen.main?.visibleFrame.height, windowSize.height > screenHeight {
-            windowSize.height = screenHeight - Constants.Widget.height
+        let maxAllowedHeight = min(NSScreen.main?.visibleFrame.height ?? Constants.Popup.maxHeight, Constants.Popup.maxHeight)
+        if windowSize.height > maxAllowedHeight {
+            windowSize.height = maxAllowedHeight - Constants.Widget.height
             isScrollVisible = true
         }
         if let screenWidth = NSScreen.main?.visibleFrame.width, windowSize.width > screenWidth {

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -353,6 +353,13 @@ public class SWidget {
     }
     
     @objc private func togglePopup() {
+        guard let event = NSApp.currentEvent else { return }
+
+        if event.type == .rightMouseDown {
+            self.showContextMenu()
+            return
+        }
+
         if let item = self.menuBarItem, let window = item.button?.window {
             NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
                 "module": self.module,
@@ -361,6 +368,40 @@ public class SWidget {
                 "center": window.frame.width/2
             ])
         }
+    }
+
+    private func showContextMenu() {
+        let menu = NSMenu()
+
+        let settingsItem = NSMenuItem(title: localizedString("Settings"), action: #selector(openSettings), keyEquivalent: ",")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let restartItem = NSMenuItem(title: localizedString("Restart"), action: #selector(restartApplication), keyEquivalent: "")
+        restartItem.target = self
+        menu.addItem(restartItem)
+
+        let quitItem = NSMenuItem(title: localizedString("Quit"), action: #selector(quitApplication), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        if let button = self.menuBarItem?.button {
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 5), in: button)
+        }
+    }
+
+    @objc private func openSettings() {
+        NotificationCenter.default.post(name: .toggleSettings, object: nil, userInfo: ["module": self.module])
+    }
+
+    @objc private func restartApplication() {
+        restartApp(self)
+    }
+
+    @objc private func quitApplication() {
+        NSApplication.shared.terminate(nil)
     }
 }
 
@@ -507,6 +548,13 @@ public class MenuBar {
     }
     
     @objc private func togglePopup() {
+        guard let event = NSApp.currentEvent else { return }
+
+        if event.type == .rightMouseDown {
+            self.showContextMenu()
+            return
+        }
+
         if let item = self.menuBarItem, let window = item.button?.window {
             NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
                 "module": self.moduleName,
@@ -515,7 +563,41 @@ public class MenuBar {
             ])
         }
     }
-    
+
+    private func showContextMenu() {
+        let menu = NSMenu()
+
+        let settingsItem = NSMenuItem(title: localizedString("Settings"), action: #selector(openSettings), keyEquivalent: ",")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let restartItem = NSMenuItem(title: localizedString("Restart"), action: #selector(restartApplication), keyEquivalent: "")
+        restartItem.target = self
+        menu.addItem(restartItem)
+
+        let quitItem = NSMenuItem(title: localizedString("Quit"), action: #selector(quitApplication), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        if let button = self.menuBarItem?.button {
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 5), in: button)
+        }
+    }
+
+    @objc private func openSettings() {
+        NotificationCenter.default.post(name: .toggleSettings, object: nil, userInfo: ["module": self.moduleName])
+    }
+
+    @objc private func restartApplication() {
+        restartApp(self)
+    }
+
+    @objc private func quitApplication() {
+        NSApplication.shared.terminate(nil)
+    }
+
     @objc private func listenForOneView(_ notification: Notification) {
         if notification.userInfo?["module"] as? String == nil {
             self.toggleOneView()

--- a/Kit/types.swift
+++ b/Kit/types.swift
@@ -14,7 +14,7 @@ import Cocoa
 public struct DoubleValue {
     public var ts: Date = Date()
     public let value: Double
-    
+
     public init(_ value: Double = 0) {
         self.value = value
     }
@@ -26,12 +26,12 @@ extension [DoubleValue] {
 public struct ColorValue: Equatable {
     public let value: Double
     public let color: NSColor?
-    
+
     public init(_ value: Double, color: NSColor? = nil) {
         self.value = value
         self.color = color
     }
-    
+
     // swiftlint:disable operator_whitespace
     public static func ==(lhs: ColorValue, rhs: ColorValue) -> Bool {
         return lhs.value == rhs.value
@@ -165,7 +165,7 @@ public let ReaderUpdateIntervals: [KeyValue_t] = [
     KeyValue_t(key: "30", value: "30 sec"),
     KeyValue_t(key: "60", value: "60 sec")
 ]
-public let NumbersOfProcesses: [Int] = [0, 3, 5, 8, 10, 15]
+public let NumbersOfProcesses: [Int] = [0, 3, 5, 8, 10, 15, 20, 25, 50, 75, 100, 150, 200, 300]
 
 public let NetworkReaders: [KeyValue_t] = [
     KeyValue_t(key: "interface", value: "Interface based"),
@@ -182,7 +182,7 @@ public struct SColor: KeyValue_p, Equatable {
     public let key: String
     public let value: String
     public var additional: Any?
-    
+
     public static func == (lhs: SColor, rhs: SColor) -> Bool {
         return lhs.key == rhs.key
     }
@@ -192,14 +192,14 @@ extension SColor: CaseIterable {
     public static var utilization: SColor { return SColor(key: "utilization", value: "Based on utilization", additional: NSColor.black) }
     public static var pressure: SColor { return SColor(key: "pressure", value: "Based on pressure", additional: NSColor.black) }
     public static var cluster: SColor { return SColor(key: "cluster", value: "Based on cluster", additional: NSColor.controlAccentColor) }
-    
+
     public static var separator1: SColor { return SColor(key: "separator_1", value: "separator_1", additional: NSColor.black) }
-    
+
     public static var systemAccent: SColor { return SColor(key: "system", value: "System accent", additional: NSColor.controlAccentColor) }
     public static var monochrome: SColor { return SColor(key: "monochrome", value: "Monochrome accent", additional: NSColor.textColor) }
-    
+
     public static var separator2: SColor { return SColor(key: "separator_2", value: "separator_2", additional: NSColor.black) }
-    
+
     public static var clear: SColor { return SColor(key: "clear", value: "Clear", additional: NSColor.clear) }
     public static var white: SColor { return SColor(key: "white", value: "White", additional: NSColor.white) }
     public static var black: SColor { return SColor(key: "black", value: "Black", additional: NSColor.black) }
@@ -230,7 +230,7 @@ extension SColor: CaseIterable {
     } else {
         return SColor(key: "indigo", value: "Indigo", additional: NSColor(red: 75, green: 0, blue: 130, alpha: 1))
     } }
-    
+
     public static var allCases: [SColor] {
         return [.utilization, .pressure, .cluster, separator1,
                 .systemAccent, .monochrome, separator2,
@@ -240,7 +240,7 @@ extension SColor: CaseIterable {
                 .cyan, .magenta, .pink, .teal, .indigo
         ]
     }
-    
+
     public static var allColors: [SColor] {
         return [.systemAccent, .monochrome, .separator2, .clear, .white, .black, .gray, .secondGray, .darkGray, .lightGray,
                 .red, .secondRed, .green, .secondGreen, .blue, .secondBlue, .yellow, .secondYellow,
@@ -248,7 +248,7 @@ extension SColor: CaseIterable {
                 .cyan, .magenta, .pink, .teal, .indigo
         ]
     }
-    
+
     public static func fromString(_ key: String, defaultValue: SColor = .systemAccent) -> SColor {
         return SColor.allCases.first{ $0.key == key } ?? defaultValue
     }
@@ -315,7 +315,7 @@ public let notificationLevels: [KeyValue_t] = [
 public struct Scale: KeyValue_p, Equatable {
     public let key: String
     public let value: String
-    
+
     public static func == (lhs: Scale, rhs: Scale) -> Bool {
         return lhs.key == rhs.key
     }
@@ -330,11 +330,11 @@ extension Scale: CaseIterable {
     public static var logarithmic: Scale { return Scale(key: "logarithmic", value: "Logarithmic") }
     public static var separator2: Scale { return Scale(key: "separator", value: "separator") }
     public static var fixed: Scale { return Scale(key: "fixed", value: "Fixed scale") }
-    
+
     public static var allCases: [Scale] {
         return [.none, .separator, .linear, .square, .cube, .logarithmic, .separator2, .fixed]
     }
-    
+
     public static func fromString(_ key: String, defaultValue: Scale = .linear) -> Scale {
         return Scale.allCases.first{ $0.key == key } ?? defaultValue
     }
@@ -360,7 +360,7 @@ public var LineChartHistory: [KeyValue_p] = [
 public struct SizeUnit: KeyValue_p, Equatable {
     public let key: String
     public let value: String
-    
+
     public static func == (lhs: SizeUnit, rhs: SizeUnit) -> Bool {
         return lhs.key == rhs.key
     }
@@ -372,15 +372,15 @@ extension SizeUnit: CaseIterable {
     public static var MB: SizeUnit { return SizeUnit(key: "MB", value: "MB") }
     public static var GB: SizeUnit { return SizeUnit(key: "GB", value: "GB") }
     public static var TB: SizeUnit { return SizeUnit(key: "TB", value: "TB") }
-    
+
     public static var allCases: [SizeUnit] {
         [.byte, .KB, .MB, .GB, .TB]
     }
-    
+
     public static func fromString(_ key: String, defaultValue: SizeUnit = .byte) -> SizeUnit {
         return SizeUnit.allCases.first{ $0.key == key } ?? defaultValue
     }
-    
+
     public func toBytes(_ value: Int) -> Int {
         switch self {
         case .KB:
@@ -401,7 +401,7 @@ public enum RAMPressure: String, Codable {
     case normal
     case warning
     case critical
-    
+
     func pressureColor() -> NSColor {
         switch self {
         case .normal:


### PR DESCRIPTION
Hey there,
Thank you for the amazing app! Really useful for knowing what's been eating up my ram or wasting CPU cycles.

Only issues I had with it was it took too many clicks to quit (so I made right clicking one of the menu items show settings restart and quit). Note: Right clicking on a widget then clicking settings opens the settings for that widget.

<img width="382" height="203" alt="2025-12-25_CleanShot_08-46-18" src="https://github.com/user-attachments/assets/2e09cd5d-f769-40ac-b7a4-3fea4c05abfa" />
<br/><br/>
And the other thing I wanted was to see way more Top Processes because I love how you combine related processes unlike Activity Monitor (max was 15 before, I just added higher options)

<img width="382" height="885" alt="2025-12-25_CleanShot_08-47-01" src="https://github.com/user-attachments/assets/fbc07aa4-3cd4-4399-a545-d2188b49d2e2" />
<br/><br/>
I also made the max height of the widget 850px (or screen height, whichever is less) because I'm on a large 55" tv screen and when I select 100 processes it fills up the whole monitor.

Hope you don't mind these changes, please let me know if there's anything you want me to change.
Also feel free to modify anything about the PR of course, you have edit access on this branch.