### PR TITLE
fix: ensure full hitbox for combined modules when popup is disabled

### DIFF
--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -92,6 +92,9 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
                     }
                 }
             }
+            self.menuBarItem?.button?.target = self
+            self.menuBarItem?.button?.action = #selector(self.handleClick)
+            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
         } else {
             self.menuBarItem?.button?.target = self
             self.menuBarItem?.button?.action = #selector(self.togglePopup)
@@ -168,6 +171,27 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
         }
     }
     
+    @objc private func handleClick(_ sender: NSButton) {
+        let mouseLocation = sender.window?.mouseLocationOutsideOfEventStream ?? NSEvent.mouseLocation
+        let pointInView = sender.convert(mouseLocation, from: nil)
+        
+        for m in self.activeModules {
+            for w in m.menuBar.widgets {
+                if w.item.frame.contains(pointInView) {
+                    if let window = w.item.window {
+                        NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
+                            "module": m.name,
+                            "widget": w.type,
+                            "origin": window.frame.origin,
+                            "center": window.frame.width/2
+                        ])
+                    }
+                    return
+                }
+            }
+        }
+    }
+    
     @objc private func listenForOneView(_ notification: Notification) {
         guard notification.userInfo?["module"] == nil else { return }
         
@@ -198,7 +222,9 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
                     }
                 }
             }
-            self.menuBarItem?.button?.action = nil
+            self.menuBarItem?.button?.target = self
+            self.menuBarItem?.button?.action = #selector(self.handleClick)
+            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
         } else {
             self.activeModules.forEach { (m: Module) in
                 m.menuBar.widgets.forEach { w in


### PR DESCRIPTION
## Description

Fixes #2998

When combined modules popup is disabled (individual module popups enabled), the hitbox was smaller than expected because individual widgets have margins and don't fill the entire menu bar height. This made the top area unclickable, which was frustrating for users who expect to be able to move their mouse to the top of the screen.

## Changes

- Added a new `handleClick` method that captures clicks across the entire button area
- The method determines which widget was clicked based on mouse position and forwards the click appropriately
- Updated both initial setup and dynamic mode switching to use the new handler

## Testing

1. Enable Combined Modules
2. Disable 'Combined modules popup' in settings (so individual module popups are used)
3. Click on the top area of the combined module in the menu bar
4. The appropriate module popup should now open

## Technical Details

Individual widgets are positioned with a y-offset (`Constants.Widget.margin.y`) and have reduced height, leaving empty space at the top. The button was not capturing clicks in this area when popup mode was disabled. This fix ensures the button always captures clicks and forwards them to the correct widget.