### PR TITLE
fix: show adapter current and voltage with correct units

### DIFF
--- a/Modules/Battery/popup.swift
+++ b/Modules/Battery/popup.swift
@@ -302,8 +302,8 @@ internal class Popup: PopupWrapper {
             
             self.powerField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\(value.ACwatts) W"
             self.chargingStateField?.stringValue = value.isCharging ? localizedString("Yes") : localizedString("No")
-            self.chargingCurrentField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\(value.chargingCurrent) mA"
-            self.chargingVoltageField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\(value.chargingVoltage) mV"
+            self.chargingCurrentField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\((Double(value.chargingCurrent) / 1000).roundTo(decimalPlaces: 2)) A"
+            self.chargingVoltageField?.stringValue = value.isBatteryPowered ? localizedString("Not connected") : "\((Double(value.chargingVoltage) / 1000).roundTo(decimalPlaces: 2)) V"
         })
     }
     

--- a/Modules/Battery/readers.swift
+++ b/Modules/Battery/readers.swift
@@ -96,19 +96,28 @@ internal class UsageReader: Reader<Battery_Usage> {
                 self.usage.temperature = self.getTemperature() ?? 0
                 
                 var ACwatts: Int = 0
+                var adapterCurrent: Int = 0
+                var adapterVoltage: Int = 0
                 if let ACDetails = IOPSCopyExternalPowerAdapterDetails() {
                     if let ACList = ACDetails.takeRetainedValue() as? [String: Any] {
-                        guard let watts = ACList[kIOPSPowerAdapterWattsKey] else {
-                            return
+                        if let watts = self.anyToInt(ACList[kIOPSPowerAdapterWattsKey]) {
+                            ACwatts = watts
                         }
-                        ACwatts = Int(watts as! Int)
+                        adapterCurrent = self.anyToInt(ACList["Current"]) ?? 0
+                        adapterVoltage = self.anyToInt(ACList["AdapterVoltage"]) ?? 0
                     }
                 }
                 self.usage.ACwatts = ACwatts
+                self.usage.chargingCurrent = adapterCurrent
+                self.usage.chargingVoltage = adapterVoltage
                 
-                if let chargerData = self.getChargerData() {
-                    self.usage.chargingCurrent = chargerData["ChargingCurrent"] as? Int ?? 0
-                    self.usage.chargingVoltage = chargerData["ChargingVoltage"] as? Int ?? 0
+                if self.usage.chargingCurrent == 0 || self.usage.chargingVoltage == 0, let chargerData = self.getChargerData() {
+                    if self.usage.chargingCurrent == 0 {
+                        self.usage.chargingCurrent = chargerData["ChargingCurrent"] as? Int ?? 0
+                    }
+                    if self.usage.chargingVoltage == 0 {
+                        self.usage.chargingVoltage = chargerData["ChargingVoltage"] as? Int ?? 0
+                    }
                 }
                 
                 self.callback(self.usage)
@@ -154,6 +163,16 @@ internal class UsageReader: Reader<Battery_Usage> {
     private func getChargerData() -> [String: Any]? {
         if let chargerData = IORegistryEntryCreateCFProperty(service, "ChargerData" as CFString, kCFAllocatorDefault, 0) {
             return chargerData.takeRetainedValue() as? [String: Any]
+        }
+        return nil
+    }
+    
+    private func anyToInt(_ value: Any?) -> Int? {
+        if let v = value as? Int {
+            return v
+        }
+        if let v = value as? NSNumber {
+            return v.intValue
         }
         return nil
     }


### PR DESCRIPTION
Read adapter current/voltage from external power details and only fall back to charger data when needed, so current is populated reliably. Format charging values in the popup as A/V instead of mA/mV to match what users expect.

Before this change on Tahoe the battery details where:

<img width="273" height="128" alt="Screenshot 2026-03-12 at 12 01 38 PM" src="https://github.com/user-attachments/assets/f8db0fa9-6e70-4610-a4f4-3b755588711a" />

After this change, the battery details are:

<img width="276" height="130" alt="Screenshot 2026-03-12 at 11 57 53 AM" src="https://github.com/user-attachments/assets/aa80a179-979e-4fe9-8ea4-835b328a5559" />


Disclaimers:

1. This is my first MacOS / swift contribution and it was AI-assisted.
2. I have only tested on the current version of Tahoe (Version 26.3.1 (25D2128)) on a MacBook Air M3.
3. I didn't see any CONTRIBUTOR.md file so I am making this a bit blindly.