### PR TITLE
fix: skip defunct processes in Disk ProcessReader to prevent crash on macOS 26

### DIFF
--- a/Modules/Disk/readers.swift
+++ b/Modules/Disk/readers.swift
@@ -462,7 +462,9 @@ public class ProcessReader: Reader<[Disk_process]> {
             // for disk I/O fields. Those values exceed Int64.max, so converting them to Int crashes
             // with a Swift precondition failure. There is no useful I/O data to display for a
             // defunct process anyway, so we skip them entirely.
-            guard name != "<defunct>" else { return }
+            // Note: we check pidFind.remain rather than the parsed name because findAndCrop uses
+            // "^[^ ]+" which won't match a leading space, leaving name as "" for defunct lines.
+            guard !pidFind.remain.contains("<defunct>") else { return }
 
             var usage = rusage_info_current()
             let result = withUnsafeMutablePointer(to: &usage) {


### PR DESCRIPTION
## What happened

The Stats Disk widget caused the app to **crash immediately on launch** on macOS 26.4 (25E246). The crash was reproducible every time the Disk widget was enabled — Stats would appear briefly in the process list, then vanish.

## Investigation

Crash reports in `~/Library/Logs/DiagnosticReports/` pointed to an `EXC_BREAKPOINT / brk 1` exception — a Swift runtime precondition failure — in `Disk.framework` on a background thread. The faulting stack showed:

```
Disk.framework (offset 153624) → StringProtocol.enumerateLines → Disk.framework (offset 156824) → crash
```

This mapped directly to `ProcessReader.read()` in `Modules/Disk/readers.swift`, inside the `enumerateLines` closure.

## Initial suspicion

The system had ~4.2 GB of swap in use (82% of 5 GB total) at the time of the crash. Our first hypothesis was that high swap pressure caused `proc_pid_rusage` to return out-of-range values for disk I/O fields — and that `Int(usage.ri_diskio_bytesread)` was crashing because the `UInt64` value exceeded `Int64.max`.

We also confirmed that `RUSAGE_INFO_CURRENT` changed from `RUSAGE_INFO_V5` to `RUSAGE_INFO_V6` in the macOS 26 SDK, which adds new fields to the struct. However, since `ri_diskio_bytesread` sits at the same offset (152 bytes) in both versions, the struct change was not the direct cause.

## Root cause

We wrote a small C diagnostic to scan all running PIDs with `proc_pid_rusage`:

```c
struct rusage_info_v5 ri;
proc_pid_rusage(pids[i], RUSAGE_INFO_V5, (rusage_info_t)&ri);
if (ri.ri_diskio_bytesread > (uint64_t)INT64_MAX ||
    ri.ri_diskio_byteswritten > (uint64_t)INT64_MAX) { ... }
```

This immediately identified the offending process:

```
PID 15738 OVERFLOW: read=28037120 written=18446744073709518848
```

PID 15738 was `<defunct>` — a zombie process. On macOS 26, calling `proc_pid_rusage` on a defunct PID causes the kernel to return `0xFFFFFFFFFFFF8000` (i.e. `-32768` as a signed value, a sentinel for "unavailable") in the `ri_diskio_byteswritten` field. That value is `18446744073709518848` as `UInt64`, which exceeds `Int64.max`. Swift's `Int(someUInt64)` crashes with a precondition failure when this happens.

The defunct process was left behind by a large application that had been force-quit under memory pressure — which is also why high swap appeared to be the trigger. It was a coincidence: the swap pressure caused the app to leave zombie processes, and *those* caused the crash.

## Fix

Two layers of protection in `ProcessReader.read()`:

1. **Guard against defunct processes** — skip any line from `ps` where the process name is `<defunct>`. These processes have no meaningful I/O data to display and their `proc_pid_rusage` results are unreliable.

2. **`Int(clamping:)`** — replaced the bare `Int(UInt64)` conversions with `Int(clamping:)` as a defensive fallback, in case any other unusual process state returns a sentinel value in the future.

Both changes include comments in the code explaining the exact failure mode.

## Reproduction environment

- **macOS**: 26.4 (Build 25E246)
- **Hardware**: Apple M5 Pro, 24 GB RAM
- **Stats version**: 2.12.5 and 2.12.7 (both affected)
- **Trigger**: a large application exits under memory pressure, leaving a defunct child process visible in the `ps` output

## Notes

This fix was developed collaboratively with [Claude](https://claude.ai) (Anthropic's AI assistant). The diagnosis involved reading crash reports, diffing `rusage_info_v5` vs `v6` struct layouts, and writing a C test to confirm the overflow. The fix itself is small and focused — easy to review, and the comments in the code explain the reasoning inline.