### PR TITLE
Deal with Mac Studio DIE_0 and DIE_1 prefixes for CPU frequency stats

### DIFF
--- a/Modules/CPU/readers.swift
+++ b/Modules/CPU/readers.swift
@@ -372,14 +372,20 @@ public class FrequencyReader: Reader<CPU_Frequency> {
                 
                 for sample in samples {
                     guard sample.group == "CPU Stats" else { continue }
-                    if sample.channel.starts(with: "ECPU") {
+
+                    var channel = sample.channel
+                    if let range = channel.range(of: #"^DIE_\d+_"#, options: .regularExpression) {
+                        channel.removeSubrange(range)
+                    }
+
+                    if channel.starts(with: "ECPU") {
                         eCore.append(self.calculateFrequencies(dict: sample.delta, freqs: self.eCoreFreqs))
                     }
-                    if sample.channel.starts(with: self.sCoreCount == 0 ? "PCPU" : "MCPU") {
+                    if channel.starts(with: self.sCoreCount == 0 ? "PCPU" : "MCPU") {
                         pCore.append(self.calculateFrequencies(dict: sample.delta, freqs: self.pCoreFreqs))
                     }
                     if self.sCoreCount != 0 {
-                        if sample.channel.starts(with: "PCPU") {
+                        if channel.starts(with: "PCPU") {
                             sCore.append(self.calculateFrequencies(dict: sample.delta, freqs: self.sCoreFreqs))
                         }
                     }


### PR DESCRIPTION
Fixes #3086. On Mac Studio, these values are prefixed with `DIE_0_` and `DIE_1_`.

We don't have to use the regex route here, if you think it's not efficient enough. We could do simpler string checks instead. Let me know what you'd like. 