### PR TITLE
Fix: Delete downloaded DMG when mounting fails; fix incorrect "Last updated" for when the pipeline errors

### DIFF
--- a/Kit/plugins/Updater.swift
+++ b/Kit/plugins/Updater.swift
@@ -186,7 +186,7 @@ public class Updater {
         print("Started new version installation...")
         
         _ = syncShell("mkdir /tmp/Stats") // make sure that directory exist
-        let res = syncShell("/usr/bin/hdiutil attach \(path) -mountpoint /tmp/Stats -noverify -nobrowse -noautoopen") // mount the dmg
+        let res = syncShell("/usr/bin/hdiutil attach \(path) -mountpoint /tmp/Stats -noverify -nobrowse -noautoopen 2>&1") // mount the dmg
         
         print("DMG is mounted")
         


### PR DESCRIPTION
Mounting the downloaded DMG during an auto update fails during edge cases, like when an MDM prevents DMG mounting (such as my work laptop). This causes problems because when it tries to update, it downloads the DMG, fails to mount it, and crashes. The DMG is also not deleted, and that leads to the same DMG downloading multiple times.

<img width="562" height="422" alt="image" src="https://github.com/user-attachments/assets/947e1e6a-20f9-4914-a39f-11e58b7f6379" />

Like this.

<hr />

This PR addresses the following two problems.
1. The updater now deletes the downloaded DMG if it fails to mount, and then gracefully exits.
2. the `defer` block which marks the timestamp when the latest update was installed, has been moved to the end of the flow, so it is only set when the updater function doesn't return preemptively.

The error message also shows properly. 

<img width="372" height="346" alt="image" src="https://github.com/user-attachments/assets/69effc8b-756e-4681-ba9c-5a22d5de98ee" />
