### PR TITLE
Fix `Ftst` key handling for M3/M4 Apple Silicon fan control

### DIFF
--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -995,11 +995,7 @@ public class SMCHelper {
             return nil
         }
         guard let service = helper.remoteObjectProxyWithErrorHandler({ error in
-            let nsError = error as NSError
-            if nsError.code == 4097 || nsError.code == 4099 {
-                return
-            }
-            print("XPC error: \(error.localizedDescription)")
+            print(error)
         }) as? HelperProtocol else {
             completion?(false)
             return nil

--- a/SMC/Helper/Info.plist
+++ b/SMC/Helper/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleName</key>
 	<string>eu.exelban.Stats.SMC.Helper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.24</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>24</string>
+	<string>3</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>SMAuthorizedClients</key>

--- a/SMC/main.swift
+++ b/SMC/main.swift
@@ -145,7 +145,7 @@ func main() {
         } else {
             print("[reset] Ftst reset FAILED")
         }
-        #else 
+        #else
         print("[reset] not needed on Intel Macs")
         #endif
     case .help, .unknown:

--- a/SMC/smc.swift
+++ b/SMC/smc.swift
@@ -540,7 +540,7 @@ public class SMC {
     }
     
     private func writeWithRetry(_ value: SMCVal_t, maxAttempts: Int = 10, delayMicros: UInt32 = 50_000) -> Bool {
-        var mutableValue = value
+        let mutableValue = value
         var lastResult: kern_return_t = kIOReturnSuccess
         for attempt in 0..<maxAttempts {
             lastResult = write(mutableValue)
@@ -671,14 +671,12 @@ public class SMC {
         
         let result = self.call(SMCKeys.kernelIndex.rawValue, input: &input, output: &output)
         if result != kIOReturnSuccess {
-            print("Error write \(value.key): 0x\(String(result, radix: 16))")
             return result
         }
         
         // IOKit can return kIOReturnSuccess but SMC firmware may still reject the write.
         // Check SMC-level result code (0x00 = success, non-zero = error)
         if output.result != 0x00 {
-            print("Error write \(value.key) SMC: 0x\(String(output.result, radix: 16))")
             return kIOReturnError
         }
         

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -387,20 +387,6 @@
 			remoteGlobalIDString = 9AF9EE0124648751005D2270;
 			remoteInfo = Disk;
 		};
-		B2D05E752F253BFA0021E479 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9A1410ED229E721100D29793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9ADE6FD7265D032100D2FBA8;
-			remoteInfo = SMC;
-		};
-		B2D05E792F2548790021E479 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9A1410ED229E721100D29793 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5CFE492629264DF1000F2856;
-			remoteInfo = Helper;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1495,8 +1481,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				B2D05E7A2F2548790021E479 /* PBXTargetDependency */,
-				B2D05E762F253BFA0021E479 /* PBXTargetDependency */,
 				9A81C75C2449A41400825D92 /* PBXTargetDependency */,
 				9AF9EE0824648751005D2270 /* PBXTargetDependency */,
 				9A3E17D2247A94AF00449CD1 /* PBXTargetDependency */,
@@ -2389,16 +2373,6 @@
 			isa = PBXTargetDependency;
 			target = 9AF9EE0124648751005D2270 /* Disk */;
 			targetProxy = 9AF9EE0724648751005D2270 /* PBXContainerItemProxy */;
-		};
-		B2D05E762F253BFA0021E479 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 9ADE6FD7265D032100D2FBA8 /* SMC */;
-			targetProxy = B2D05E752F253BFA0021E479 /* PBXContainerItemProxy */;
-		};
-		B2D05E7A2F2548790021E479 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 5CFE492629264DF1000F2856 /* Helper */;
-			targetProxy = B2D05E792F2548790021E479 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Stats/Supporting Files/Info.plist
+++ b/Stats/Supporting Files/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>752</string>
+	<string>750</string>
 	<key>Description</key>
 	<string>Simple macOS system monitor in your menu bar</string>
 	<key>LSApplicationCategoryType</key>

--- a/Widgets/Supporting Files/Info.plist
+++ b/Widgets/Supporting Files/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.11.66</string>
 	<key>CFBundleVersion</key>
-	<string>752</string>
+	<string>750</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Fixes #2928

## Summary

On M3+ (M2 may behave the same; untested), `thermalmonitord` blocks direct writes to `F%dMd` (mode) and `F%dTg` (target). M1 allows direct writes.

This PR tries a direct write of `F%dMd=1` first and only uses the Ftst unlock sequence if that fails. On M1 the direct write succeeds and Ftst is never used. On M3+ it fails, so the code falls back to Ftst, waits for `thermalmonitord` to yield, then retries the mode write.

## Demo

| Before | After |
|--------|-------|
| Fan control unavailable on Apple silicon | ✅ Full manual control on M-series processors |
| <video src="https://github.com/user-attachments/assets/dfc1d022-8da5-4c40-8047-c51d683ebc74" width="400"></video> | <video src="https://github.com/user-attachments/assets/13963dae-cd64-4994-9e74-7b1342db8a12" width="400"></video> |

## Testing

- [x] Validated on Apple Silicon (`Mac16,6`, MacBook Pro M4 Max) - fan speed changes take effect
- [x] Validated on Apple Silicon (`MacBookPro18,1`, MacBook Pro M1 Pro) - fan speed changes take effect
- [x] Intel Mac backward compatibility verified (`iMac19,1` - `FS!` bitmask and `fpe2` format work correctly)

## References

Implementation based on [macos-smc-fan](https://github.com/agoodkind/macos-smc-fan), which provides detailed technical analysis of SMC fan control mechanisms on Apple Silicon.