### PR TITLE
Add 10s delay option for CPU/RAM/GPU alerts

### DIFF
--- a/Modules/CPU/notifications.swift
+++ b/Modules/CPU/notifications.swift
@@ -18,18 +18,21 @@ class Notifications: NotificationsWrapper {
     private let userLoadID: String = "userUsage"
     private let eCoresLoadID: String = "eCoresUsage"
     private let pCoresLoadID: String = "pCoresUsage"
+    private let sustainedID: String = "delay10s"
     
     private var totalLoadState: Bool = false
     private var systemLoadState: Bool = false
     private var userLoadState: Bool = false
     private var eCoresLoadState: Bool = false
     private var pCoresLoadState: Bool = false
+    private var sustainedState: Bool = false
     
     private var totalLoad: Int = 75
     private var systemLoad: Int = 75
     private var userLoad: Int = 75
     private var eCoresLoad: Int = 75
     private var pCoresLoad: Int = 75
+    private let sustainedDuration: TimeInterval = 10
     
     public init(_ module: ModuleType) {
         super.init(module, [self.totalLoadID, self.systemLoadID, self.userLoadID, self.eCoresLoadID, self.pCoresLoadID])
@@ -87,6 +90,7 @@ class Notifications: NotificationsWrapper {
         self.eCoresLoad = Store.shared.int(key: "\(self.module)_notifications_eCoresLoad_value", defaultValue: self.eCoresLoad)
         self.pCoresLoadState = Store.shared.bool(key: "\(self.module)_notifications_pCoresLoad_state", defaultValue: self.pCoresLoadState)
         self.pCoresLoad = Store.shared.int(key: "\(self.module)_notifications_pCoresLoad_value", defaultValue: self.pCoresLoad)
+        self.sustainedState = Store.shared.bool(key: "\(self.module)_notifications_\(self.sustainedID)_state", defaultValue: self.sustainedState)
         
         self.addArrangedSubview(PreferencesSection([
             PreferencesRow(localizedString("Total load"), component: PreferencesSwitch(
@@ -115,6 +119,12 @@ class Notifications: NotificationsWrapper {
             ))
         ]))
         #endif
+
+        self.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Delay alerts by 10 seconds"), component: PreferencesSwitch(
+                action: self.toggleSustained, state: self.sustainedState
+            ))
+        ]))
     }
     
     required init?(coder: NSCoder) {
@@ -126,27 +136,62 @@ class Notifications: NotificationsWrapper {
         
         if self.totalLoadState {
             let subtitle = "\(localizedString("Total load")): \(Int((value.totalUsage)*100))%"
-            self.checkDouble(id: self.totalLoadID, value: value.totalUsage, threshold: Double(self.totalLoad)/100, title: title, subtitle: subtitle)
+            self.checkDouble(
+                id: self.totalLoadID,
+                value: value.totalUsage,
+                threshold: Double(self.totalLoad)/100,
+                title: title,
+                subtitle: subtitle,
+                duration: self.sustainedState ? self.sustainedDuration : nil
+            )
         }
         
         if self.systemLoadState {
             let subtitle = "\(localizedString("System load")): \(Int((value.systemLoad)*100))%"
-            self.checkDouble(id: self.systemLoadID, value: value.systemLoad, threshold: Double(self.systemLoad)/100, title: title, subtitle: subtitle)
+            self.checkDouble(
+                id: self.systemLoadID,
+                value: value.systemLoad,
+                threshold: Double(self.systemLoad)/100,
+                title: title,
+                subtitle: subtitle,
+                duration: self.sustainedState ? self.sustainedDuration : nil
+            )
         }
         
         if self.userLoadState {
             let subtitle = "\(localizedString("User load")): \(Int((value.userLoad)*100))%"
-            self.checkDouble(id: self.userLoadID, value: value.userLoad, threshold: Double(self.userLoad)/100, title: title, subtitle: subtitle)
+            self.checkDouble(
+                id: self.userLoadID,
+                value: value.userLoad,
+                threshold: Double(self.userLoad)/100,
+                title: title,
+                subtitle: subtitle,
+                duration: self.sustainedState ? self.sustainedDuration : nil
+            )
         }
         
         if self.eCoresLoadState, let usage = value.usageECores {
             let subtitle = "\(localizedString("Efficiency cores load")): \(Int((usage)*100))%"
-            self.checkDouble(id: self.eCoresLoadID, value: usage, threshold: Double(self.eCoresLoad)/100, title: title, subtitle: subtitle)
+            self.checkDouble(
+                id: self.eCoresLoadID,
+                value: usage,
+                threshold: Double(self.eCoresLoad)/100,
+                title: title,
+                subtitle: subtitle,
+                duration: self.sustainedState ? self.sustainedDuration : nil
+            )
         }
         
         if self.pCoresLoadState, let usage = value.usagePCores {
             let subtitle = "\(localizedString("Performance cores load")): \(Int((usage)*100))%"
-            self.checkDouble(id: self.pCoresLoadID, value: usage, threshold: Double(self.pCoresLoad)/100, title: title, subtitle: subtitle)
+            self.checkDouble(
+                id: self.pCoresLoadID,
+                value: usage,
+                threshold: Double(self.pCoresLoad)/100,
+                title: title,
+                subtitle: subtitle,
+                duration: self.sustainedState ? self.sustainedDuration : nil
+            )
         }
     }
     
@@ -195,5 +240,10 @@ class Notifications: NotificationsWrapper {
     @objc private func changePCoresLoad(_ newValue: Int) {
         self.pCoresLoad = newValue
         Store.shared.set(key: "\(self.module)_notifications_pCoresLoad_value", value: self.pCoresLoad)
+    }
+    
+    @objc private func toggleSustained(_ sender: NSControl) {
+        self.sustainedState = controlState(sender)
+        Store.shared.set(key: "\(self.module)_notifications_\(self.sustainedID)_state", value: self.sustainedState)
     }
 }


### PR DESCRIPTION
## Changes

Adds an optional 10s delay toggle to CPU, RAM, and GPU notifications, as some requested in #2436 
Support sustained-threshold checks in `NotificationsWrapper` to suppress brief spikes.

I'm open to discuss whether a 10s delay is enough, or if it's more reasonable to let user choose between two 10 or 30 options. In such a case I propose a refactor in which users must choose the delay to be 0, 10 or 30 (with 0 seconds being the default option).

## Testing

- Manual: enabled the 10s delay and verified that alerts fire only after sustained load.
- Confirmed no alerts on brief spikes (CPU/RAM/GPU).