### PR TITLE
Add base M5 CPU and GPU core sensors

### DIFF
--- a/Modules/Sensors/values.swift
+++ b/Modules/Sensors/values.swift
@@ -464,7 +464,6 @@ internal let SensorsList: [Sensor] = [
     Sensor(key: "Tm0p", name: "Memory Proximity 1", group: .sensor, type: .temperature, platforms: Platform.m4Gen),
     Sensor(key: "Tm1p", name: "Memory Proximity 2", group: .sensor, type: .temperature, platforms: Platform.m4Gen),
     Sensor(key: "Tm2p", name: "Memory Proximity 3", group: .sensor, type: .temperature, platforms: Platform.m4Gen),
-
     
     // M5
     Sensor(key: "Tp00", name: "CPU efficiency core 1", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),


### PR DESCRIPTION
I was trialing with various SMC scripts I found attached to previous sensor update PRs/issues and took the that as basis to try to deduce the sensors on a base M5 Macbook Air. (10 CPU cores - 8 GPU Cores).

## CPU
I used both custom python scripts and Cinebench to try to differentiate the different cores. For P core tests, I ran a simple busyloop with 4 instances and those seemed to always land on the P cores. For E core tests, I ran same busyloop with 6 instances, and`taskpolicy -c background` to keep all the tasks on the E cores. E cores proved to be quite hard to discern this way, since the power usage of them is so low that the temperatures barely change. I thus also tried to run Cinebencg 2026 all core test with `taskpolicy -c background` and got a bit better results, but it is still quite fuzzy. The power only goes from like 3 -> 4.5 watts with this taskpolicy method.

For "all core" tests I ran the python script with 10 instances without any taskpolicy, and also Cinebench with all core render test. There is a interesting difference in core utilization with the simple Python busyloop test with 10 separate processes and Cinebench with more complex load and within single process. The Cinebench test uses 5-7W more power, but the P cores stay almost 10c cooler, while the E cores get way hotter. I don't know enough about MacOS internals to comment further, but I can only guess there is some optimization either on Apple's or Cinebench's side to optimize benchmark. Or maybe it is just an OS optimization to reduce load on P cores when there is a task that truly fully utilizes the CPU capabilities.

### CPU extras
In addition to the PR's definitions, there are 4 extras in CPU section, that seem to somewhat correlate with the CPU load.

- `Tp0O` seems to somewhat match the calculated average of the performance core values
- `Tp0R` seems to somwwhat match the average of all cores
- `Tp0p` and `Tp0u` are both in the P core range, but seem to have no other immediately obvious correlations

## GPU
These are most likely wrong, but at least a starting point maybe... Method included running `osx-bench` GPU test on loop and Cinebench 2026 GPU render test with multiple trials. These 8 sensors in the PR were the ones that consistently were the 8 hottest ones. Especially in Cinebench the delta between the 8th sensor and 9th sensor was around 1 degrees. In otherwords, in Cinebench a clear pattern of 8 cores could be separated from the Tg sensor set.

## Result Images

### CPU P cores only
#### Graph
<img width="1200" height="700" alt="full_p_core" src="https://github.com/user-attachments/assets/8db46138-da1e-48e0-acdf-de105adb8b76" />

#### Utilization
<img width="276" height="883" alt="full_p_core_util" src="https://github.com/user-attachments/assets/53d0c11d-0357-477c-8b27-30dd26ce3621" />

### CPU E cores only
#### Graph (cinebench)
<img width="1200" height="700" alt="full_e_core" src="https://github.com/user-attachments/assets/c9209342-a4db-4df0-ad59-a33cbe0b9f22" />

#### Utilization (cinebench)
<img width="275" height="877" alt="full_e_core_util" src="https://github.com/user-attachments/assets/8dd5a4c4-594c-4ed3-9901-d4d29a7e025f" />

### CPU All cores
#### Graph (python)
<img width="1200" height="700" alt="full_all_core_python" src="https://github.com/user-attachments/assets/3bff811c-cf6e-4296-8f0e-3dc19bcd48b7" />

#### Utilization (python)
<img width="275" height="873" alt="full_all_core_python_util" src="https://github.com/user-attachments/assets/63b8b5bc-2cc3-4444-a1bd-e2d1b2df901b" />

#### Graph (cinebench)
<img width="1200" height="700" alt="full_all_core_cinebench" src="https://github.com/user-attachments/assets/a28d10a9-0781-40cb-a0c1-06a75bb2f833" />

#### Utilization (cinebench)
<img width="271" height="875" alt="full_all_core_cinebench_util" src="https://github.com/user-attachments/assets/4e7d95bd-8e85-4176-8e78-f6e19d65c15f" />

