### PR TITLE
Add a pinned RAM process/app memory widget

### DIFF
--- a/Kit/Widgets/Text.swift
+++ b/Kit/Widgets/Text.swift
@@ -98,3 +98,223 @@ public class TextWidget: WidgetWrapper {
         return pairs
     }
 }
+
+public class ProcessMemoryWidget: WidgetWrapper {
+    private var showIconState: Bool = true
+    private var showLabelState: Bool = true
+
+    private var selection: ProcessMemorySelection? = nil
+    private var value: TrackedProcessMemory? = nil
+
+    public init(title: String, config: NSDictionary?, preview: Bool = false) {
+        super.init(.processMemory, title: title, frame: CGRect(
+            x: 0,
+            y: Constants.Widget.margin.y,
+            width: 90,
+            height: Constants.Widget.height - (2 * Constants.Widget.margin.y)
+        ))
+
+        if preview {
+            let selection = ProcessMemorySelection(
+                pid: 0,
+                responsiblePid: 0,
+                name: "Fabriqa",
+                bundleIdentifier: nil,
+                mode: .application
+            )
+            self.selection = selection
+            self.value = TrackedProcessMemory(
+                selection: selection,
+                pid: nil,
+                name: "Fabriqa",
+                usage: 2.12 * Double(1024 * 1024 * 1024),
+                bundleIdentifier: nil
+            )
+        } else {
+            self.showIconState = Store.shared.bool(
+                key: "\(self.title)_\(self.type.rawValue)_showIcon",
+                defaultValue: self.showIconState
+            )
+            self.showLabelState = Store.shared.bool(
+                key: "\(self.title)_\(self.type.rawValue)_showLabel",
+                defaultValue: self.showLabelState
+            )
+            self.selection = ProcessMemorySelection.load(module: title)
+        }
+
+        self.canDrawConcurrently = true
+        self.updateTooltip()
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        var selection: ProcessMemorySelection? = nil
+        var value: TrackedProcessMemory? = nil
+        self.queue.sync {
+            selection = self.selection
+            value = self.value
+        }
+
+        let label = self.shortLabel(value?.displayName ?? selection?.displayName ?? localizedString("None"))
+        let usageValue = value?.usage == nil
+            ? "--"
+            : Units(bytes: Int64(value?.usage ?? 0)).getReadableMemory(style: .memory)
+        let icon = self.icon(selection: selection, value: value)
+        let iconSize: CGFloat = 14
+        let labelSize: CGFloat = 7
+        let valueSize: CGFloat = self.showLabelState ? 11 : 12
+
+        let style = NSMutableParagraphStyle()
+        style.alignment = .left
+
+        let labelAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: labelSize, weight: .light),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: style
+        ]
+        let valueAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: valueSize, weight: .regular),
+            .foregroundColor: NSColor.textColor,
+            .paragraphStyle: style
+        ]
+
+        let labelWidth = NSAttributedString(string: label, attributes: labelAttributes)
+            .boundingRect(with: CGSize(width: .greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude), options: [.usesLineFragmentOrigin, .usesFontLeading]).width
+        let valueWidth = NSAttributedString(string: usageValue, attributes: valueAttributes)
+            .boundingRect(with: CGSize(width: .greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude), options: [.usesLineFragmentOrigin, .usesFontLeading]).width
+
+        var x = Constants.Widget.margin.x
+        if self.showIconState {
+            let iconRect = CGRect(
+                x: x,
+                y: ((Constants.Widget.height - iconSize) / 2) - 0.5,
+                width: iconSize,
+                height: iconSize
+            )
+            icon.draw(in: iconRect)
+            x += iconSize + 4
+        }
+
+        let textWidth = max(labelWidth, valueWidth)
+        if self.showLabelState {
+            let labelRect = CGRect(
+                x: x,
+                y: 11.5,
+                width: textWidth,
+                height: labelSize + 1
+            )
+            NSAttributedString(string: label, attributes: labelAttributes).draw(with: labelRect)
+        }
+
+        let valueY: CGFloat = self.showLabelState ? 0.5 : ((Constants.Widget.height - valueSize) / 2) - 0.5
+        let valueRect = CGRect(
+            x: x,
+            y: valueY,
+            width: textWidth,
+            height: valueSize + 1
+        )
+        NSAttributedString(string: usageValue, attributes: valueAttributes).draw(with: valueRect)
+
+        let width = (x + textWidth + Constants.Widget.margin.x).roundedUpToNearestTen()
+        self.setWidth(width)
+    }
+
+    public func setSelection(_ selection: ProcessMemorySelection?) {
+        self.queue.sync {
+            self.selection = selection
+        }
+        self.updateTooltip()
+        DispatchQueue.main.async {
+            self.display()
+        }
+    }
+
+    public func setValue(_ value: TrackedProcessMemory?) {
+        self.queue.sync {
+            self.value = value
+            if let selection = value?.selection {
+                self.selection = selection
+            }
+        }
+        self.updateTooltip()
+        DispatchQueue.main.async {
+            self.display()
+        }
+    }
+
+    public override func settings() -> NSView {
+        let view = SettingsContainerView()
+        let selection = self.queue.sync { self.selection } ?? ProcessMemorySelection.load(module: self.title)
+        let trackedName = selection?.displayName ?? localizedString("None")
+        let trackingMode = selection?.mode.title ?? localizedString("None")
+
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Selected item"), component: textView(trackedName, alignment: .right)),
+            PreferencesRow(localizedString("Tracking"), component: textView(trackingMode, alignment: .right))
+        ]))
+
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Pictogram"), component: switchView(
+                action: #selector(self.toggleShowIcon),
+                state: self.showIconState
+            )),
+            PreferencesRow(localizedString("Label"), component: switchView(
+                action: #selector(self.toggleShowLabel),
+                state: self.showLabelState
+            ))
+        ]))
+
+        return view
+    }
+
+    @objc private func toggleShowIcon(_ sender: NSControl) {
+        self.showIconState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_showIcon", value: self.showIconState)
+        self.display()
+    }
+
+    @objc private func toggleShowLabel(_ sender: NSControl) {
+        self.showLabelState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_showLabel", value: self.showLabelState)
+        self.display()
+    }
+
+    private func shortLabel(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 10 else { return trimmed }
+        return "\(trimmed.prefix(9))…"
+    }
+
+    private func icon(selection: ProcessMemorySelection?, value: TrackedProcessMemory?) -> NSImage {
+        if let pid = value?.pid,
+           let app = NSRunningApplication(processIdentifier: pid_t(pid)),
+           let icon = app.icon {
+            return icon
+        }
+        if let bundleIdentifier = value?.bundleIdentifier ?? selection?.bundleIdentifier,
+           let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first,
+           let icon = app.icon {
+            return icon
+        }
+        if let pid = selection?.responsiblePid,
+           let app = NSRunningApplication(processIdentifier: pid_t(pid)),
+           let icon = app.icon {
+            return icon
+        }
+        return Constants.defaultProcessIcon
+    }
+
+    private func updateTooltip() {
+        let selection = self.queue.sync { self.selection }
+        let trackedName = selection?.displayName ?? localizedString("None")
+        let trackingMode = selection?.mode.title ?? localizedString("None")
+        DispatchQueue.main.async {
+            self.toolTip = "\(trackedName) (\(trackingMode))"
+        }
+    }
+}

--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -624,6 +624,85 @@ public struct TopProcess: Codable, Process_p {
     }
 }
 
+public enum ProcessMemoryTrackMode: String, Codable {
+    case process = "process"
+    case application = "application"
+
+    public var title: String {
+        switch self {
+        case .process: return localizedString("Single process")
+        case .application: return localizedString("Combined application")
+        }
+    }
+}
+
+public struct ProcessMemorySelection: Codable {
+    public let pid: Int
+    public let responsiblePid: Int
+    public let name: String
+    public let bundleIdentifier: String?
+    public let mode: ProcessMemoryTrackMode
+
+    public init(pid: Int, responsiblePid: Int, name: String, bundleIdentifier: String?, mode: ProcessMemoryTrackMode) {
+        self.pid = pid
+        self.responsiblePid = responsiblePid
+        self.name = name
+        self.bundleIdentifier = bundleIdentifier
+        self.mode = mode
+    }
+
+    public var displayName: String {
+        if !self.name.isEmpty {
+            return self.name
+        }
+        return "\(self.mode.title) \(self.mode == .application ? self.responsiblePid : self.pid)"
+    }
+
+    public static func storeKey(module: String) -> String {
+        "\(module)_processMemorySelection"
+    }
+
+    public static func load(module: String) -> ProcessMemorySelection? {
+        guard let raw = Store.shared.data(key: self.storeKey(module: module)),
+              let value = try? JSONDecoder().decode(ProcessMemorySelection.self, from: raw) else {
+            return nil
+        }
+        return value
+    }
+
+    public func save(module: String) {
+        guard let raw = try? JSONEncoder().encode(self) else { return }
+        Store.shared.set(key: Self.storeKey(module: module), value: raw)
+    }
+
+    public static func clear(module: String) {
+        Store.shared.remove(self.storeKey(module: module))
+    }
+}
+
+public struct TrackedProcessMemory: Codable {
+    public let selection: ProcessMemorySelection
+    public let pid: Int?
+    public let name: String
+    public let usage: Double?
+    public let bundleIdentifier: String?
+
+    public init(selection: ProcessMemorySelection, pid: Int?, name: String, usage: Double?, bundleIdentifier: String?) {
+        self.selection = selection
+        self.pid = pid
+        self.name = name
+        self.usage = usage
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    public var displayName: String {
+        if !self.name.isEmpty {
+            return self.name
+        }
+        return self.selection.displayName
+    }
+}
+
 public func fetchIOService(_ name: String) -> [NSDictionary]? {
     var iterator: io_iterator_t = io_iterator_t()
     var obj: io_registry_entry_t = 1

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -27,6 +27,7 @@ public enum widget_t: String {
     case tachometer = "tachometer"
     case state = "state"
     case text = "text"
+    case processMemory = "process_memory"
     
     public func new(module: String, config: NSDictionary, defaultWidget: widget_t) -> SWidget? {
         guard let widgetConfig: NSDictionary = config[self.rawValue] as? NSDictionary else { return nil }
@@ -78,6 +79,9 @@ public enum widget_t: String {
         case .text:
             preview = TextWidget(title: module, config: widgetConfig, preview: true)
             item = TextWidget(title: module, config: widgetConfig, preview: false)
+        case .processMemory:
+            preview = ProcessMemoryWidget(title: module, config: widgetConfig, preview: true)
+            item = ProcessMemoryWidget(title: module, config: widgetConfig, preview: false)
         default: break
         }
         
@@ -142,6 +146,7 @@ public enum widget_t: String {
         case .tachometer: return localizedString("Tachometer widget")
         case .state: return localizedString("State widget")
         case .text: return localizedString("Text widget")
+        case .processMemory: return localizedString("Process memory widget")
         default: return ""
         }
     }

--- a/Kit/process.swift
+++ b/Kit/process.swift
@@ -25,6 +25,11 @@ public class ProcessesView: NSStackView {
     }
     private var list: [ProcessView] = []
     private var colorViews: [ColorView] = []
+    public var contextualMenu: ((Process_p) -> NSMenu?)? {
+        didSet {
+            self.list.forEach { $0.contextualMenu = self.contextualMenu }
+        }
+    }
     
     public init(frame: NSRect, values: [ProcessHeader], n: Int = 0) {
         super.init(frame: frame)
@@ -37,6 +42,7 @@ public class ProcessesView: NSStackView {
         
         for _ in 0..<n {
             let view = ProcessView(n: values.count)
+            view.contextualMenu = self.contextualMenu
             self.addArrangedSubview(view)
             self.list.append(view)
         }
@@ -122,6 +128,8 @@ public class ProcessView: NSStackView {
     
     private var pid: Int? = nil
     private var lock: Bool = false
+    fileprivate var contextualMenu: ((Process_p) -> NSMenu?)? = nil
+    private var currentProcess: Process_p? = nil
     
     private var imageView: NSImageView = NSImageView()
     private var killView: NSButton = NSButton()
@@ -230,10 +238,21 @@ public class ProcessView: NSStackView {
     public override func mouseDown(with: NSEvent) {
         self.setLock(!self.lock)
     }
+
+    public override func rightMouseDown(with event: NSEvent) {
+        guard let process = self.currentProcess,
+              let menu = self.contextualMenu?(process),
+              menu.items.isEmpty == false else {
+            super.rightMouseDown(with: event)
+            return
+        }
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
     
     fileprivate func set(_ process: Process_p, _ values: [String]) {
         if self.lock && process.pid != self.pid { return }
         
+        self.currentProcess = process
         self.labelView.stringValue = process.name
         values.enumerated().forEach({ self.valueViews[$0.offset].stringValue = $0.element })
         self.imageView.image = process.icon
@@ -246,6 +265,7 @@ public class ProcessView: NSStackView {
         self.valueViews.forEach({ $0.stringValue = symbol })
         self.imageView.image = nil
         self.pid = nil
+        self.currentProcess = nil
         self.setLock(false)
         self.toolTip = symbol
     }

--- a/Modules/RAM/config.plist
+++ b/Modules/RAM/config.plist
@@ -99,6 +99,13 @@
 			<key>Order</key>
 			<integer>7</integer>
 		</dict>
+		<key>process_memory</key>
+		<dict>
+			<key>Default</key>
+			<false/>
+			<key>Order</key>
+			<integer>8</integer>
+		</dict>
 	</dict>
 	<key>Settings</key>
 	<dict>

--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -61,6 +61,7 @@ public class RAM: Module {
     
     private var usageReader: UsageReader? = nil
     private var processReader: ProcessReader? = nil
+    private var pinnedProcessReader: PinnedProcessReader? = nil
     
     private var splitValueState: Bool {
         return Store.shared.bool(key: "\(self.config.name)_splitValue", defaultValue: false)
@@ -115,6 +116,8 @@ public class RAM: Module {
         
         self.settingsView.callback = { [weak self] in
             self?.usageReader?.read()
+            self?.processReader?.read()
+            self?.pinnedProcessReader?.read()
         }
         self.settingsView.setInterval = { [weak self] value in
             self?.processReader?.read()
@@ -122,6 +125,7 @@ public class RAM: Module {
         }
         self.settingsView.setTopInterval = { [weak self] value in
             self?.processReader?.setInterval(value)
+            self?.pinnedProcessReader?.setInterval(value)
         }
         
         self.usageReader = UsageReader(.RAM) { [weak self] value in
@@ -132,6 +136,12 @@ public class RAM: Module {
                 self?.popupView.processCallback(list)
             }
         }
+        self.pinnedProcessReader = PinnedProcessReader(.RAM) { [weak self] value in
+            self?.loadTrackedProcess(value)
+        }
+        self.popupView.pinProcessCallback = { [weak self] process, mode in
+            self?.pinProcess(process, mode: mode)
+        }
         
         self.settingsView.callbackWhenUpdateNumberOfProcesses = { [weak self] in
             self?.popupView.numberOfProcessesUpdated()
@@ -140,7 +150,8 @@ public class RAM: Module {
             }
         }
         
-        self.setReaders([self.usageReader, self.processReader])
+        self.setReaders([self.usageReader, self.processReader, self.pinnedProcessReader])
+        self.syncPinnedProcessWidgets()
     }
     
     private func loadCallback(_ raw: RAM_Usage?) {
@@ -242,6 +253,46 @@ public class RAM: Module {
             }
             WidgetCenter.shared.reloadTimelines(ofKind: RAM_entry.kind)
             WidgetCenter.shared.reloadTimelines(ofKind: "UnitedWidget")
+        }
+    }
+
+    private func pinProcess(_ process: TopProcess, mode: ProcessMemoryTrackMode) {
+        let selection = ProcessReader.selection(for: process, mode: mode)
+        selection.save(module: self.config.name)
+        self.loadTrackedProcess(TrackedProcessMemory(
+            selection: selection,
+            pid: nil,
+            name: selection.displayName,
+            usage: nil,
+            bundleIdentifier: selection.bundleIdentifier
+        ))
+
+        if let widget = self.menuBar.widgets.first(where: { $0.type == .processMemory }), !widget.isActive {
+            widget.toggle(true)
+        }
+
+        DispatchQueue.global(qos: .background).async {
+            self.pinnedProcessReader?.read()
+        }
+    }
+
+    private func syncPinnedProcessWidgets(_ selection: ProcessMemorySelection? = nil) {
+        let target = selection ?? ProcessMemorySelection.load(module: self.config.name)
+        self.menuBar.widgets.forEach { widget in
+            if let processWidget = widget.item as? ProcessMemoryWidget {
+                processWidget.setSelection(target)
+            }
+        }
+    }
+
+    private func loadTrackedProcess(_ raw: TrackedProcessMemory?) {
+        let selection = raw?.selection ?? ProcessMemorySelection.load(module: self.config.name)
+
+        self.menuBar.widgets.forEach { widget in
+            if let processWidget = widget.item as? ProcessMemoryWidget {
+                processWidget.setSelection(selection)
+                processWidget.setValue(raw)
+            }
         }
     }
 }

--- a/Modules/RAM/popup.swift
+++ b/Modules/RAM/popup.swift
@@ -12,6 +12,16 @@
 import Cocoa
 import Kit
 
+private final class ProcessPinPayload: NSObject {
+    let process: TopProcess
+    let mode: ProcessMemoryTrackMode
+
+    init(process: TopProcess, mode: ProcessMemoryTrackMode) {
+        self.process = process
+        self.mode = mode
+    }
+}
+
 internal class Popup: PopupWrapper {
     private var grid: NSGridView? = nil
     
@@ -42,9 +52,13 @@ internal class Popup: PopupWrapper {
     private var processesInitialized: Bool = false
     
     private var processes: ProcessesView? = nil
+    public var pinProcessCallback: ((TopProcess, ProcessMemoryTrackMode) -> Void) = { _, _ in }
     
     private var numberOfProcesses: Int {
         Store.shared.int(key: "\(self.title)_processes", defaultValue: 8)
+    }
+    private var combinedProcessesState: Bool {
+        Store.shared.bool(key: "\(self.title)_combinedProcesses", defaultValue: false)
     }
     private var processesHeight: CGFloat {
         (self.processHeight*CGFloat(self.numberOfProcesses)) + (self.numberOfProcesses == 0 ? 0 : Constants.Popup.separatorHeight + 22)
@@ -205,6 +219,9 @@ internal class Popup: PopupWrapper {
             values: [(localizedString("Usage"), nil)],
             n: self.numberOfProcesses
         )
+        container.contextualMenu = { [weak self] process in
+            self?.processMenu(for: process)
+        }
         self.processes = container
         
         view.addSubview(separator)
@@ -278,6 +295,41 @@ internal class Popup: PopupWrapper {
             
             self.processesInitialized = true
         })
+    }
+
+    private func processMenu(for process: Process_p) -> NSMenu? {
+        guard let process = process as? TopProcess else { return nil }
+
+        let menu = NSMenu()
+        let pinProcessItem = NSMenuItem(
+            title: localizedString("Pin %0 process memory to the menu bar", process.name),
+            action: #selector(self.pinProcess),
+            keyEquivalent: ""
+        )
+        pinProcessItem.target = self
+        pinProcessItem.representedObject = ProcessPinPayload(process: process, mode: .process)
+
+        let pinApplicationItem = NSMenuItem(
+            title: localizedString("Pin %0 app memory to the menu bar", process.name),
+            action: #selector(self.pinProcess),
+            keyEquivalent: ""
+        )
+        pinApplicationItem.target = self
+        pinApplicationItem.representedObject = ProcessPinPayload(process: process, mode: .application)
+
+        if self.combinedProcessesState {
+            menu.addItem(pinApplicationItem)
+        } else {
+            menu.addItem(pinProcessItem)
+            menu.addItem(pinApplicationItem)
+        }
+
+        return menu
+    }
+
+    @objc private func pinProcess(_ sender: NSMenuItem) {
+        guard let payload = sender.representedObject as? ProcessPinPayload else { return }
+        self.pinProcessCallback(payload.process, payload.mode)
     }
     
     // MARK: - Settings

--- a/Modules/RAM/readers.swift
+++ b/Modules/RAM/readers.swift
@@ -123,86 +123,20 @@ public class ProcessReader: Reader<[TopProcess]> {
     
     public override func read() {
         if self.numberOfProcesses == 0 {
+            self.callback([])
             return
         }
-        
-        let task = Process()
-        task.launchPath = "/usr/bin/top"
-        if self.combinedProcesses {
-            task.arguments = ["-l", "1", "-o", "mem", "-stats", "pid,command,mem"]
-        } else {
-            task.arguments = ["-l", "1", "-o", "mem", "-n", "\(self.numberOfProcesses)", "-stats", "pid,command,mem"]
-        }
-        
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        
-        defer {
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
-        }
-        
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-        
-        do {
-            try task.run()
-        } catch let err {
-            error("top(): \(err.localizedDescription)", log: self.log)
-            return
-        }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8)
-        _ = String(data: errorData, encoding: .utf8)
-        guard let output, !output.isEmpty else { return }
-        
-        var processes: [TopProcess] = []
-        output.enumerateLines { (line, _) in
-            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
-                processes.append(ProcessReader.parseProcess(line))
-            }
-        }
-        
+
+        let processes = ProcessReader.fetchProcesses(
+            limit: self.combinedProcesses ? nil : self.numberOfProcesses,
+            log: self.log
+        )
         if !self.combinedProcesses {
             self.callback(processes)
             return
         }
-        
-        var processGroups: [String: [TopProcess]] = [:]
-        for process in processes {
-            let responsiblePid = ProcessReader.getResponsiblePid(process.pid)
-            let groupKey = "\(responsiblePid)"
-            
-            if processGroups[groupKey] != nil {
-                processGroups[groupKey]!.append(process)
-            } else {
-                processGroups[groupKey] = [process]
-            }
-        }
-        
-        var result: [TopProcess] = []
-        for (_, processes) in processGroups {
-            let totalUsage = processes.reduce(0) { $0 + $1.usage }
-            let firstProcess = processes.first!
-            let name: String
-            
-            if let app = NSRunningApplication(processIdentifier: pid_t(ProcessReader.getResponsiblePid(firstProcess.pid))),
-               let appName = app.localizedName {
-                name = appName
-            } else {
-                name = firstProcess.name
-            }
-            
-            result.append(TopProcess(
-                pid: ProcessReader.getResponsiblePid(firstProcess.pid),
-                name: name,
-                usage: totalUsage
-            ))
-        }
-        
-        result.sort { $0.usage > $1.usage }
+
+        let result = ProcessReader.combineProcesses(processes)
         self.callback(Array(result.prefix(self.numberOfProcesses)))
     }
     
@@ -223,6 +157,145 @@ public class ProcessReader: Reader<[TopProcess]> {
             return childPid
         }
         return Int(responsiblePid)
+    }
+
+    static func selection(for process: TopProcess, mode: ProcessMemoryTrackMode) -> ProcessMemorySelection {
+        let responsiblePid = self.getResponsiblePid(process.pid)
+
+        switch mode {
+        case .process:
+            return ProcessMemorySelection(
+                pid: process.pid,
+                responsiblePid: responsiblePid,
+                name: process.name,
+                bundleIdentifier: self.bundleIdentifier(for: process.pid),
+                mode: .process
+            )
+        case .application:
+            let name = self.applicationName(for: responsiblePid, fallback: process.name)
+            return ProcessMemorySelection(
+                pid: process.pid,
+                responsiblePid: responsiblePid,
+                name: name,
+                bundleIdentifier: self.bundleIdentifier(for: responsiblePid),
+                mode: .application
+            )
+        }
+    }
+
+    static func fetchProcesses(limit: Int? = nil, log: NextLog = NextLog.shared) -> [TopProcess] {
+        let task = Process()
+        task.launchPath = "/usr/bin/top"
+
+        var arguments = ["-l", "1", "-o", "mem"]
+        if let limit {
+            arguments += ["-n", "\(limit)"]
+        }
+        arguments += ["-stats", "pid,command,mem"]
+        task.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+
+        defer {
+            outputPipe.fileHandleForReading.closeFile()
+            errorPipe.fileHandleForReading.closeFile()
+        }
+
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+        } catch let err {
+            error("top(): \(err.localizedDescription)", log: log)
+            return []
+        }
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)
+        _ = String(data: errorData, encoding: .utf8)
+        guard let output, !output.isEmpty else { return [] }
+
+        var processes: [TopProcess] = []
+        output.enumerateLines { line, _ in
+            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
+                processes.append(ProcessReader.parseProcess(line))
+            }
+        }
+
+        return processes
+    }
+
+    static func combineProcesses(_ processes: [TopProcess]) -> [TopProcess] {
+        var processGroups: [String: [TopProcess]] = [:]
+        for process in processes {
+            let responsiblePid = self.getResponsiblePid(process.pid)
+            let groupKey = "\(responsiblePid)"
+
+            if processGroups[groupKey] != nil {
+                processGroups[groupKey]!.append(process)
+            } else {
+                processGroups[groupKey] = [process]
+            }
+        }
+
+        var result: [TopProcess] = []
+        for (_, processes) in processGroups {
+            let totalUsage = processes.reduce(0) { $0 + $1.usage }
+            let firstProcess = processes.first!
+            let responsiblePid = self.getResponsiblePid(firstProcess.pid)
+            let name = self.applicationName(for: responsiblePid, fallback: firstProcess.name)
+
+            result.append(TopProcess(
+                pid: responsiblePid,
+                name: name,
+                usage: totalUsage
+            ))
+        }
+
+        return result.sorted { $0.usage > $1.usage }
+    }
+
+    static func trackedProcess(for selection: ProcessMemorySelection, in processes: [TopProcess]) -> TopProcess? {
+        switch selection.mode {
+        case .application:
+            let combined = self.combineProcesses(processes)
+            if let process = combined.first(where: { $0.pid == selection.responsiblePid }) {
+                return process
+            }
+            if let bundleIdentifier = selection.bundleIdentifier,
+               let process = combined.first(where: { self.bundleIdentifier(for: $0.pid) == bundleIdentifier }) {
+                return process
+            }
+            return combined.first(where: { $0.name == selection.name })
+        case .process:
+            if let process = processes.first(where: { $0.pid == selection.pid }) {
+                return process
+            }
+            if let bundleIdentifier = selection.bundleIdentifier {
+                let matches = processes.filter { self.bundleIdentifier(for: $0.pid) == bundleIdentifier }
+                if matches.count == 1 {
+                    return matches[0]
+                }
+            }
+            let matches = processes.filter { $0.name == selection.name }
+            return matches.count == 1 ? matches[0] : nil
+        }
+    }
+
+    static func bundleIdentifier(for pid: Int) -> String? {
+        NSRunningApplication(processIdentifier: pid_t(pid))?.bundleIdentifier
+    }
+
+    private static func applicationName(for pid: Int, fallback: String) -> String {
+        if let app = NSRunningApplication(processIdentifier: pid_t(pid)),
+           let name = app.localizedName,
+           !name.isEmpty {
+            return name
+        }
+        return fallback
     }
     
     static public func parseProcess(_ raw: String) -> TopProcess {
@@ -273,5 +346,29 @@ public class ProcessReader: Reader<[TopProcess]> {
         }
         
         return TopProcess(pid: pid, name: name, usage: usage * Double(1000 * 1000))
+    }
+}
+
+public class PinnedProcessReader: Reader<TrackedProcessMemory> {
+    private let title: String = "RAM"
+
+    public override func setup() {
+        self.optional = true
+        self.setInterval(Store.shared.int(key: "\(self.title)_updateTopInterval", defaultValue: 1))
+    }
+
+    public override func read() {
+        guard let selection = ProcessMemorySelection.load(module: self.title) else { return }
+
+        let processes = ProcessReader.fetchProcesses(log: self.log)
+        let process = ProcessReader.trackedProcess(for: selection, in: processes)
+
+        self.callback(TrackedProcessMemory(
+            selection: selection,
+            pid: process?.pid,
+            name: process?.name ?? selection.displayName,
+            usage: process?.usage,
+            bundleIdentifier: process.flatMap { ProcessReader.bundleIdentifier(for: $0.pid) } ?? selection.bundleIdentifier
+        ))
     }
 }

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -213,6 +213,7 @@
 "Tachometer widget" = "Tachometer";
 "State widget" = "State widget";
 "Text widget" = "Text widget";
+"Process memory widget" = "Process memory";
 "Battery details widget" = "Battery details widget";
 "Show symbols" = "Show symbols";
 "Label widget" = "Label";
@@ -243,6 +244,10 @@
 "No available widgets to configure" = "No available widgets to configure";
 "No options to configure for the popup in this module" = "No options to configure for the popup in this module";
 "Process" = "Process";
+"Selected item" = "Selected item";
+"Tracking" = "Tracking";
+"Single process" = "Single process";
+"Combined application" = "Combined application";
 "Kill process" = "Kill process";
 "Keyboard shortcut" = "Keyboard shortcut";
 "Listening..." = "Listening...";
@@ -330,6 +335,8 @@
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";
 "Free RAM is" = "Free RAM is %0";
+"Pin %0 process memory to the menu bar" = "Pin %0 process memory to the menu bar";
+"Pin %0 app memory to the menu bar" = "Pin %0 app memory to the menu bar";
 
 // Disk
 "Show removable disks" = "Show removable disks";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -213,6 +213,7 @@
 "Tachometer widget" = "Tachometer";
 "State widget" = "State widget";
 "Text widget" = "Text widget";
+"Process memory widget" = "Process memory";
 "Battery details widget" = "Battery details widget";
 "Show symbols" = "Show symbols";
 "Label widget" = "Label";
@@ -243,6 +244,10 @@
 "No available widgets to configure" = "No available widgets to configure";
 "No options to configure for the popup in this module" = "No options to configure for the popup in this module";
 "Process" = "Process";
+"Selected item" = "Selected item";
+"Tracking" = "Tracking";
+"Single process" = "Single process";
+"Combined application" = "Combined application";
 "Kill process" = "Kill process";
 "Keyboard shortcut" = "Keyboard shortcut";
 "Listening..." = "Listening...";
@@ -330,6 +335,8 @@
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";
 "Free RAM is" = "Free RAM is %0";
+"Pin %0 process memory to the menu bar" = "Pin %0 process memory to the menu bar";
+"Pin %0 app memory to the menu bar" = "Pin %0 app memory to the menu bar";
 
 // Disk
 "Show removable disks" = "Show removable disks";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -213,6 +213,7 @@
 "Tachometer widget" = "Tachometer";
 "State widget" = "State widget";
 "Text widget" = "Text widget";
+"Process memory widget" = "Process memory";
 "Battery details widget" = "Battery details widget";
 "Show symbols" = "Show symbols";
 "Label widget" = "Label";
@@ -243,6 +244,10 @@
 "No available widgets to configure" = "No available widgets to configure";
 "No options to configure for the popup in this module" = "No options to configure for the popup in this module";
 "Process" = "Process";
+"Selected item" = "Selected item";
+"Tracking" = "Tracking";
+"Single process" = "Single process";
+"Combined application" = "Combined application";
 "Kill process" = "Kill process";
 "Keyboard shortcut" = "Keyboard shortcut";
 "Listening..." = "Listening...";
@@ -330,6 +335,8 @@
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";
 "Free RAM is" = "Free RAM is %0";
+"Pin %0 process memory to the menu bar" = "Pin %0 process memory to the menu bar";
+"Pin %0 app memory to the menu bar" = "Pin %0 app memory to the menu bar";
 
 // Disk
 "Show removable disks" = "Show removable disks";


### PR DESCRIPTION
<img  alt="image" src="https://github.com/user-attachments/assets/2e3c549e-06df-47e5-b214-0200cdbbcf6a" />


## Summary
- add a RAM menu bar widget that can show memory usage for a pinned process or a combined app group
- add popup actions to pin either a single process or the responsible parent app from the RAM top-processes list
- keep the pinned item updated using the existing RAM top-process refresh cadence

## Note
This was vibe-coded for my own workflow and it works for my need.

Please do not feel any pressure to accept or merge this if it does not fit the project direction or quality bar. I mainly wanted to share a working implementation because it would be great to have a feature like this in Stats if you think it makes sense.

## Manual check
- built locally with code signing disabled
- launched the debug app and verified the pinned process/app RAM widget behavior locally