### PR TITLE
feat: toggle normal or statusBar Window level

### DIFF
--- a/Kit/module/popup.swift
+++ b/Kit/module/popup.swift
@@ -82,6 +82,9 @@ public class PopupWindow: NSWindow, NSWindowDelegate {
         self.collectionBehavior = .moveToActiveSpace
         self.backgroundColor = .clear
         self.hasShadow = true
+        if Store.shared.bool(key: "popup_above_floating", defaultValue: false) {
+            self.level = .statusBar
+        }
         self.setIsVisible(false)
         self.delegate = self
     }

--- a/Stats/Views/AppSettings.swift
+++ b/Stats/Views/AppSettings.swift
@@ -22,6 +22,11 @@ class ApplicationSettings: NSStackView {
         set { Store.shared.set(key: "temperature_units", value: newValue) }
     }
     
+    private var popupAboveFloatingState: Bool {
+        get { Store.shared.bool(key: "popup_above_floating", defaultValue: false) }
+        set { Store.shared.set(key: "popup_above_floating", value: newValue) }
+    }
+
     private var combinedModulesState: Bool {
         get { Store.shared.bool(key: "CombinedModules", defaultValue: false) }
         set { Store.shared.set(key: "CombinedModules", value: newValue) }
@@ -105,7 +110,11 @@ class ApplicationSettings: NSStackView {
                 action: #selector(self.toggleDock),
                 state: Store.shared.bool(key: "dockIcon", defaultValue: false)
             )),
-            PreferencesRow(localizedString("Start at login"), component: self.startAtLoginBtn!)
+            PreferencesRow(localizedString("Start at login"), component: self.startAtLoginBtn!),
+            PreferencesRow(localizedString("Keep popups above other windows"), component: switchView(
+                action: #selector(self.togglePopupAboveFloating),
+                state: self.popupAboveFloatingState
+            ))
         ]))
         
         scrollView.stackView.addArrangedSubview(PreferencesSection([
@@ -327,6 +336,17 @@ class ApplicationSettings: NSStackView {
         LaunchAtLogin.isEnabled = sender.state == NSControl.StateValue.on
         if !Store.shared.exist(key: "runAtLoginInitialized") {
             Store.shared.set(key: "runAtLoginInitialized", value: true)
+        }
+    }
+
+    @objc private func togglePopupAboveFloating(_ sender: NSButton) {
+        let state = sender.state == NSControl.StateValue.on
+        self.popupAboveFloatingState = state
+        let newLevel: NSWindow.Level = state ? .statusBar : .normal
+        for window in NSApplication.shared.windows {
+            if window is PopupWindow {
+                window.level = newLevel
+            }
         }
     }
     


### PR DESCRIPTION
Allow module popups to be above other floating windows.

I use iTerm2 in floating window mode as a dropdown terminal. So when I opened a stats popup it was always behind my terminal. With this you can toggle it above all floating windows in the settings by setting the windowlevel to statusBar.

Before patch (or toggle off):
<img width="1797" height="957" alt="Screenshot 2026-04-16 at 20 28 00" src="https://github.com/user-attachments/assets/8fdc3066-c7f9-42c2-b158-166f6643d186" />

after patch with toggle on:
<img width="1800" height="977" alt="Screenshot 2026-04-16 at 20 28 10" src="https://github.com/user-attachments/assets/9d866fca-0086-4e53-984a-7914141ea140" />
