### PR TITLE
lang: updated Japanese translations for notifications and calendar mo…

### DIFF
--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -140,9 +140,9 @@
 "Close application" = "Stats を終了";
 "Open application settings" = "Stats の設定を開く";
 "Open dashboard" = "ダッシュボードを開く";
-"No notifications available in this module" = "No notifications available in this module";
-"Open Calendar" = "Open Calendar";
-"Toggle the module" = "Toggle the module";
+"No notifications available in this module" = "このモジュールには利用可能な通知がありません";
+"Open Calendar" = "カレンダーを開く";
+"Toggle the module" = "モジュールの切り替え";
 
 // Application settings
 "Update application" = "アプリをアップデートする";


### PR DESCRIPTION
This pull request updates several Japanese translations in the `Stats/Supporting Files/ja.lproj/Localizable.strings` file to improve localization quality and provide more accurate Japanese equivalents for several UI phrases.

Localization improvements:

* Updated the translation for "No notifications available in this module" to a natural Japanese phrase: "このモジュールには利用可能な通知がありません" (`Stats/Supporting Files/ja.lproj/Localizable.strings`).
* Translated "Open Calendar" to "カレンダーを開く" and "Toggle the module" to "モジュールの切り替え" for better clarity and consistency in Japanese (`Stats/Supporting Files/ja.lproj/Localizable.strings`).…dule