### PR TITLE
feat: Add Apple Silicon (M1/M2/M3/M4) fan control support

### DIFF
--- a/SMC/Helper/protocol.swift
+++ b/SMC/Helper/protocol.swift
@@ -15,8 +15,16 @@ import Foundation
     func version(completion: @escaping (String) -> Void)
     func setSMCPath(_ path: String)
     
+    // Fan control
     func setFanMode(id: Int, mode: Int, completion: @escaping (String?) -> Void)
     func setFanSpeed(id: Int, value: Int, completion: @escaping (String?) -> Void)
+    
+    // Apple Silicon Ftst unlock (required for M1/M2/M3/M4 fan control)
+    func setFtstUnlock(completion: @escaping (Bool, String?) -> Void)
+    func setFtstLock(completion: @escaping (Bool, String?) -> Void)
+    func getFtstStatus(completion: @escaping (Bool, Int, String?) -> Void)
+    
+    // System
     func powermetrics(_ samplers: [String], completion: @escaping (String?) -> Void)
     
     func uninstall()

--- a/SMC/main.swift
+++ b/SMC/main.swift
@@ -16,6 +16,9 @@ enum CMDType: String {
     case set
     case fan
     case fans
+    case unlock
+    case lock
+    case ftstStatus
     case help
     case unknown
     
@@ -25,6 +28,9 @@ enum CMDType: String {
         case "set": self = .set
         case "fan": self = .fan
         case "fans": self = .fans
+        case "unlock": self = .unlock
+        case "lock": self = .lock
+        case "ftst": self = .ftstStatus
         case "help": self = .help
         default: self = .unknown
         }
@@ -102,15 +108,64 @@ func main() {
             return
         }
         var help: Bool = true
+        let needsUnlock = SMC.shared.isAppleSilicon
+        var didUnlock = false
+        
+        // Auto-unlock for Apple Silicon when writing speed
+        if needsUnlock && args.contains("-v") {
+            let currentFtst = SMC.shared.getFtstValue() ?? 0
+            if currentFtst == 0 {
+                print("[INFO] Apple Silicon detected, unlocking Ftst...")
+                let unlockResult = SMC.shared.setFtstUnlock()
+                if unlockResult != kIOReturnSuccess {
+                    print("[ERROR] Ftst unlock failed: \(unlockResult)")
+                    // Continue anyway, write might still work
+                } else {
+                    didUnlock = true
+                    // Wait for mode transition
+                    print("[INFO] Waiting for mode transition...")
+                    if SMC.shared.waitForModeTransition(timeout: 5.0) {
+                        print("[INFO] Mode transition complete")
+                    } else {
+                        print("[WARNING] Mode transition timeout")
+                    }
+                }
+            }
+        }
+        
+        // Note: Don't auto-reset Ftst here - let it stay unlocked for continuous control
+        // The helper daemon handles Ftst lifecycle (inactivity timeout, orphan detection)
         
         if let index = args.firstIndex(where: { $0 == "-v" }), args.indices.contains(index+1), let value = Int(args[index+1]) {
-            SMC.shared.setFanSpeed(id, speed: value)
+            // Use safe method with min/max enforcement
+            let minSpeed = Int(SMC.shared.getValue("F\(id)Mn") ?? 1000)
+            let maxSpeed = Int(SMC.shared.getValue("F\(id)Mx") ?? 6000)
+            
+            // Safety checks
+            if value <= 0 {
+                print("[ERROR] Zero or negative RPM not allowed for safety")
+                return
+            }
+            
+            var safeValue = value
+            if value < minSpeed {
+                print("[WARNING] RPM \(value) below minimum \(minSpeed), using minimum")
+                safeValue = minSpeed
+            }
+            if value > maxSpeed {
+                print("[WARNING] RPM \(value) above maximum \(maxSpeed), using maximum")
+                safeValue = maxSpeed
+            }
+            
+            SMC.shared.setFanSpeed(id, speed: safeValue)
+            print("[INFO] Set fan \(id) speed to \(safeValue) RPM")
             help = false
         }
         
         if let index = args.firstIndex(where: { $0 == "-m" }), args.indices.contains(index+1),
            let raw = Int(args[index+1]), let mode = FanMode.init(rawValue: raw) {
             SMC.shared.setFanMode(id, mode: mode)
+            print("[INFO] Set fan \(id) mode to \(mode.description)")
             help = false
         }
         
@@ -119,6 +174,8 @@ func main() {
         print("Available Flags:")
         print("  -m    change the fan mode: 0 - automatic, 1 - manual")
         print("  -v    change the fan speed")
+        print("")
+        print("Note: On Apple Silicon, Ftst unlock is handled automatically")
     case .fans:
         guard let count = SMC.shared.getValue("FNum") else {
             print("FNum not found")
@@ -136,6 +193,79 @@ func main() {
             
             print()
         }
+    case .unlock:
+        if !SMC.shared.isAppleSilicon {
+            print("[INFO] Not Apple Silicon - Ftst unlock not needed")
+            return
+        }
+        
+        let currentFtst = SMC.shared.getFtstValue()
+        print("[INFO] Current Ftst value: \(currentFtst ?? 255)")
+        
+        if currentFtst == 1 {
+            print("[INFO] Ftst already unlocked")
+            return
+        }
+        
+        let result = SMC.shared.setFtstUnlock()
+        if result == kIOReturnSuccess {
+            print("[INFO] Ftst unlock: success")
+            
+            // Wait for and report mode transition
+            print("[INFO] Waiting for mode transition...")
+            if SMC.shared.waitForModeTransition(timeout: 10.0) {
+                let mode = SMC.shared.getValue("F0Md") ?? -1
+                print("[INFO] Mode transition complete (F0Md = \(Int(mode)))")
+            } else {
+                print("[WARNING] Mode transition timeout")
+            }
+        } else {
+            print("[ERROR] Ftst unlock failed: \(result)")
+            exit(1)
+        }
+        
+    case .lock:
+        if !SMC.shared.isAppleSilicon {
+            print("[INFO] Not Apple Silicon - Ftst lock not needed")
+            return
+        }
+        
+        let result = SMC.shared.setFtstLock()
+        if result == kIOReturnSuccess {
+            print("[INFO] Ftst lock: success")
+            
+            // Report final mode
+            usleep(500_000) // Wait 500ms for mode to update
+            let mode = SMC.shared.getValue("F0Md") ?? -1
+            print("[INFO] F0Md = \(Int(mode))")
+        } else {
+            print("[ERROR] Ftst lock failed: \(result)")
+            exit(1)
+        }
+        
+    case .ftstStatus:
+        print("Ftst Status:")
+        print("  Apple Silicon: \(SMC.shared.isAppleSilicon)")
+        print("  Ftst key exists: \(SMC.shared.hasFtstKey())")
+        
+        if let ftst = SMC.shared.getFtstValue() {
+            print("  Ftst value: \(ftst) (\(ftst == 1 ? "unlocked" : "locked"))")
+        } else {
+            print("  Ftst value: N/A")
+        }
+        
+        if let mode = SMC.shared.getValue("F0Md") {
+            let modeInt = Int(mode)
+            let modeDesc: String
+            switch modeInt {
+            case 0: modeDesc = "automatic"
+            case 1: modeDesc = "manual"
+            case 3: modeDesc = "system (thermalmonitord)"
+            default: modeDesc = "unknown"
+            }
+            print("  F0Md: \(modeInt) (\(modeDesc))")
+        }
+        
     case .help, .unknown:
         print("SMC tool\n")
         print("Usage:")
@@ -143,14 +273,21 @@ func main() {
         print("Available Commands:")
         print("  list     list keys and values")
         print("  set      set value to a key")
-        print("  fan      set fan speed")
+        print("  fan      set fan speed/mode (auto-handles Ftst on Apple Silicon)")
         print("  fans     list of fans")
+        print("  unlock   unlock Ftst for Apple Silicon fan control")
+        print("  lock     lock Ftst to restore automatic control")
+        print("  ftst     show Ftst status")
         print("  help     help menu\n")
         print("Available Flags:")
         print("  -t    list temperature sensors")
         print("  -v    list voltage sensors (list cmd) / value (set cmd)")
         print("  -p    list power sensors")
         print("  -f    list fans\n")
+        print("Apple Silicon Notes:")
+        print("  Fan control on M1/M2/M3/M4 requires Ftst unlock.")
+        print("  The 'fan' command handles this automatically.")
+        print("  Use 'unlock' and 'lock' for manual control.\n")
     }
 }
 

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         self.parseArguments()
         self.parseVersion()
         SMCHelper.shared.checkForUpdate()
+        SMCHelper.shared.syncFtstState() // Sync Ftst state with helper daemon
         self.setup {
             modules.reversed().forEach{ $0.mount() }
             self.settingsWindow.setModules()


### PR DESCRIPTION
Implements Ftst unlock mechanism required for manual fan control on Apple Silicon Macs.

Changes:
- SMC: Add Ftst unlock/lock functions and mode transition handling
- SMC CLI: Auto-unlock Ftst when setting fan speed, safety checks for RPM bounds
- Helper: Add signal handlers and atexit cleanup for safe Ftst reset
- Helper: Add Ftst state tracking and inactivity timeout (60s)
- Protocol: Add setFtstUnlock, setFtstLock, getFtstStatus methods
- App: Sync Ftst state on startup, reset on termination

Technical details:
- Apple Silicon requires Ftst=1 to enable manual fan control
- Mode transition (3→0) takes ~3.5s after Ftst unlock
- F0Md=1 must be written before F0Tg for fan to respond
- FS! key skipped on Apple Silicon (Intel-only)

Safety features:
- Ftst auto-reset on app termination (atexit, SIGTERM, SIGINT)
- RPM bounds enforcement (min/max from SMC)
- Zero RPM blocked for safety