### PR TITLE
Update logic CPU frequency detection for M5

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -723,9 +723,7 @@ public class SystemKit {
                     return .m4
                 }
             } else if name.contains("m5") {
-                if name.contains("pro") {
-                    return .m5
-                }
+                return .m5
             }
         }
         return nil


### PR DESCRIPTION
My macbook m5 pro is missing frequency in CPU tab, so i added support for m5 macbook