### PR TITLE
Add state widget to RAM module for memory pressure dot

### DIFF
--- a/Kit/Widgets/State.swift
+++ b/Kit/Widgets/State.swift
@@ -16,6 +16,7 @@ public class StateWidget: WidgetWrapper {
     private var nonactiveColorState: SColor = .secondRed
     
     private var value: Bool = false
+    private var _pressureLevel: RAMPressure?
     
     private var colors: [SColor] = SColor.allColors
     
@@ -56,8 +57,12 @@ public class StateWidget: WidgetWrapper {
         super.draw(dirtyRect)
         
         let circle = NSBezierPath(ovalIn: CGRect(x: Constants.Widget.margin.x, y: (self.frame.height - 8)/2, width: 8, height: 8))
-        let color = self.value ? self.activeColorState : self.nonactiveColorState
-        (color.additional as? NSColor)?.set()
+        if let pressure = self._pressureLevel {
+            pressure.pressureColor().set()
+        } else {
+            let color = self.value ? self.activeColorState : self.nonactiveColorState
+            (color.additional as? NSColor)?.set()
+        }
         circle.fill()
     }
     
@@ -66,6 +71,14 @@ public class StateWidget: WidgetWrapper {
         self.value = value
         DispatchQueue.main.async(execute: {
             self.display()
+        })
+    }
+
+    public func setPressure(_ newPressureLevel: RAMPressure) {
+        guard self._pressureLevel != newPressureLevel else { return }
+        self._pressureLevel = newPressureLevel
+        DispatchQueue.main.async(execute: {
+            self.needsDisplay = true
         })
     }
     

--- a/Modules/RAM/config.plist
+++ b/Modules/RAM/config.plist
@@ -92,12 +92,24 @@
 			<key>Order</key>
 			<integer>6</integer>
 		</dict>
+		<key>state</key>
+		<dict>
+			<key>Default</key>
+			<false/>
+			<key>Preview</key>
+			<dict>
+				<key>Value</key>
+				<true/>
+			</dict>
+			<key>Order</key>
+			<integer>7</integer>
+		</dict>
 		<key>text</key>
 		<dict>
 			<key>Default</key>
 			<false/>
 			<key>Order</key>
-			<integer>7</integer>
+			<integer>8</integer>
 		</dict>
 	</dict>
 	<key>Settings</key>

--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -188,6 +188,8 @@ public class RAM: Module {
                     circle_segment(value: value.wired/total, color: self.wiredColor),
                     circle_segment(value: value.compressed/total, color: self.compressedColor)
                 ])
+            case let widget as StateWidget:
+                widget.setPressure(value.pressure.value)
             case let widget as TextWidget:
                 var text = "\(self.textValue)"
                 let pairs = TextWidget.parseText(text)


### PR DESCRIPTION
Closes #3042

## Summary
- add the state (dot) widget to the RAM module
- the dot colors based on memory pressure: green for normal, yellow for warning, red for critical
- existing binary state behavior (Net module) is unchanged

## Test plan
- [ ] Enable the state widget in RAM settings
- [ ] Verify the dot appears green under normal pressure
- [ ] Simulate pressure with `sudo memory_pressure -l warn` and verify yellow
- [ ] Simulate pressure with `sudo memory_pressure -l critical` and verify red