### PR TITLE
feat(RAM): add "Show decimals" toggle for Memory widget

### DIFF
--- a/Kit/Widgets/Memory.swift
+++ b/Kit/Widgets/Memory.swift
@@ -18,6 +18,7 @@ public class MemoryWidget: WidgetWrapper {
     private var pressureLevel: RAMPressure = .normal
     private var symbolsState: Bool = true
     private var colorState: SColor = .monochrome
+    public var showDecimalsState: Bool = true
     
     private let width: CGFloat = 50
     
@@ -52,6 +53,7 @@ public class MemoryWidget: WidgetWrapper {
             self.orderReversedState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_orderReversed", defaultValue: self.orderReversedState)
             self.symbolsState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_symbols", defaultValue: self.symbolsState)
             self.colorState = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_color", defaultValue: self.colorState.key))
+            self.showDecimalsState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_showDecimals", defaultValue: self.showDecimalsState)
         }
         
         if preview {
@@ -161,6 +163,10 @@ public class MemoryWidget: WidgetWrapper {
             PreferencesRow(localizedString("Reverse order"), component: switchView(
                 action: #selector(self.toggleOrder),
                 state: self.orderReversedState
+            )),
+            PreferencesRow(localizedString("Show decimals"), component: switchView(
+                action: #selector(self.toggleDecimals),
+                state: self.showDecimalsState
             ))
         ]))
         
@@ -179,6 +185,12 @@ public class MemoryWidget: WidgetWrapper {
         self.display()
     }
     
+    @objc private func toggleDecimals(_ sender: NSControl) {
+        self.showDecimalsState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_showDecimals", value: self.showDecimalsState)
+        self.display()
+    }
+
     @objc private func toggleColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
         if let newColor = SColor.allCases.first(where: { $0.key == key }) {

--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -191,17 +191,23 @@ public struct Units {
         }
     }
     
-    public func getReadableMemory(style: ByteCountFormatter.CountStyle = .file) -> String {
+    public func getReadableMemory(style: ByteCountFormatter.CountStyle = .file, fractionDigits: Int? = nil) -> String {
+        if let fractionDigits, fractionDigits == 0, abs(self.gigabytes) >= 1 {
+            let divisor: Double = style == .memory ? 1_073_741_824 : 1_000_000_000
+            let gb = Double(self.bytes) / divisor
+            return "\(Int(gb.rounded())) GB"
+        }
+
         let formatter: ByteCountFormatter = ByteCountFormatter()
         formatter.countStyle = style
         formatter.includesUnit = true
         formatter.isAdaptive = true
-        
+
         var value = formatter.string(fromByteCount: Int64(self.bytes))
         if let idx = value.lastIndex(of: ",") {
             value.replaceSubrange(idx...idx, with: ".")
         }
-        
+
         return value
     }
     

--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -178,8 +178,9 @@ public class RAM: Module {
                     circle_segment(value: value.compressed/total, color: self.compressedColor)
                 ])
             case let widget as MemoryWidget:
-                let free = Units(bytes: Int64(value.free)).getReadableMemory(style: .memory)
-                let used = Units(bytes: Int64(value.used)).getReadableMemory(style: .memory)
+                let fractionDigits: Int? = widget.showDecimalsState ? nil : 0
+                let free = Units(bytes: Int64(value.free)).getReadableMemory(style: .memory, fractionDigits: fractionDigits)
+                let used = Units(bytes: Int64(value.used)).getReadableMemory(style: .memory, fractionDigits: fractionDigits)
                 widget.setValue((free, used), usedPercentage: value.usage)
                 widget.setPressure(value.pressure.value)
             case let widget as Tachometer:


### PR DESCRIPTION
## Summary

- Adds a **"Show decimals"** toggle to the Memory widget settings (alongside Color, Show symbols, Reverse order)
- When disabled, GB values in the menu bar are rounded to the nearest whole number (e.g., `32 GB` instead of `32.39 GB`)
- Defaults to enabled, preserving current behavior for existing users

## Changes

| File | Change |
|------|--------|
| `Kit/helpers.swift` | Add optional `fractionDigits` parameter to `getReadableMemory()` |
| `Kit/Widgets/Memory.swift` | Add `showDecimalsState` setting with toggle UI |
| `Modules/RAM/main.swift` | Pass `fractionDigits: 0` when decimals are disabled |

## Screenshots

**Before (Show decimals: ON):**
```
F: 32.39 GB
U: 31.61 GB
```

**After (Show decimals: OFF):**
```
F: 32 GB
U: 32 GB
```

## Test plan

- [x] Build succeeds (Xcode, macOS 26, ad-hoc signing)
- [x] Toggle ON: values display with decimals (existing behavior)
- [x] Toggle OFF: values display as rounded whole numbers
- [x] Setting persists across app restarts via Store
- [x] Values below 1 GB still use ByteCountFormatter (MB display unaffected)

Closes #2993

🤖 Generated with [Claude Code](https://claude.com/claude-code)