### PR TITLE
feat: M5 CPU core naming (super cores)

### DIFF
--- a/Kit/plugins/SystemKit.swift
+++ b/Kit/plugins/SystemKit.swift
@@ -64,6 +64,9 @@ public enum Platform: String, Codable {
     public static var m5Gen: [Platform] {
         return [.m5, .m5Pro, .m5Max, .m5Ultra]
     }
+    public static var m5ProAndAbove: [Platform] {
+        return [.m5Pro, .m5Max, .m5Ultra]
+    }
     
     public static var all: [Platform] {
         return apple + [.intel]
@@ -91,6 +94,23 @@ public enum coreType: Int, Codable {
     case unknown = -1
     case efficiency = 1
     case performance = 2
+
+    public func displayName(platform: Platform?) -> String {
+        switch self {
+        case .efficiency:
+            if let platform, Platform.m5ProAndAbove.contains(platform) {
+                return localizedString("Performance cores")
+            }
+            return localizedString("Efficiency cores")
+        case .performance:
+            if let platform, Platform.m5Gen.contains(platform) {
+                return localizedString("Super cores")
+            }
+            return localizedString("Performance cores")
+        default:
+            return localizedString("Unknown")
+        }
+    }
 }
 
 public struct model_s {

--- a/Modules/CPU/notifications.swift
+++ b/Modules/CPU/notifications.swift
@@ -104,12 +104,13 @@ class Notifications: NotificationsWrapper {
         ]))
         
         #if arch(arm64)
+        let platform = SystemKit.shared.device.platform
         self.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Efficiency cores load"), component: PreferencesSwitch(
+            PreferencesRow("\(coreType.efficiency.displayName(platform: platform)) \(localizedString("load"))", component: PreferencesSwitch(
                 action: self.toggleECoresLoad, state: self.eCoresLoadState,
                 with: StepperInput(self.eCoresLoad, callback: self.changeECoresLoad)
             )),
-            PreferencesRow(localizedString("Performance cores load"), component: PreferencesSwitch(
+            PreferencesRow("\(coreType.performance.displayName(platform: platform)) \(localizedString("load"))", component: PreferencesSwitch(
                 action: self.togglePCoresLoad, state: self.pCoresLoadState,
                 with: StepperInput(self.pCoresLoad, callback: self.changePCoresLoad)
             ))
@@ -139,13 +140,14 @@ class Notifications: NotificationsWrapper {
             self.checkDouble(id: self.userLoadID, value: value.userLoad, threshold: Double(self.userLoad)/100, title: title, subtitle: subtitle)
         }
         
+        let platform = SystemKit.shared.device.platform
         if self.eCoresLoadState, let usage = value.usageECores {
-            let subtitle = "\(localizedString("Efficiency cores load")): \(Int((usage)*100))%"
+            let subtitle = "\(coreType.efficiency.displayName(platform: platform)) \(localizedString("load")): \(Int((usage)*100))%"
             self.checkDouble(id: self.eCoresLoadID, value: usage, threshold: Double(self.eCoresLoad)/100, title: title, subtitle: subtitle)
         }
-        
+
         if self.pCoresLoadState, let usage = value.usagePCores {
-            let subtitle = "\(localizedString("Performance cores load")): \(Int((usage)*100))%"
+            let subtitle = "\(coreType.performance.displayName(platform: platform)) \(localizedString("load")): \(Int((usage)*100))%"
             self.checkDouble(id: self.pCoresLoadID, value: usage, threshold: Double(self.pCoresLoad)/100, title: title, subtitle: subtitle)
         }
     }

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -283,10 +283,12 @@ internal class Popup: PopupWrapper {
         }
         
         if SystemKit.shared.device.info.cpu?.eCores != nil {
-            (self.eCoresColorView, _, self.eCoresField) = popupWithColorRow(container, color: self.eCoresColor, title: "\(localizedString("Efficiency cores")):", value: "")
+            let eCoresLabel = coreType.efficiency.displayName(platform: SystemKit.shared.device.platform)
+            (self.eCoresColorView, _, self.eCoresField) = popupWithColorRow(container, color: self.eCoresColor, title: "\(eCoresLabel):", value: "")
         }
         if SystemKit.shared.device.info.cpu?.pCores != nil {
-            (self.pCoresColorView, _, self.pCoresField) = popupWithColorRow(container, color: self.pCoresColor, title: "\(localizedString("Performance cores")):", value: "")
+            let pCoresLabel = coreType.performance.displayName(platform: SystemKit.shared.device.platform)
+            (self.pCoresColorView, _, self.pCoresField) = popupWithColorRow(container, color: self.pCoresColor, title: "\(pCoresLabel):", value: "")
         }
         
         self.uptimeField = popupRow(container, title: "\(localizedString("Uptime")):", value: self.uptimeValue).1
@@ -328,10 +330,12 @@ internal class Popup: PopupWrapper {
         
         if isARM {
             if SystemKit.shared.device.info.cpu?.eCores != nil {
-                (self.eCoresFreqColorView, _, self.eCoresFreqField) = popupWithColorRow(container, color: self.eCoresColor, title: "\(localizedString("Efficiency cores")):", value: "")
+                let eCoresLabel = coreType.efficiency.displayName(platform: SystemKit.shared.device.platform)
+                (self.eCoresFreqColorView, _, self.eCoresFreqField) = popupWithColorRow(container, color: self.eCoresColor, title: "\(eCoresLabel):", value: "")
             }
             if SystemKit.shared.device.info.cpu?.pCores != nil {
-                (self.pCoresFreqColorView, _, self.pCoresFreqField) = popupWithColorRow(container, color: self.pCoresColor, title: "\(localizedString("Performance cores")):", value: "")
+                let pCoresLabel = coreType.performance.displayName(platform: SystemKit.shared.device.platform)
+                (self.pCoresFreqColorView, _, self.pCoresFreqField) = popupWithColorRow(container, color: self.pCoresColor, title: "\(pCoresLabel):", value: "")
             }
         }
         
@@ -546,13 +550,16 @@ internal class Popup: PopupWrapper {
             ))
         ]))
         
+        let platform = SystemKit.shared.device.platform
+        let eCoresSettingsLabel = "\(coreType.efficiency.displayName(platform: platform)) \(localizedString("Color").lowercased())"
+        let pCoresSettingsLabel = "\(coreType.performance.displayName(platform: platform)) \(localizedString("Color").lowercased())"
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Efficiency cores color"), component: selectView(
+            PreferencesRow(eCoresSettingsLabel, component: selectView(
                 action: #selector(self.toggleECoresColor),
                 items: SColor.allColors,
                 selected: self.eCoresColorState.key
             )),
-            PreferencesRow(localizedString("Performance cores color"), component: selectView(
+            PreferencesRow(pCoresSettingsLabel, component: selectView(
                 action: #selector(self.togglePCoresColor),
                 items: SColor.allColors,
                 selected: self.pCoresColorState.key

--- a/Modules/Sensors/values.swift
+++ b/Modules/Sensors/values.swift
@@ -472,11 +472,11 @@ internal let SensorsList: [Sensor] = [
     Sensor(key: "Tp0G", name: "CPU efficiency core 4", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
     Sensor(key: "Tp0X", name: "CPU efficiency core 5", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
     Sensor(key: "Tp0a", name: "CPU efficiency core 6", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
-    
-    Sensor(key: "Tp0y", name: "CPU performance core 1", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
-    Sensor(key: "Tp12", name: "CPU performance core 2", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
-    Sensor(key: "Tp16", name: "CPU performance core 3", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
-    Sensor(key: "Tp1E", name: "CPU performance core 4", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
+
+    Sensor(key: "Tp0y", name: "CPU super core 1", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
+    Sensor(key: "Tp12", name: "CPU super core 2", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
+    Sensor(key: "Tp16", name: "CPU super core 3", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
+    Sensor(key: "Tp1E", name: "CPU super core 4", group: .CPU, type: .temperature, platforms: Platform.m5Gen, average: true),
     
     Sensor(key: "Tg0U", name: "GPU 1", group: .GPU, type: .temperature, platforms: Platform.m5Gen, average: true),
     Sensor(key: "Tg0X", name: "GPU 2", group: .GPU, type: .temperature, platforms: Platform.m5Gen, average: true),

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -276,6 +276,7 @@
 "CPU usage is" = "CPU usage is %0";
 "Efficiency cores" = "Efficiency cores";
 "Performance cores" = "Performance cores";
+"Super cores" = "Super cores";
 "System color" = "System color";
 "User color" = "User color";
 "Idle color" = "Idle color";


### PR DESCRIPTION
## Summary

Adds Apple's M5 3-tier CPU core naming via a single `coreType.displayName(platform:)` method that resolves the correct label at runtime:

| Chip | Lower-tier cores | Top-tier cores |
|------|-----------------|----------------|
| M1–M4 (all) | Efficiency cores | Performance cores |
| M5 (base) | Efficiency cores | **Super cores** |
| M5 Pro/Max/Ultra | **Performance cores** | **Super cores** |

### Changes
- `coreType.displayName(platform:)` in SystemKit — single method, all label logic
- CPU popup details, frequency, and settings use dynamic labels
- CPU notifications use dynamic labels
- M5 sensor temperatures: renamed P-cores to "CPU super core 1–4"
- Added `"Super cores"` localization key

### Files changed (5)
`SystemKit.swift` · `popup.swift` · `notifications.swift` · `values.swift` · `Localizable.strings`

## Test plan
- [ ] M1–M4: labels unchanged (efficiency + performance)
- [ ] M5 base: efficiency + super cores
- [ ] M5 Pro/Max/Ultra: performance + super cores
- [ ] Build succeeds