### PR TITLE
Use "read/write" instead of "upload/download" in Disk widget color labels.

### DIFF
--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -20,6 +20,7 @@ public class NetworkChart: WidgetWrapper {
     private var uploadColor: SColor = .secondRed
     private var scaleState: Scale = .linear
     private var reverseOrderState: Bool = false
+    private var colorNames: (download: String, upload: String) = ("Color of download", "Color of upload")
     
     private var points: [(Double, Double)] = Array(repeating: (0, 0), count: 60)
     
@@ -61,6 +62,10 @@ public class NetworkChart: WidgetWrapper {
             }
             if let unsupportedColors = config["Unsupported colors"] as? [String] {
                 self.colors = self.colors.filter{ !unsupportedColors.contains($0.key) }
+            }
+            if let colorConfig = config["Colors"] as? NSDictionary {
+                if let d = colorConfig["Download"] as? String { self.colorNames.download = d }
+                if let u = colorConfig["Upload"] as? String { self.colorNames.upload = u }
             }
         }
         
@@ -300,12 +305,12 @@ public class NetworkChart: WidgetWrapper {
                 action: #selector(self.toggleReverseOrder),
                 state: self.reverseOrderState
             )),
-            PreferencesRow(localizedString("Color of download"), component: selectView(
+            PreferencesRow(localizedString(self.colorNames.download), component: selectView(
                 action: #selector(self.toggleDownloadColor),
                 items: self.colors,
                 selected: self.downloadColor.key
             )),
-            PreferencesRow(localizedString("Color of upload"), component: selectView(
+            PreferencesRow(localizedString(self.colorNames.upload), component: selectView(
                 action: #selector(self.toggleUploadColor),
                 items: self.colors,
                 selected: self.uploadColor.key

--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -28,6 +28,7 @@ public class SpeedWidget: WidgetWrapper {
     
     private var symbols: (input: String, output: String) = ("I", "O")
     private var words: (input: String, output: String) = ("Input", "Output")
+    private var colorNames: (input: String, output: String) = ("Color of download", "Color of upload")
     
     private var inputValue: Int64 = 0
     private var outputValue: Int64 = 0
@@ -89,6 +90,10 @@ public class SpeedWidget: WidgetWrapper {
             if let words = config!["Words"] as? NSDictionary {
                 if let i = words["Input"] as? String { self.words.input = i }
                 if let o = words["Output"] as? String { self.words.output = o }
+            }
+            if let colors = config!["Colors"] as? NSDictionary {
+                if let i = colors["Input"] as? String { self.colorNames.input = i }
+                if let o = colors["Output"] as? String { self.colorNames.output = o }
             }
         }
         
@@ -559,12 +564,12 @@ public class SpeedWidget: WidgetWrapper {
                 action: #selector(self.toggleMonochrome),
                 state: self.monochromeState
             )),
-            PreferencesRow(localizedString("Color of download"), component: selectView(
+            PreferencesRow(localizedString(self.colorNames.input), component: selectView(
                 action: #selector(self.toggleInputColor),
                 items: SColor.allColors,
                 selected: self.inputColorState.key
             )),
-            PreferencesRow(localizedString("Color of upload"), component: selectView(
+            PreferencesRow(localizedString(self.colorNames.output), component: selectView(
                 action: #selector(self.toggleOutputColor),
                 items: SColor.allColors,
                 selected: self.outputColorState.key

--- a/Modules/Disk/config.plist
+++ b/Modules/Disk/config.plist
@@ -107,6 +107,13 @@
 				<key>Input</key>
 				<string>Read speed</string>
 			</dict>
+			<key>Colors</key>
+			<dict>
+				<key>Input</key>
+				<string>Read color</string>
+				<key>Output</key>
+				<string>Write color</string>
+			</dict>
 			<key>Order</key>
 			<integer>5</integer>
 		</dict>
@@ -124,6 +131,13 @@
 				<string>pressure</string>
 				<string>system</string>
 			</array>
+			<key>Colors</key>
+			<dict>
+				<key>Download</key>
+				<string>Read color</string>
+				<key>Upload</key>
+				<string>Write color</string>
+			</dict>
 		</dict>
 		<key>text</key>
 		<dict>


### PR DESCRIPTION
**Why**

It's confusing to have "Color of upload" and "Color of download" as the labels for Disk widget, because upload and download are not well defined in the context of a hard disk.

(If anything, I'd argue "download" more closely maps to "write". If you do a Google images search for "save icon arrow" you'll see that 90% of the arrows point down.)

We already use "Write color" and "Read color" as the color labels for configuring the Disk Popup, so it makes sense to use the same labels on the Widgets screen.

**How**

Make the color names configurable in `NetworkChart.swift` and set them to "Read color" and "Write color" just for the Disk widgets. Use the prior upload/download language as the default so we don't change the labels for Network widgets.

Note: I tested this locally and it seems to work, but I have no idea what I'm doing in swift. Thank you for this project!

<img width="1004" height="1320" alt="stats-disk-colors-read-write" src="https://github.com/user-attachments/assets/3265155b-49ce-4b5d-a93b-498bf06306eb" />

