### PR TITLE
Fix stale popup data when reopening a module popup

### DIFF
--- a/Kit/module/reader.swift
+++ b/Kit/module/reader.swift
@@ -148,6 +148,9 @@ open class Reader<T: Codable>: NSObject, ReaderInternal_p {
                 self.repeatTask?.start()
             }
             self.initlizalized = true
+        } else if (self.popup || self.sleep) && !self.active {
+            DispatchQueue.global(qos: .background).async { self.read() }
+            self.repeatTask?.start()
         } else {
             self.repeatTask?.start()
         }


### PR DESCRIPTION
Fixes #2140.

## Summary
High update intervals leave popup values stale on reopen. `Reader.start()` only primes a fresh read during initial setup, so when a popup reader pauses on close and is restarted on open, it waits for the next scheduled tick before showing current data. Add a branch that dispatches a background read when a popup or sleep reader reopens while inactive.

## Testing
- [x] `xcodebuild -project Stats.xcodeproj -scheme Stats -destination 'platform=macOS' -configuration Release archive CODE_SIGNING_ALLOWED=NO`
- [x] Verified on macOS: popup refreshes immediately on reopen with a 5s update interval