### PR TITLE
fix: improve RAM usage calculation and top processes

### DIFF
--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -118,6 +118,7 @@ public class RAM: Module {
         
         self.settingsView.callback = { [weak self] in
             self?.usageReader?.read()
+            self?.processReader?.read()
         }
         self.settingsView.setInterval = { [weak self] value in
             self?.processReader?.read()

--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -118,7 +118,6 @@ public class RAM: Module {
         
         self.settingsView.callback = { [weak self] in
             self?.usageReader?.read()
-            self?.processReader?.read()
         }
         self.settingsView.setInterval = { [weak self] value in
             self?.processReader?.read()

--- a/Modules/RAM/readers.swift
+++ b/Modules/RAM/readers.swift
@@ -10,11 +10,7 @@
 //
 
 import Cocoa
-import Darwin
 import Kit
-
-@_silgen_name("proc_pid_rusage")
-private func proc_pid_rusage_bridge(_ pid: Int32, _ flavor: Int32, _ buffer: UnsafeMutableRawPointer) -> Int32
 
 internal struct RAMMemoryBreakdown {
     let app: Double
@@ -23,12 +19,6 @@ internal struct RAMMemoryBreakdown {
     let cache: Double
     let used: Double
     let free: Double
-}
-
-internal struct RAMProcessSnapshot {
-    let pid: Int
-    let name: String
-    let usage: Double
 }
 
 internal class UsageReader: Reader<RAM_Usage> {
@@ -65,7 +55,6 @@ internal class UsageReader: Reader<RAM_Usage> {
         
         if result == KERN_SUCCESS {
             let active = Double(stats.active_count) * Double(vm_page_size)
-            let speculative = Double(stats.speculative_count) * Double(vm_page_size)
             let inactive = Double(stats.inactive_count) * Double(vm_page_size)
             let breakdown = Self.memoryBreakdown(
                 totalSize: self.totalSize,
@@ -118,7 +107,7 @@ internal class UsageReader: Reader<RAM_Usage> {
         
         error("host_statistics64(): \(String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error")", log: self.log)
     }
-    
+
     static func memoryBreakdown(totalSize: Double, stats: vm_statistics64, pageSize: Double) -> RAMMemoryBreakdown {
         let wired = Double(stats.wire_count) * pageSize
         let compressed = Double(stats.compressor_page_count) * pageSize
@@ -129,7 +118,7 @@ internal class UsageReader: Reader<RAM_Usage> {
         let cache = purgeable + external
         let used = min(max(app + wired + compressed, 0), totalSize)
         let free = max(totalSize - used, 0)
-        
+
         return RAMMemoryBreakdown(
             app: app,
             wired: wired,
@@ -163,32 +152,85 @@ public class ProcessReader: Reader<[TopProcess]> {
         if self.numberOfProcesses == 0 {
             return
         }
-        let snapshots = Self.readProcessSnapshots()
-        if !snapshots.isEmpty {
-            self.callback(Self.buildTopProcessList(
-                from: snapshots,
-                combined: self.combinedProcesses,
-                limit: self.numberOfProcesses
-            ))
+        
+        let task = Process()
+        task.launchPath = "/usr/bin/top"
+        if self.combinedProcesses {
+            task.arguments = ["-l", "1", "-o", "mem", "-stats", "pid,command,mem"]
+        } else {
+            task.arguments = ["-l", "1", "-o", "mem", "-n", "\(self.numberOfProcesses)", "-stats", "pid,command,mem"]
+        }
+        
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        
+        defer {
+            outputPipe.fileHandleForReading.closeFile()
+            errorPipe.fileHandleForReading.closeFile()
+        }
+        
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+        
+        do {
+            try task.run()
+        } catch let err {
+            error("top(): \(err.localizedDescription)", log: self.log)
             return
         }
         
-        let fallbackProcesses = Self.readTopProcesses(
-            arguments: self.combinedProcesses ?
-                ["-l", "1", "-o", "mem", "-stats", "pid,command,mem"] :
-                ["-l", "1", "-o", "mem", "-n", "\(self.numberOfProcesses)", "-stats", "pid,command,mem"],
-            log: self.log
-        )
-        guard !fallbackProcesses.isEmpty else { return }
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)
+        _ = String(data: errorData, encoding: .utf8)
+        guard let output, !output.isEmpty else { return }
         
-        let fallbackSnapshots = fallbackProcesses.map {
-            RAMProcessSnapshot(pid: $0.pid, name: $0.name, usage: $0.usage)
+        var processes: [TopProcess] = []
+        output.enumerateLines { (line, _) in
+            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
+                processes.append(ProcessReader.parseProcess(line))
+            }
         }
-        self.callback(Self.buildTopProcessList(
-            from: fallbackSnapshots,
-            combined: self.combinedProcesses,
-            limit: self.numberOfProcesses
-        ))
+        
+        if !self.combinedProcesses {
+            self.callback(processes)
+            return
+        }
+        
+        var processGroups: [String: [TopProcess]] = [:]
+        for process in processes {
+            let responsiblePid = ProcessReader.getResponsiblePid(process.pid)
+            let groupKey = "\(responsiblePid)"
+            
+            if processGroups[groupKey] != nil {
+                processGroups[groupKey]!.append(process)
+            } else {
+                processGroups[groupKey] = [process]
+            }
+        }
+        
+        var result: [TopProcess] = []
+        for (_, processes) in processGroups {
+            let totalUsage = processes.reduce(0) { $0 + $1.usage }
+            let firstProcess = processes.first!
+            let name: String
+            
+            if let app = NSRunningApplication(processIdentifier: pid_t(ProcessReader.getResponsiblePid(firstProcess.pid))),
+               let appName = app.localizedName {
+                name = appName
+            } else {
+                name = firstProcess.name
+            }
+            
+            result.append(TopProcess(
+                pid: ProcessReader.getResponsiblePid(firstProcess.pid),
+                name: name,
+                usage: totalUsage
+            ))
+        }
+        
+        result.sort { $0.usage > $1.usage }
+        self.callback(Array(result.prefix(self.numberOfProcesses)))
     }
     
     private static let dynGetResponsiblePidFunc: UnsafeMutableRawPointer? = {
@@ -208,206 +250,6 @@ public class ProcessReader: Reader<[TopProcess]> {
             return childPid
         }
         return Int(responsiblePid)
-    }
-    
-    static func localizedAppName(pid: Int) -> String? {
-        NSRunningApplication(processIdentifier: pid_t(pid))?.localizedName
-    }
-    
-    static func executablePath(pid: Int) -> String? {
-        var pathBuffer = [CChar](repeating: 0, count: 4096)
-        let length = proc_pidpath(pid_t(pid), &pathBuffer, UInt32(pathBuffer.count))
-        guard length > 0 else {
-            return nil
-        }
-        let path = String(cString: pathBuffer)
-        return path.isEmpty ? nil : path
-    }
-    
-    static func processName(pid: Int, executablePath: String? = nil) -> String {
-        if let executablePath {
-            let executableName = URL(fileURLWithPath: executablePath).lastPathComponent
-            if !executableName.isEmpty {
-                return executableName
-            }
-        }
-        
-        var nameBuffer = [CChar](repeating: 0, count: 1024)
-        let length = proc_name(pid_t(pid), &nameBuffer, UInt32(nameBuffer.count))
-        guard length > 0 else {
-            return "\(pid)"
-        }
-        
-        let name = String(cString: nameBuffer)
-        return name.isEmpty ? "\(pid)" : name
-    }
-    
-    static func bestProcessName(
-        pid: Int,
-        fallbackName: String,
-        executablePath: String? = nil,
-        preferAppName: Bool,
-        appNameProvider: ((Int) -> String?) = ProcessReader.localizedAppName
-    ) -> String {
-        if fallbackName.contains("com.apple.Virtua"), let appName = appNameProvider(pid), appName.contains("Docker") {
-            return "Docker"
-        }
-        
-        if preferAppName, let appName = appNameProvider(pid), !appName.isEmpty {
-            return appName
-        }
-        
-        if let executablePath {
-            let executableName = URL(fileURLWithPath: executablePath).lastPathComponent
-            if !executableName.isEmpty && executableName.count >= fallbackName.count {
-                return executableName
-            }
-        }
-        
-        if !fallbackName.isEmpty {
-            return fallbackName
-        }
-        
-        return appNameProvider(pid) ?? "\(pid)"
-    }
-    
-    static func buildTopProcessList(
-        from snapshots: [RAMProcessSnapshot],
-        combined: Bool,
-        limit: Int,
-        responsiblePidProvider: ((Int) -> Int) = ProcessReader.getResponsiblePid,
-        appNameProvider: ((Int) -> String?) = ProcessReader.localizedAppName
-    ) -> [TopProcess] {
-        let sortedSnapshots = snapshots.sorted { $0.usage > $1.usage }
-        guard combined else {
-            return Array(sortedSnapshots.prefix(limit)).map {
-                TopProcess(pid: $0.pid, name: $0.name, usage: $0.usage)
-            }
-        }
-        
-        var processGroups: [Int: [RAMProcessSnapshot]] = [:]
-        sortedSnapshots.forEach { snapshot in
-            let responsiblePid = responsiblePidProvider(snapshot.pid)
-            processGroups[responsiblePid, default: []].append(snapshot)
-        }
-        
-        let result = processGroups.map { (responsiblePid, group) in
-            let totalUsage = group.reduce(0) { $0 + $1.usage }
-            let fallbackName = group.first(where: { $0.pid == responsiblePid })?.name ?? group.first?.name ?? "\(responsiblePid)"
-            return TopProcess(
-                pid: responsiblePid,
-                name: bestProcessName(
-                    pid: responsiblePid,
-                    fallbackName: fallbackName,
-                    preferAppName: true,
-                    appNameProvider: appNameProvider
-                ),
-                usage: totalUsage
-            )
-        }
-        
-        return Array(result.sorted { $0.usage > $1.usage }.prefix(limit))
-    }
-    
-    private static func readProcessSnapshots() -> [RAMProcessSnapshot] {
-        let processCount = proc_listallpids(nil, 0)
-        guard processCount > 0 else {
-            return []
-        }
-        
-        var pids = [pid_t](repeating: 0, count: Int(processCount))
-        let written = proc_listallpids(&pids, Int32(MemoryLayout<pid_t>.stride * pids.count))
-        guard written > 0 else {
-            return []
-        }
-        
-        var snapshots: [RAMProcessSnapshot] = []
-        snapshots.reserveCapacity(Int(written) + 1)
-        
-        pids.prefix(Int(written)).forEach { pid in
-            guard pid > 0, let snapshot = self.readProcessSnapshot(pid: Int(pid)) else {
-                return
-            }
-            snapshots.append(snapshot)
-        }
-        
-        if let kernelTask = self.kernelTaskSnapshot() {
-            snapshots.append(kernelTask)
-        }
-        
-        return snapshots
-    }
-    
-    private static func readProcessSnapshot(pid: Int) -> RAMProcessSnapshot? {
-        var info = rusage_info_current()
-        let result = withUnsafeMutablePointer(to: &info) { pointer in
-            proc_pid_rusage_bridge(pid_t(pid), RUSAGE_INFO_CURRENT, UnsafeMutableRawPointer(pointer))
-        }
-        guard result == 0, info.ri_phys_footprint > 0 else {
-            return nil
-        }
-        
-        let executablePath = self.executablePath(pid: pid)
-        let fallbackName = self.processName(pid: pid, executablePath: executablePath)
-        let name = self.bestProcessName(
-            pid: pid,
-            fallbackName: fallbackName,
-            executablePath: executablePath,
-            preferAppName: false
-        )
-        
-        return RAMProcessSnapshot(pid: pid, name: name, usage: Double(info.ri_phys_footprint))
-    }
-    
-    private static func kernelTaskSnapshot() -> RAMProcessSnapshot? {
-        let processes = self.readTopProcesses(arguments: ["-l", "1", "-pid", "0", "-stats", "pid,command,mem"])
-        guard let process = processes.first(where: { $0.pid == 0 }) else {
-            return nil
-        }
-        return RAMProcessSnapshot(pid: process.pid, name: process.name, usage: process.usage)
-    }
-    
-    private static func readTopProcesses(arguments: [String], log: NextLog? = nil) -> [TopProcess] {
-        let task = Process()
-        task.launchPath = "/usr/bin/top"
-        task.arguments = arguments
-        
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        
-        defer {
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
-        }
-        
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-        
-        do {
-            try task.run()
-        } catch let err {
-            if let log {
-                error("top(): \(err.localizedDescription)", log: log)
-            }
-            return []
-        }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8)
-        _ = String(data: errorData, encoding: .utf8)
-        guard let output, !output.isEmpty else {
-            return []
-        }
-        
-        var processes: [TopProcess] = []
-        output.enumerateLines { (line, _) in
-            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
-                processes.append(ProcessReader.parseProcess(line))
-            }
-        }
-        
-        return processes
     }
     
     static public func parseProcess(_ raw: String) -> TopProcess {
@@ -448,7 +290,14 @@ public class ProcessReader: Reader<[TopProcess]> {
             usage *= 1000
         }
         
-        let name = bestProcessName(pid: pid, fallbackName: command, preferAppName: false)
+        var name: String = command
+        if let app = NSRunningApplication(processIdentifier: pid_t(pid)), let n = app.localizedName {
+            name = n
+        }
+        
+        if command.contains("com.apple.Virtua") && name.contains("Docker") {
+            name = "Docker"
+        }
         
         return TopProcess(pid: pid, name: name, usage: usage * Double(1000 * 1000))
     }

--- a/Modules/RAM/readers.swift
+++ b/Modules/RAM/readers.swift
@@ -10,7 +10,26 @@
 //
 
 import Cocoa
+import Darwin
 import Kit
+
+@_silgen_name("proc_pid_rusage")
+private func proc_pid_rusage_bridge(_ pid: Int32, _ flavor: Int32, _ buffer: UnsafeMutableRawPointer) -> Int32
+
+internal struct RAMMemoryBreakdown {
+    let app: Double
+    let wired: Double
+    let compressed: Double
+    let cache: Double
+    let used: Double
+    let free: Double
+}
+
+internal struct RAMProcessSnapshot {
+    let pid: Int
+    let name: String
+    let usage: Double
+}
 
 internal class UsageReader: Reader<RAM_Usage> {
     public var totalSize: Double = 0
@@ -48,15 +67,13 @@ internal class UsageReader: Reader<RAM_Usage> {
             let active = Double(stats.active_count) * Double(vm_page_size)
             let speculative = Double(stats.speculative_count) * Double(vm_page_size)
             let inactive = Double(stats.inactive_count) * Double(vm_page_size)
-            let wired = Double(stats.wire_count) * Double(vm_page_size)
-            let compressed = Double(stats.compressor_page_count) * Double(vm_page_size)
-            let purgeable = Double(stats.purgeable_count) * Double(vm_page_size)
-            let external = Double(stats.external_page_count) * Double(vm_page_size)
+            let breakdown = Self.memoryBreakdown(
+                totalSize: self.totalSize,
+                stats: stats,
+                pageSize: Double(vm_page_size)
+            )
             let swapins = Int64(stats.swapins)
             let swapouts = Int64(stats.swapouts)
-            
-            let used = active + inactive + speculative + wired + compressed - purgeable - external
-            let free = self.totalSize - used
             
             var intSize: size_t = MemoryLayout<uint>.size
             var pressureLevel: Int = 0
@@ -75,16 +92,16 @@ internal class UsageReader: Reader<RAM_Usage> {
             
             self.callback(RAM_Usage(
                 total: self.totalSize,
-                used: used,
-                free: free,
+                used: breakdown.used,
+                free: breakdown.free,
                 
                 active: active,
                 inactive: inactive,
-                wired: wired,
-                compressed: compressed,
+                wired: breakdown.wired,
+                compressed: breakdown.compressed,
                 
-                app: used - wired - compressed,
-                cache: purgeable + external,
+                app: breakdown.app,
+                cache: breakdown.cache,
                 
                 swap: Swap(
                     total: Double(swap.xsu_total),
@@ -100,6 +117,27 @@ internal class UsageReader: Reader<RAM_Usage> {
         }
         
         error("host_statistics64(): \(String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error")", log: self.log)
+    }
+    
+    static func memoryBreakdown(totalSize: Double, stats: vm_statistics64, pageSize: Double) -> RAMMemoryBreakdown {
+        let wired = Double(stats.wire_count) * pageSize
+        let compressed = Double(stats.compressor_page_count) * pageSize
+        let purgeable = Double(stats.purgeable_count) * pageSize
+        let external = Double(stats.external_page_count) * pageSize
+        let appPages = max(Int64(stats.internal_page_count) - Int64(stats.purgeable_count), 0)
+        let app = Double(appPages) * pageSize
+        let cache = purgeable + external
+        let used = min(max(app + wired + compressed, 0), totalSize)
+        let free = max(totalSize - used, 0)
+        
+        return RAMMemoryBreakdown(
+            app: app,
+            wired: wired,
+            compressed: compressed,
+            cache: cache,
+            used: used,
+            free: free
+        )
     }
 }
 
@@ -125,85 +163,32 @@ public class ProcessReader: Reader<[TopProcess]> {
         if self.numberOfProcesses == 0 {
             return
         }
-        
-        let task = Process()
-        task.launchPath = "/usr/bin/top"
-        if self.combinedProcesses {
-            task.arguments = ["-l", "1", "-o", "mem", "-stats", "pid,command,mem"]
-        } else {
-            task.arguments = ["-l", "1", "-o", "mem", "-n", "\(self.numberOfProcesses)", "-stats", "pid,command,mem"]
-        }
-        
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        
-        defer {
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
-        }
-        
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-        
-        do {
-            try task.run()
-        } catch let err {
-            error("top(): \(err.localizedDescription)", log: self.log)
-            return
-        }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8)
-        _ = String(data: errorData, encoding: .utf8)
-        guard let output, !output.isEmpty else { return }
-        
-        var processes: [TopProcess] = []
-        output.enumerateLines { (line, _) in
-            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
-                processes.append(ProcessReader.parseProcess(line))
-            }
-        }
-        
-        if !self.combinedProcesses {
-            self.callback(processes)
-            return
-        }
-        
-        var processGroups: [String: [TopProcess]] = [:]
-        for process in processes {
-            let responsiblePid = ProcessReader.getResponsiblePid(process.pid)
-            let groupKey = "\(responsiblePid)"
-            
-            if processGroups[groupKey] != nil {
-                processGroups[groupKey]!.append(process)
-            } else {
-                processGroups[groupKey] = [process]
-            }
-        }
-        
-        var result: [TopProcess] = []
-        for (_, processes) in processGroups {
-            let totalUsage = processes.reduce(0) { $0 + $1.usage }
-            let firstProcess = processes.first!
-            let name: String
-            
-            if let app = NSRunningApplication(processIdentifier: pid_t(ProcessReader.getResponsiblePid(firstProcess.pid))),
-               let appName = app.localizedName {
-                name = appName
-            } else {
-                name = firstProcess.name
-            }
-            
-            result.append(TopProcess(
-                pid: ProcessReader.getResponsiblePid(firstProcess.pid),
-                name: name,
-                usage: totalUsage
+        let snapshots = Self.readProcessSnapshots()
+        if !snapshots.isEmpty {
+            self.callback(Self.buildTopProcessList(
+                from: snapshots,
+                combined: self.combinedProcesses,
+                limit: self.numberOfProcesses
             ))
+            return
         }
         
-        result.sort { $0.usage > $1.usage }
-        self.callback(Array(result.prefix(self.numberOfProcesses)))
+        let fallbackProcesses = Self.readTopProcesses(
+            arguments: self.combinedProcesses ?
+                ["-l", "1", "-o", "mem", "-stats", "pid,command,mem"] :
+                ["-l", "1", "-o", "mem", "-n", "\(self.numberOfProcesses)", "-stats", "pid,command,mem"],
+            log: self.log
+        )
+        guard !fallbackProcesses.isEmpty else { return }
+        
+        let fallbackSnapshots = fallbackProcesses.map {
+            RAMProcessSnapshot(pid: $0.pid, name: $0.name, usage: $0.usage)
+        }
+        self.callback(Self.buildTopProcessList(
+            from: fallbackSnapshots,
+            combined: self.combinedProcesses,
+            limit: self.numberOfProcesses
+        ))
     }
     
     private static let dynGetResponsiblePidFunc: UnsafeMutableRawPointer? = {
@@ -223,6 +208,206 @@ public class ProcessReader: Reader<[TopProcess]> {
             return childPid
         }
         return Int(responsiblePid)
+    }
+    
+    static func localizedAppName(pid: Int) -> String? {
+        NSRunningApplication(processIdentifier: pid_t(pid))?.localizedName
+    }
+    
+    static func executablePath(pid: Int) -> String? {
+        var pathBuffer = [CChar](repeating: 0, count: 4096)
+        let length = proc_pidpath(pid_t(pid), &pathBuffer, UInt32(pathBuffer.count))
+        guard length > 0 else {
+            return nil
+        }
+        let path = String(cString: pathBuffer)
+        return path.isEmpty ? nil : path
+    }
+    
+    static func processName(pid: Int, executablePath: String? = nil) -> String {
+        if let executablePath {
+            let executableName = URL(fileURLWithPath: executablePath).lastPathComponent
+            if !executableName.isEmpty {
+                return executableName
+            }
+        }
+        
+        var nameBuffer = [CChar](repeating: 0, count: 1024)
+        let length = proc_name(pid_t(pid), &nameBuffer, UInt32(nameBuffer.count))
+        guard length > 0 else {
+            return "\(pid)"
+        }
+        
+        let name = String(cString: nameBuffer)
+        return name.isEmpty ? "\(pid)" : name
+    }
+    
+    static func bestProcessName(
+        pid: Int,
+        fallbackName: String,
+        executablePath: String? = nil,
+        preferAppName: Bool,
+        appNameProvider: ((Int) -> String?) = ProcessReader.localizedAppName
+    ) -> String {
+        if fallbackName.contains("com.apple.Virtua"), let appName = appNameProvider(pid), appName.contains("Docker") {
+            return "Docker"
+        }
+        
+        if preferAppName, let appName = appNameProvider(pid), !appName.isEmpty {
+            return appName
+        }
+        
+        if let executablePath {
+            let executableName = URL(fileURLWithPath: executablePath).lastPathComponent
+            if !executableName.isEmpty && executableName.count >= fallbackName.count {
+                return executableName
+            }
+        }
+        
+        if !fallbackName.isEmpty {
+            return fallbackName
+        }
+        
+        return appNameProvider(pid) ?? "\(pid)"
+    }
+    
+    static func buildTopProcessList(
+        from snapshots: [RAMProcessSnapshot],
+        combined: Bool,
+        limit: Int,
+        responsiblePidProvider: ((Int) -> Int) = ProcessReader.getResponsiblePid,
+        appNameProvider: ((Int) -> String?) = ProcessReader.localizedAppName
+    ) -> [TopProcess] {
+        let sortedSnapshots = snapshots.sorted { $0.usage > $1.usage }
+        guard combined else {
+            return Array(sortedSnapshots.prefix(limit)).map {
+                TopProcess(pid: $0.pid, name: $0.name, usage: $0.usage)
+            }
+        }
+        
+        var processGroups: [Int: [RAMProcessSnapshot]] = [:]
+        sortedSnapshots.forEach { snapshot in
+            let responsiblePid = responsiblePidProvider(snapshot.pid)
+            processGroups[responsiblePid, default: []].append(snapshot)
+        }
+        
+        let result = processGroups.map { (responsiblePid, group) in
+            let totalUsage = group.reduce(0) { $0 + $1.usage }
+            let fallbackName = group.first(where: { $0.pid == responsiblePid })?.name ?? group.first?.name ?? "\(responsiblePid)"
+            return TopProcess(
+                pid: responsiblePid,
+                name: bestProcessName(
+                    pid: responsiblePid,
+                    fallbackName: fallbackName,
+                    preferAppName: true,
+                    appNameProvider: appNameProvider
+                ),
+                usage: totalUsage
+            )
+        }
+        
+        return Array(result.sorted { $0.usage > $1.usage }.prefix(limit))
+    }
+    
+    private static func readProcessSnapshots() -> [RAMProcessSnapshot] {
+        let processCount = proc_listallpids(nil, 0)
+        guard processCount > 0 else {
+            return []
+        }
+        
+        var pids = [pid_t](repeating: 0, count: Int(processCount))
+        let written = proc_listallpids(&pids, Int32(MemoryLayout<pid_t>.stride * pids.count))
+        guard written > 0 else {
+            return []
+        }
+        
+        var snapshots: [RAMProcessSnapshot] = []
+        snapshots.reserveCapacity(Int(written) + 1)
+        
+        pids.prefix(Int(written)).forEach { pid in
+            guard pid > 0, let snapshot = self.readProcessSnapshot(pid: Int(pid)) else {
+                return
+            }
+            snapshots.append(snapshot)
+        }
+        
+        if let kernelTask = self.kernelTaskSnapshot() {
+            snapshots.append(kernelTask)
+        }
+        
+        return snapshots
+    }
+    
+    private static func readProcessSnapshot(pid: Int) -> RAMProcessSnapshot? {
+        var info = rusage_info_current()
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            proc_pid_rusage_bridge(pid_t(pid), RUSAGE_INFO_CURRENT, UnsafeMutableRawPointer(pointer))
+        }
+        guard result == 0, info.ri_phys_footprint > 0 else {
+            return nil
+        }
+        
+        let executablePath = self.executablePath(pid: pid)
+        let fallbackName = self.processName(pid: pid, executablePath: executablePath)
+        let name = self.bestProcessName(
+            pid: pid,
+            fallbackName: fallbackName,
+            executablePath: executablePath,
+            preferAppName: false
+        )
+        
+        return RAMProcessSnapshot(pid: pid, name: name, usage: Double(info.ri_phys_footprint))
+    }
+    
+    private static func kernelTaskSnapshot() -> RAMProcessSnapshot? {
+        let processes = self.readTopProcesses(arguments: ["-l", "1", "-pid", "0", "-stats", "pid,command,mem"])
+        guard let process = processes.first(where: { $0.pid == 0 }) else {
+            return nil
+        }
+        return RAMProcessSnapshot(pid: process.pid, name: process.name, usage: process.usage)
+    }
+    
+    private static func readTopProcesses(arguments: [String], log: NextLog? = nil) -> [TopProcess] {
+        let task = Process()
+        task.launchPath = "/usr/bin/top"
+        task.arguments = arguments
+        
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        
+        defer {
+            outputPipe.fileHandleForReading.closeFile()
+            errorPipe.fileHandleForReading.closeFile()
+        }
+        
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+        
+        do {
+            try task.run()
+        } catch let err {
+            if let log {
+                error("top(): \(err.localizedDescription)", log: log)
+            }
+            return []
+        }
+        
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)
+        _ = String(data: errorData, encoding: .utf8)
+        guard let output, !output.isEmpty else {
+            return []
+        }
+        
+        var processes: [TopProcess] = []
+        output.enumerateLines { (line, _) in
+            if line.matches("^\\d+\\** +.* +\\d+[A-Z]*\\+?\\-? *$") {
+                processes.append(ProcessReader.parseProcess(line))
+            }
+        }
+        
+        return processes
     }
     
     static public func parseProcess(_ raw: String) -> TopProcess {
@@ -263,14 +448,7 @@ public class ProcessReader: Reader<[TopProcess]> {
             usage *= 1000
         }
         
-        var name: String = command
-        if let app = NSRunningApplication(processIdentifier: pid_t(pid)), let n = app.localizedName {
-            name = n
-        }
-        
-        if command.contains("com.apple.Virtua") && name.contains("Docker") {
-            name = "Docker"
-        }
+        let name = bestProcessName(pid: pid, fallbackName: command, preferAppName: false)
         
         return TopProcess(pid: pid, name: name, usage: usage * Double(1000 * 1000))
     }

--- a/Tests/RAM.swift
+++ b/Tests/RAM.swift
@@ -79,7 +79,7 @@ class RAM: XCTestCase {
         XCTAssertEqual(process.name, "Safari")
         XCTAssertEqual(process.usage, 658 * Double(1000 * 1000))
     }
-    
+
     func testMemoryBreakdownUsesAppWiredAndCompressedMemory() throws {
         var stats = vm_statistics64()
         stats.internal_page_count = 100
@@ -89,12 +89,11 @@ class RAM: XCTestCase {
         stats.external_page_count = 30
         stats.active_count = 40
         stats.inactive_count = 50
-        stats.speculative_count = 40
-        
+
         let pageSize = Double(4_096)
         let totalSize = Double(200) * pageSize
         let breakdown = UsageReader.memoryBreakdown(totalSize: totalSize, stats: stats, pageSize: pageSize)
-        
+
         XCTAssertEqual(breakdown.app, Double(90) * pageSize)
         XCTAssertEqual(breakdown.wired, Double(20) * pageSize)
         XCTAssertEqual(breakdown.compressed, Double(5) * pageSize)
@@ -102,68 +101,5 @@ class RAM: XCTestCase {
         XCTAssertEqual(breakdown.used, Double(115) * pageSize)
         XCTAssertEqual(breakdown.free, Double(85) * pageSize)
     }
-    
-    func testBuildTopProcessListKeepsRealProcessNamesInIndividualMode() throws {
-        let list = ProcessReader.buildTopProcessList(
-            from: [
-                RAMProcessSnapshot(pid: 101, name: "com.apple.WebKit.WebContent", usage: 800),
-                RAMProcessSnapshot(pid: 202, name: "Telegram", usage: 400)
-            ],
-            combined: false,
-            limit: 1,
-            responsiblePidProvider: { $0 },
-            appNameProvider: { _ in "Safari Web Content" }
-        )
-        
-        XCTAssertEqual(list.count, 1)
-        XCTAssertEqual(list[0].pid, 101)
-        XCTAssertEqual(list[0].name, "com.apple.WebKit.WebContent")
-        XCTAssertEqual(list[0].usage, 800)
-    }
-    
-    func testBuildTopProcessListCombinesResponsibleProcesses() throws {
-        let list = ProcessReader.buildTopProcessList(
-            from: [
-                RAMProcessSnapshot(pid: 11, name: "Codex Helper", usage: 500),
-                RAMProcessSnapshot(pid: 12, name: "Codex Helper (Renderer)", usage: 300),
-                RAMProcessSnapshot(pid: 21, name: "Telegram", usage: 600)
-            ],
-            combined: true,
-            limit: 2,
-            responsiblePidProvider: { pid in
-                switch pid {
-                case 11, 12: return 1
-                case 21: return 2
-                default: return pid
-                }
-            },
-            appNameProvider: { pid in
-                switch pid {
-                case 1: return "Codex"
-                case 2: return "Telegram"
-                default: return nil
-                }
-            }
-        )
-        
-        XCTAssertEqual(list.count, 2)
-        XCTAssertEqual(list[0].pid, 1)
-        XCTAssertEqual(list[0].name, "Codex")
-        XCTAssertEqual(list[0].usage, 800)
-        XCTAssertEqual(list[1].pid, 2)
-        XCTAssertEqual(list[1].name, "Telegram")
-        XCTAssertEqual(list[1].usage, 600)
-    }
-    
-    func testBestProcessNamePrefersExecutableNameOverLocalizedAppName() throws {
-        let name = ProcessReader.bestProcessName(
-            pid: 5726,
-            fallbackName: "Яндекс Музыка Helpe",
-            executablePath: "/Applications/Яндекс Музыка.app/Contents/Frameworks/Яндекс Музыка Helper (Renderer).app/Contents/MacOS/Яндекс Музыка Helper (Renderer)",
-            preferAppName: false,
-            appNameProvider: { _ in "Яндекс Музыка" }
-        )
-        
-        XCTAssertEqual(name, "Яндекс Музыка Helper (Renderer)")
-    }
+
 }

--- a/Tests/RAM.swift
+++ b/Tests/RAM.swift
@@ -10,7 +10,8 @@
 //
 
 import XCTest
-import RAM
+import Darwin
+@testable import RAM
 
 class RAM: XCTestCase {
     func testProcessReader_parseProcess() throws {
@@ -77,5 +78,92 @@ class RAM: XCTestCase {
         XCTAssertEqual(process.pid, 0)
         XCTAssertEqual(process.name, "Safari")
         XCTAssertEqual(process.usage, 658 * Double(1000 * 1000))
+    }
+    
+    func testMemoryBreakdownUsesAppWiredAndCompressedMemory() throws {
+        var stats = vm_statistics64()
+        stats.internal_page_count = 100
+        stats.purgeable_count = 10
+        stats.wire_count = 20
+        stats.compressor_page_count = 5
+        stats.external_page_count = 30
+        stats.active_count = 40
+        stats.inactive_count = 50
+        stats.speculative_count = 40
+        
+        let pageSize = Double(4_096)
+        let totalSize = Double(200) * pageSize
+        let breakdown = UsageReader.memoryBreakdown(totalSize: totalSize, stats: stats, pageSize: pageSize)
+        
+        XCTAssertEqual(breakdown.app, Double(90) * pageSize)
+        XCTAssertEqual(breakdown.wired, Double(20) * pageSize)
+        XCTAssertEqual(breakdown.compressed, Double(5) * pageSize)
+        XCTAssertEqual(breakdown.cache, Double(40) * pageSize)
+        XCTAssertEqual(breakdown.used, Double(115) * pageSize)
+        XCTAssertEqual(breakdown.free, Double(85) * pageSize)
+    }
+    
+    func testBuildTopProcessListKeepsRealProcessNamesInIndividualMode() throws {
+        let list = ProcessReader.buildTopProcessList(
+            from: [
+                RAMProcessSnapshot(pid: 101, name: "com.apple.WebKit.WebContent", usage: 800),
+                RAMProcessSnapshot(pid: 202, name: "Telegram", usage: 400)
+            ],
+            combined: false,
+            limit: 1,
+            responsiblePidProvider: { $0 },
+            appNameProvider: { _ in "Safari Web Content" }
+        )
+        
+        XCTAssertEqual(list.count, 1)
+        XCTAssertEqual(list[0].pid, 101)
+        XCTAssertEqual(list[0].name, "com.apple.WebKit.WebContent")
+        XCTAssertEqual(list[0].usage, 800)
+    }
+    
+    func testBuildTopProcessListCombinesResponsibleProcesses() throws {
+        let list = ProcessReader.buildTopProcessList(
+            from: [
+                RAMProcessSnapshot(pid: 11, name: "Codex Helper", usage: 500),
+                RAMProcessSnapshot(pid: 12, name: "Codex Helper (Renderer)", usage: 300),
+                RAMProcessSnapshot(pid: 21, name: "Telegram", usage: 600)
+            ],
+            combined: true,
+            limit: 2,
+            responsiblePidProvider: { pid in
+                switch pid {
+                case 11, 12: return 1
+                case 21: return 2
+                default: return pid
+                }
+            },
+            appNameProvider: { pid in
+                switch pid {
+                case 1: return "Codex"
+                case 2: return "Telegram"
+                default: return nil
+                }
+            }
+        )
+        
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list[0].pid, 1)
+        XCTAssertEqual(list[0].name, "Codex")
+        XCTAssertEqual(list[0].usage, 800)
+        XCTAssertEqual(list[1].pid, 2)
+        XCTAssertEqual(list[1].name, "Telegram")
+        XCTAssertEqual(list[1].usage, 600)
+    }
+    
+    func testBestProcessNamePrefersExecutableNameOverLocalizedAppName() throws {
+        let name = ProcessReader.bestProcessName(
+            pid: 5726,
+            fallbackName: "Яндекс Музыка Helpe",
+            executablePath: "/Applications/Яндекс Музыка.app/Contents/Frameworks/Яндекс Музыка Helper (Renderer).app/Contents/MacOS/Яндекс Музыка Helper (Renderer)",
+            preferAppName: false,
+            appNameProvider: { _ in "Яндекс Музыка" }
+        )
+        
+        XCTAssertEqual(name, "Яндекс Музыка Helper (Renderer)")
     }
 }


### PR DESCRIPTION
 
<img width="556" height="1682" alt="image" src="https://github.com/user-attachments/assets/1f6903f3-4469-4287-bee6-c1ece9ad3f5c" />



This PR fixes two RAM-related issues:

- the used memory value is now closer to Activity Monitor
- the top processes list now uses more accurate RAM data and preserves real process names in non-combined mode

### Changes

- adjusted RAM breakdown calculation in `Modules/RAM/readers.swift`
- switched top process memory usage to `proc_pid_rusage(..., ri_phys_footprint)`
- improved process name resolution for helper/web content processes
- refreshed the RAM process list immediately after RAM settings changes

### Tests

- updated `Tests/RAM.swift`
- verified with:

```bash
xcodebuild test \
  -project Stats.xcodeproj \
  -scheme Stats \
  -destination 'platform=macOS' \
  -only-testing:Tests/RAM \
  CODE_SIGNING_ALLOWED=NO \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGN_IDENTITY=''