### PR TITLE
Add week numbers to Clock calendar

### DIFF
--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -471,6 +471,8 @@
 "Time zone" = "Time zone";
 "Local" = "Local";
 "Calendar" = "Calendar";
+"Show week numbers" = "Show week numbers";
+"Wk" = "Wk";
 "Local time" = "Local time";
 "Add new clock" = "Add new clock";
 "Delete selected clock" = "Delete selected clock";


### PR DESCRIPTION
## Summary
- add an optional week-number column in the Clock popup calendar
- expose a toggle and persist the setting
- keep header layout stable with week numbers enabled

## Test plan
- [ ] Toggle "Show week numbers" on/off in Clock popup
- [ ] Navigate months forward/back
- [ ] Check dark mode and light mode