### PR TITLE
Fix combined module hitbox when details are disabled

### DIFF
--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -92,6 +92,9 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
                     }
                 }
             }
+            self.menuBarItem?.button?.target = self
+            self.menuBarItem?.button?.action = #selector(self.handleClick)
+            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
         } else {
             self.menuBarItem?.button?.target = self
             self.menuBarItem?.button?.action = #selector(self.togglePopup)
@@ -167,6 +170,25 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
             popup.setIsVisible(false)
         }
     }
+
+    @objc private func handleClick(_ sender: NSButton) {
+        let mouseLocation = sender.window?.mouseLocationOutsideOfEventStream ?? NSEvent.mouseLocation
+        let pointInView = sender.convert(mouseLocation, from: nil)
+
+        for m in self.activeModules {
+            for w in m.menuBar.widgets where w.item.frame.contains(pointInView) {
+                if let window = w.item.window {
+                    NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
+                        "module": m.name,
+                        "widget": w.type,
+                        "origin": window.frame.origin,
+                        "center": window.frame.width/2
+                    ])
+                }
+                return
+            }
+        }
+    }
     
     @objc private func listenForOneView(_ notification: Notification) {
         guard notification.userInfo?["module"] == nil else { return }
@@ -198,7 +220,9 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
                     }
                 }
             }
-            self.menuBarItem?.button?.action = nil
+            self.menuBarItem?.button?.target = self
+            self.menuBarItem?.button?.action = #selector(self.handleClick)
+            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
         } else {
             self.activeModules.forEach { (m: Module) in
                 m.menuBar.widgets.forEach { w in


### PR DESCRIPTION
Fixes #2998.

## Summary
- route combined status item button clicks through `handleClick(_:)` when the popup is disabled
- map the click position back to the underlying widget frame so the full visible combined module area is clickable
- keep the change scoped to `Stats/Views/CombinedView.swift`

## How to verify
1. Enable Combined Modules.
2. Disable combined details/popup.
3. Click near the top edge of the combined module area.
4. Confirm the expected module popup still opens and the full visible hitbox responds.

## Validation
- `swiftlint lint Stats/Views/CombinedView.swift` (0 serious violations)
- `xcodebuild -project Stats.xcodeproj -scheme Stats -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
  - local build reaches a pre-existing repository lint failure in `Kit/plugins/Charts.swift` unrelated to this change