### PR TITLE
Update interface speed display to Mbps and enhance Wi-Fi handling

### DIFF
--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -447,7 +447,7 @@ internal class Popup: PopupWrapper {
                     self.interfaceField?.stringValue += ")"
                     self.interfaceStatusField?.stringValue = localizedString(interface.status ? "UP" : "DOWN")
                     self.macAddressField?.stringValue = interface.address
-                    self.interfaceSpeedField?.stringValue = "\(Int(interface.transmitRate.rounded()))baseT"
+                    self.interfaceSpeedField?.stringValue = "\(Int(interface.transmitRate.rounded()))Mbps"
                 } else {
                     self.interfaceField?.stringValue = localizedString("Unknown")
                     self.interfaceStatusField?.stringValue = localizedString("Unknown")

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -237,18 +237,26 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
                 continue
             }
             self.usage.interface?.status = (pointer.pointee.ifa_flags & UInt32(IFF_UP)) != 0
-            
-            if let raw = pointer.pointee.ifa_data {
-                let dataPtr = raw.assumingMemoryBound(to: if_data.self)
-                let ifData = dataPtr.pointee
-                let baud = UInt64(ifData.ifi_baudrate)
-                if baud > 0 {
-                    self.usage.interface?.transmitRate = Double(baud) / 1_000_000.0
+
+            // For Wi‑Fi, `if_data.ifi_baudrate` is often empty; use CoreWLAN.
+            if let wifiInterface = CWWiFiClient.shared().interface(withName: self.interfaceID) {
+                let rate = wifiInterface.transmitRate()
+                if rate > 0 {
+                    self.usage.interface?.transmitRate = rate
+                }
+            } else {
+                if let raw = pointer.pointee.ifa_data {
+                    let dataPtr = raw.assumingMemoryBound(to: if_data.self)
+                    let ifData = dataPtr.pointee
+                    let baud = UInt64(ifData.ifi_baudrate)
+                    if baud > 0 {
+                        self.usage.interface?.transmitRate = Double(baud) / 1_000_000.0
+                    }
                 }
             }
-            
+
             self.getLocalIP(pointer)
-            
+
             if let info = self.getBytesInfo(pointer) {
                 totalUpload += info.upload
                 totalDownload += info.download


### PR DESCRIPTION
This pull request improves the accuracy and clarity of network interface speed reporting in the `Modules/Net` module. fix #3028. The most important changes are grouped below by theme:

Accuracy improvements for Wi-Fi transmit rate:

* [`Modules/Net/readers.swift`](diffhunk://#diff-b989e3c0653d12da46746d7d294a22de7830cfbe67e24d984feb2c880547aca9R241-R247): Added logic to retrieve the Wi-Fi transmit rate using CoreWLAN (`CWWiFiClient`) when available, ensuring more accurate speed reporting for Wi-Fi interfaces.
* [`Modules/Net/readers.swift`](diffhunk://#diff-b989e3c0653d12da46746d7d294a22de7830cfbe67e24d984feb2c880547aca9R256): Adjusted the assignment of `transmitRate` to use the CoreWLAN value if present, otherwise fallback to the previous method.

User interface clarity:

* [`Modules/Net/popup.swift`](diffhunk://#diff-f0264ce5a85464a7fa90cb8fe5920a5785765a631d1a865253acb8db93b0d3c6L450-R450): Changed the display format for interface speed from `"baseT"` to `"Mbps"` for clearer and more standard presentation in the popup UI.