### PR TITLE
Fix race condition crashes in Chart and Stack widgets

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -223,27 +223,33 @@ public class BarChart: WidgetWrapper {
     }
     
     public func setValue(_ newValue: [[ColorValue]]) {
-        let tolerance: CGFloat = 0.01
-        let isDifferent = self._value.count != newValue.count || zip(self._value, newValue).contains { row1, row2 in
-            row1.count != row2.count || zip(row1, row2).contains { val1, val2 in
-                abs(val1.value - val2.value) > tolerance || val1.color != val2.color
+        DispatchQueue.main.async(execute: {
+            let tolerance: CGFloat = 0.01
+            let isDifferent = self._value.count != newValue.count || zip(self._value, newValue).contains { row1, row2 in
+                row1.count != row2.count || zip(row1, row2).contains { val1, val2 in
+                    abs(val1.value - val2.value) > tolerance || val1.color != val2.color
+                }
             }
-        }
-        guard isDifferent else { return }
-        self._value = newValue
-        self.redraw()
+            guard isDifferent else { return }
+            self._value = newValue
+            self.redraw()
+        })
     }
     
     public func setPressure(_ newPressureLevel: RAMPressure) {
-        guard self._pressureLevel != newPressureLevel else { return }
-        self._pressureLevel = newPressureLevel
-        self.redraw()
+        DispatchQueue.main.async(execute: {
+            guard self._pressureLevel != newPressureLevel else { return }
+            self._pressureLevel = newPressureLevel
+            self.redraw()
+        })
     }
     
     public func setColorZones(_ newColorZones: colorZones) {
-        guard self._colorZones != newColorZones else { return }
-        self._colorZones = newColorZones
-        self.redraw()
+        DispatchQueue.main.async(execute: {
+            guard self._colorZones != newColorZones else { return }
+            self._colorZones = newColorZones
+            self.redraw()
+        })
     }
     
     // MARK: - Settings

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -249,17 +249,17 @@ public class LineChart: WidgetWrapper {
     }
     
     public func setValue(_ newValue: Double) {
-        self._value = newValue
         DispatchQueue.main.async(execute: {
+            self._value = newValue
             self.chart.addValue(newValue)
             self.display()
         })
     }
     
     public func setPressure(_ newPressureLevel: RAMPressure) {
-        guard self._pressureLevel != newPressureLevel else { return }
-        self._pressureLevel = newPressureLevel
         DispatchQueue.main.async(execute: {
+            guard self._pressureLevel != newPressureLevel else { return }
+            self._pressureLevel = newPressureLevel
             self.display()
         })
     }

--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -263,10 +263,10 @@ public class NetworkChart: WidgetWrapper {
     }
     
     public func setValue(upload: Double, download: Double) {
-        self.points.remove(at: 0)
-        self.points.append((upload, download))
-        
         DispatchQueue.main.async(execute: {
+            self.points.remove(at: 0)
+            self.points.append((upload, download))
+            
             if self.window?.isVisible ?? false {
                 self.display()
             }

--- a/Kit/Widgets/Stack.swift
+++ b/Kit/Widgets/Stack.swift
@@ -226,24 +226,24 @@ public class StackWidget: WidgetWrapper {
     }
     
     public func setValues(_ values: [Stack_t]) {
-        var tableNeedsToBeUpdated: Bool = false
-        
-        values.forEach { (p: Stack_t) in
-            if let idx = self.values.firstIndex(where: { $0.key == p.key }) {
-                self.values[idx].value = p.value
-                return
-            }
-            tableNeedsToBeUpdated = true
-            self.values.append(p)
-        }
-        
-        let diff = self.values.filter({ v in values.contains(where: { $0.key == v.key }) })
-        if diff.count != self.values.count {
-            tableNeedsToBeUpdated = true
-        }
-        self.values = diff.sorted(by: { $0.index < $1.index })
-        
         DispatchQueue.main.async(execute: {
+            var tableNeedsToBeUpdated: Bool = false
+            
+            values.forEach { (p: Stack_t) in
+                if let idx = self.values.firstIndex(where: { $0.key == p.key }) {
+                    self.values[idx].value = p.value
+                    return
+                }
+                tableNeedsToBeUpdated = true
+                self.values.append(p)
+            }
+            
+            let diff = self.values.filter({ v in values.contains(where: { $0.key == v.key }) })
+            if diff.count != self.values.count {
+                tableNeedsToBeUpdated = true
+            }
+            self.values = diff.sorted(by: { $0.index < $1.index })
+            
             if tableNeedsToBeUpdated {
                 self.orderTableView.update()
             }


### PR DESCRIPTION
### Description:

This PR fixes multiple race conditions identified in StackWidget, NetworkChart, LineChart, and BarChart that were causing hard-to-reproduce crashes (SIGABRT and SIGTRAP) after extended runtimes (typically 1-3 days).

### Issues

This issue always show up when 'Combined modules' is enabled.

The crashes stem from a classic Reader-Writer race condition between background module threads and the main UI thread. 

_SIGABRT in StackWidget (Memory Corruption):_

**Context**: StackWidget maintains a values: [Stack_t] array. This array is passed as an UnsafeMutablePointer to its subview OrderTableView.

**The Bug**: The Sensors module (running on a background thread) updates the stack values via StackWidget.setValues. This method was mutating the values array directly on the background thread.

**The Crash**: If the background thread triggered a reallocation of the values array (e.g., during append or reassignment) while the Main Thread was simultaneously accessing it via the unsafe pointer in OrderTableView's drawing/delegate methods, the application would crash with a memory corruption error (swift_release_dealloc).



_SIGTRAP in NetworkChart (Index Out of Bounds):_

**Context**: NetworkChart maintains a points array for drawing the graph.

**The Bug**: The Net module (background thread) calls setValue(upload:download:), which was mutating (remove(at: 0) / append) the points array without any lock or thread affinity.

**The Crash**: The NetworkChart.draw(_:) method (Main Thread) iterates over this array to draw the paths. If the array is mutated by the background thread during this iteration, the bounds check fails (or the internal buffer is swapped out), triggering a SIGTRAP (assertion failure) for Index Out of Bounds.

Similar Patterns in LineChart and BarChart:
Identified similar unprotected mutations of self._value and other state variables (pressureLevel, colorZones) from background threads while they were being read/copied on the Main Thread for drawing.

**The Fix**
The fix ensures that all state mutations in these widgets are dispatched to the Main Thread, strictly serializing them with the drawing cycle.

StackWidget.swift: Wrapped setValues mutation logic in DispatchQueue.main.async. This ensures the array underlying the UnsafeMutablePointer is only touched by the Main Thread.

NetworkChart.swift
: Wrapped setValue array mutation in DispatchQueue.main.async.

LineChart.swift / BarChart.swift
: Wrapped setValue, setPressure, and configuration setters in 
DispatchQueue.main.async.


### Verification
**Reproduction**: Confirmed SIGABRT in Kit.StackWidget.setValues and SIGTRAP in Kit.NetworkChart.draw via custom signal handlers and stack trace logging during extended debugging sessions.


**Stability Test**: After applying the fixes, the application ran stable for 182+ hours (7.6 days) with zero crashes or issues, confirming the resolution.
