### PR TITLE
lang: updated Korean translations for Text and Battery details widgets

### DIFF
--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -212,8 +212,8 @@
 "Static width" = "너비 고정";
 "Tachometer widget" = "반원 도표";
 "State widget" = "상태 위젯";
-"Text widget" = "Text widget";
-"Battery details widget" = "Battery details widget";
+"Text widget" = "텍스트 위젯";
+"Battery details widget" = "배터리 세부 정보 위젯";
 "Show symbols" = "기호 표시";
 "Label widget" = "레이블 위젯";
 "Number of reads in the chart" = "도표의 행 크기";


### PR DESCRIPTION
This pull request updates the Korean localization strings to provide more accurate translations for widget names.

Localization improvements:

* Updated the translation for `"Text widget"` to `"텍스트 위젯"` in `Stats/Supporting Files/ko.lproj/Localizable.strings`.
* Updated the translation for `"Battery details widget"` to `"배터리 세부 정보 위젯"` in `Stats/Supporting Files/ko.lproj/Localizable.strings`.