### PR TITLE
feat: allow custom colors for widgets

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -273,7 +273,7 @@ public class BarChart: WidgetWrapper {
                 action: #selector(self.toggleLabel),
                 state: self.labelState
             )),
-            PreferencesRow(localizedString("Color"), component: selectView(
+            PreferencesRow(localizedString("Color"), component: colorSelectView(
                 action: #selector(self.toggleColor),
                 items: self.colors,
                 selected: self.colorState.key
@@ -319,11 +319,8 @@ public class BarChart: WidgetWrapper {
     
     @objc private func toggleColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = self.colors.first(where: { $0.key == key }) {
-            self.colorState = newColor
-        }
-        
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: key)
+        self.colorState = SColor.fromString(key, defaultValue: self.colorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: self.colorState.key)
         self.redraw()
     }
 }

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -290,7 +290,7 @@ public class LineChart: WidgetWrapper {
             )),
             PreferencesRow(localizedString("Box"), component: box),
             PreferencesRow(localizedString("Frame"), component: frame),
-            PreferencesRow(localizedString("Color"), component: selectView(
+            PreferencesRow(localizedString("Color"), component: colorSelectView(
                 action: #selector(self.toggleColor),
                 items: self.colors,
                 selected: self.colorState.key
@@ -354,10 +354,8 @@ public class LineChart: WidgetWrapper {
     
     @objc private func toggleColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = SColor.allCases.first(where: { $0.key == key }) {
-            self.colorState = newColor
-        }
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: key)
+        self.colorState = SColor.fromString(key, defaultValue: self.colorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: self.colorState.key)
         self.display()
     }
     

--- a/Kit/Widgets/Memory.swift
+++ b/Kit/Widgets/Memory.swift
@@ -149,7 +149,7 @@ public class MemoryWidget: WidgetWrapper {
         let view = SettingsContainerView()
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Color"), component: selectView(
+            PreferencesRow(localizedString("Color"), component: colorSelectView(
                 action: #selector(self.toggleColor),
                 items: SColor.allCases.filter({ $0 != .cluster }),
                 selected: self.colorState.key
@@ -181,10 +181,8 @@ public class MemoryWidget: WidgetWrapper {
     
     @objc private func toggleColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = SColor.allCases.first(where: { $0.key == key }) {
-            self.colorState = newColor
-        }
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: key)
+        self.colorState = SColor.fromString(key, defaultValue: self.colorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: self.colorState.key)
         self.display()
     }
 }

--- a/Kit/Widgets/Mini.swift
+++ b/Kit/Widgets/Mini.swift
@@ -201,7 +201,7 @@ public class Mini: WidgetWrapper {
                 action: #selector(self.toggleLabel),
                 state: self.labelState
             )),
-            PreferencesRow(localizedString("Color"), component: selectView(
+            PreferencesRow(localizedString("Color"), component: colorSelectView(
                 action: #selector(self.toggleColor),
                 items: self.colors,
                 selected: self.colorState.key
@@ -218,10 +218,8 @@ public class Mini: WidgetWrapper {
     
     @objc private func toggleColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = SColor.allCases.first(where: { $0.key == key }) {
-            self.colorState = newColor
-        }
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: key)
+        self.colorState = SColor.fromString(key, defaultValue: self.colorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: self.colorState.key)
         self.display()
     }
     

--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -300,12 +300,12 @@ public class NetworkChart: WidgetWrapper {
                 action: #selector(self.toggleReverseOrder),
                 state: self.reverseOrderState
             )),
-            PreferencesRow(localizedString("Color of download"), component: selectView(
+            PreferencesRow(localizedString("Color of download"), component: colorSelectView(
                 action: #selector(self.toggleDownloadColor),
                 items: self.colors,
                 selected: self.downloadColor.key
             )),
-            PreferencesRow(localizedString("Color of upload"), component: selectView(
+            PreferencesRow(localizedString("Color of upload"), component: colorSelectView(
                 action: #selector(self.toggleUploadColor),
                 items: self.colors,
                 selected: self.uploadColor.key
@@ -373,19 +373,15 @@ public class NetworkChart: WidgetWrapper {
     
     @objc private func toggleDownloadColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = SColor.allCases.first(where: { $0.key == key }) {
-            self.downloadColor = newColor
-            Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_downloadColor", value: newColor.key)
-        }
+        self.downloadColor = SColor.fromString(key, defaultValue: self.downloadColor)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_downloadColor", value: self.downloadColor.key)
         self.display()
     }
     
     @objc private func toggleUploadColor(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }
-        if let newColor = SColor.allCases.first(where: { $0.key == key }) {
-            self.uploadColor = newColor
-            Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_uploadColor", value: newColor.key)
-        }
+        self.uploadColor = SColor.fromString(key, defaultValue: self.uploadColor)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_uploadColor", value: self.uploadColor.key)
         self.display()
     }
     

--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -559,12 +559,12 @@ public class SpeedWidget: WidgetWrapper {
                 action: #selector(self.toggleMonochrome),
                 state: self.monochromeState
             )),
-            PreferencesRow(localizedString("Color of download"), component: selectView(
+            PreferencesRow(localizedString("Color of download"), component: colorSelectView(
                 action: #selector(self.toggleInputColor),
                 items: SColor.allColors,
                 selected: self.inputColorState.key
             )),
-            PreferencesRow(localizedString("Color of upload"), component: selectView(
+            PreferencesRow(localizedString("Color of upload"), component: colorSelectView(
                 action: #selector(self.toggleOutputColor),
                 items: SColor.allColors,
                 selected: self.outputColorState.key
@@ -638,20 +638,16 @@ public class SpeedWidget: WidgetWrapper {
     }
     
     @objc private func toggleOutputColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.outputColorState = newValue
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_uploadColor", value: key)
+        guard let key = sender.representedObject as? String else { return }
+        self.outputColorState = SColor.fromString(key, defaultValue: self.outputColorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_uploadColor", value: self.outputColorState.key)
+        self.display()
     }
     @objc private func toggleInputColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.inputColorState = newValue
-        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_downloadColor", value: key)
+        guard let key = sender.representedObject as? String else { return }
+        self.inputColorState = SColor.fromString(key, defaultValue: self.inputColorState)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_downloadColor", value: self.inputColorState.key)
+        self.display()
     }
     
     public func setValue(input: Int64, output: Int64) {

--- a/Kit/extensions.swift
+++ b/Kit/extensions.swift
@@ -303,6 +303,10 @@ public extension NSView {
         return select
     }
     
+    func colorSelectView(action: Selector, items: [SColor], selected: String) -> NSView {
+        return SColorSelectView(target: self, action: action, items: items, selected: selected)
+    }
+    
     func switchView(action: Selector, state: Bool) -> NSSwitch {
         let s = NSSwitch()
         s.heightAnchor.constraint(equalToConstant: 25).isActive = true
@@ -374,6 +378,110 @@ public extension NSView {
     }
 }
 
+private class SColorSelectView: NSStackView {
+    private static let customKey = "custom"
+    
+    private weak var callbackTarget: NSObject?
+    private let callbackAction: Selector
+    private let select: NSPopUpButton = NSPopUpButton(frame: NSRect(x: 0, y: 4, width: 50, height: 28))
+    private let colorWell: NSColorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 28, height: 24))
+    private var customItem: NSMenuItem?
+    
+    init(target: NSObject, action: Selector, items: [SColor], selected: String) {
+        self.callbackTarget = target
+        self.callbackAction = action
+        
+        super.init(frame: .zero)
+        
+        let selectedColor = SColor.fromString(selected)
+        self.orientation = .horizontal
+        self.alignment = .centerY
+        self.spacing = 6
+        
+        self.select.target = self
+        self.select.action = #selector(self.selectColor)
+        self.select.menu = self.menu(items: items, selected: selectedColor)
+        self.select.sizeToFit()
+        
+        if selectedColor.isCustom {
+            self.select.select(self.customItem)
+        }
+        
+        self.colorWell.color = selectedColor.additional as? NSColor ?? NSColor.controlAccentColor
+        self.colorWell.target = self
+        self.colorWell.action = #selector(self.changeCustomColor)
+        self.colorWell.widthAnchor.constraint(equalToConstant: 28).isActive = true
+        self.colorWell.heightAnchor.constraint(equalToConstant: 24).isActive = true
+        
+        self.addArrangedSubview(self.select)
+        self.addArrangedSubview(self.colorWell)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func menu(items: [SColor], selected: SColor) -> NSMenu {
+        let menu = NSMenu()
+        items.forEach { (item) in
+            if item.key.contains("separator") {
+                menu.addItem(NSMenuItem.separator())
+            } else {
+                let menuItem = NSMenuItem(title: localizedString(item.value), action: nil, keyEquivalent: "")
+                menuItem.representedObject = item.key
+                menuItem.state = selected.key == item.key ? .on : .off
+                menu.addItem(menuItem)
+            }
+        }
+        
+        menu.addItem(NSMenuItem.separator())
+        let customItem = NSMenuItem(title: localizedString("Custom..."), action: nil, keyEquivalent: "")
+        customItem.representedObject = SColorSelectView.customKey
+        customItem.state = selected.isCustom ? .on : .off
+        menu.addItem(customItem)
+        self.customItem = customItem
+        
+        return menu
+    }
+    
+    @objc private func selectColor(_ sender: NSPopUpButton) {
+        guard let key = sender.selectedItem?.representedObject as? String else { return }
+        if key == SColorSelectView.customKey {
+            self.updateMenuState(selectedKey: key)
+            self.select.select(self.customItem)
+            self.colorWell.activate(true)
+            NSColorPanel.shared.orderFront(nil)
+            return
+        }
+        
+        let color = SColor.fromString(key)
+        if let nsColor = color.additional as? NSColor {
+            self.colorWell.color = nsColor
+        }
+        self.updateMenuState(selectedKey: key)
+        self.send(key)
+    }
+    
+    @objc private func changeCustomColor(_ sender: NSColorWell) {
+        self.updateMenuState(selectedKey: SColorSelectView.customKey)
+        self.select.select(self.customItem)
+        self.send(SColor.custom(sender.color).key)
+    }
+    
+    private func updateMenuState(selectedKey: String) {
+        self.select.menu?.items.forEach { (item) in
+            guard let key = item.representedObject as? String else { return }
+            item.state = key == selectedKey ? .on : .off
+        }
+    }
+    
+    private func send(_ key: String) {
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.representedObject = key
+        _ = self.callbackTarget?.perform(self.callbackAction, with: item)
+    }
+}
+
 public class NSButtonWithPadding: NSButton {
     public var horizontalPadding: CGFloat = 0
     public var verticalPadding: CGFloat = 0
@@ -418,6 +526,46 @@ extension URL {
 }
 
 public extension NSColor {
+    convenience init?(hex: String) {
+        var value = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("#") {
+            value.removeFirst()
+        }
+        guard value.count == 6 || value.count == 8, let intValue = UInt32(value, radix: 16) else {
+            return nil
+        }
+        
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let alpha: CGFloat
+        if value.count == 8 {
+            red = CGFloat((intValue >> 24) & 0xff) / 255
+            green = CGFloat((intValue >> 16) & 0xff) / 255
+            blue = CGFloat((intValue >> 8) & 0xff) / 255
+            alpha = CGFloat(intValue & 0xff) / 255
+        } else {
+            red = CGFloat((intValue >> 16) & 0xff) / 255
+            green = CGFloat((intValue >> 8) & 0xff) / 255
+            blue = CGFloat(intValue & 0xff) / 255
+            alpha = 1
+        }
+        
+        self.init(deviceRed: red, green: green, blue: blue, alpha: alpha)
+    }
+    
+    var hexString: String {
+        guard let color = self.usingColorSpace(.deviceRGB) else {
+            return "#000000FF"
+        }
+        
+        let red = Int((color.redComponent * 255).rounded())
+        let green = Int((color.greenComponent * 255).rounded())
+        let blue = Int((color.blueComponent * 255).rounded())
+        let alpha = Int((color.alphaComponent * 255).rounded())
+        return String(format: "#%02X%02X%02X%02X", red, green, blue, alpha)
+    }
+    
     func grayscaled() -> NSColor {
         guard let space = CGColorSpace(name: CGColorSpace.extendedGray),
               let cg = self.cgColor.converted(to: space, intent: .perceptual, options: nil),

--- a/Kit/types.swift
+++ b/Kit/types.swift
@@ -183,8 +183,18 @@ public struct SColor: KeyValue_p, Equatable {
     public let value: String
     public var additional: Any?
     
+    private static let customPrefix = "custom:"
+    
     public static func == (lhs: SColor, rhs: SColor) -> Bool {
         return lhs.key == rhs.key
+    }
+    
+    public static func custom(_ color: NSColor) -> SColor {
+        return SColor(key: "\(customPrefix)\(color.hexString)", value: "Custom...", additional: color)
+    }
+    
+    public var isCustom: Bool {
+        return self.key.hasPrefix(SColor.customPrefix)
     }
 }
 
@@ -250,7 +260,13 @@ extension SColor: CaseIterable {
     }
     
     public static func fromString(_ key: String, defaultValue: SColor = .systemAccent) -> SColor {
-        return SColor.allCases.first{ $0.key == key } ?? defaultValue
+        if let color = SColor.allCases.first(where: { $0.key == key }) {
+            return color
+        }
+        if key.hasPrefix(customPrefix), let color = NSColor(hex: String(key.dropFirst(customPrefix.count))) {
+            return SColor.custom(color)
+        }
+        return defaultValue
     }
 }
 

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -562,17 +562,17 @@ internal class Popup: PopupWrapper {
         ]))
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("System color"), component: selectView(
+            PreferencesRow(localizedString("System color"), component: colorSelectView(
                 action: #selector(self.toggleSystemColor),
                 items: SColor.allColors,
                 selected: self.systemColorState.key
             )),
-            PreferencesRow(localizedString("User color"), component: selectView(
+            PreferencesRow(localizedString("User color"), component: colorSelectView(
                 action: #selector(self.toggleUserColor),
                 items: SColor.allColors,
                 selected: self.userColorState.key
             )),
-            PreferencesRow(localizedString("Idle color"), component: selectView(
+            PreferencesRow(localizedString("Idle color"), component: colorSelectView(
                 action: #selector(self.toggleIdleColor),
                 items: SColor.allColors,
                 selected: self.idleColorState.key
@@ -580,17 +580,17 @@ internal class Popup: PopupWrapper {
         ]))
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Efficiency cores color"), component: selectView(
+            PreferencesRow(localizedString("Efficiency cores color"), component: colorSelectView(
                 action: #selector(self.toggleECoresColor),
                 items: SColor.allColors,
                 selected: self.eCoresColorState.key
             )),
-            PreferencesRow(localizedString("Performance cores color"), component: selectView(
+            PreferencesRow(localizedString("Performance cores color"), component: colorSelectView(
                 action: #selector(self.togglePCoresColor),
                 items: SColor.allColors,
                 selected: self.pCoresColorState.key
             )),
-            PreferencesRow(localizedString("Super cores color"), component: selectView(
+            PreferencesRow(localizedString("Super cores color"), component: colorSelectView(
                 action: #selector(self.toggleSCoresColor),
                 items: SColor.allColors,
                 selected: self.sCoresColorState.key
@@ -603,7 +603,7 @@ internal class Popup: PopupWrapper {
             initialValue: "\(Int(self.lineChartFixedScale * 100)) %"
         )
         self.chartPrefSection = PreferencesSection([
-            PreferencesRow(localizedString("Chart color"), component: selectView(
+            PreferencesRow(localizedString("Chart color"), component: colorSelectView(
                 action: #selector(self.toggleChartColor),
                 items: SColor.allColors,
                 selected: self.chartColorState.key
@@ -627,71 +627,54 @@ internal class Popup: PopupWrapper {
     }
     
     @objc private func toggleSystemColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.systemColorState = newValue
-        Store.shared.set(key: "\(self.title)_systemColor", value: key)
-        self.systemColorView?.layer?.backgroundColor = (newValue.additional as? NSColor)?.cgColor
+        guard let key = sender.representedObject as? String else { return }
+        self.systemColorState = SColor.fromString(key, defaultValue: self.systemColorState)
+        Store.shared.set(key: "\(self.title)_systemColor", value: self.systemColorState.key)
+        self.systemColorView?.layer?.backgroundColor = (self.systemColorState.additional as? NSColor)?.cgColor
     }
     @objc private func toggleUserColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.userColorState = newValue
-        Store.shared.set(key: "\(self.title)_userColor", value: key)
-        self.userColorView?.layer?.backgroundColor = (newValue.additional as? NSColor)?.cgColor
+        guard let key = sender.representedObject as? String else { return }
+        self.userColorState = SColor.fromString(key, defaultValue: self.userColorState)
+        Store.shared.set(key: "\(self.title)_userColor", value: self.userColorState.key)
+        self.userColorView?.layer?.backgroundColor = (self.userColorState.additional as? NSColor)?.cgColor
     }
     @objc private func toggleIdleColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.idleColorState = newValue
-        Store.shared.set(key: "\(self.title)_idleColor", value: key)
-        if let color = newValue.additional as? NSColor {
-            self.idleColorView?.layer?.backgroundColor = color.cgColor
-        }
-        self.idleColorView?.layer?.backgroundColor = (newValue.additional as? NSColor)?.cgColor
+        guard let key = sender.representedObject as? String else { return }
+        self.idleColorState = SColor.fromString(key, defaultValue: self.idleColorState)
+        Store.shared.set(key: "\(self.title)_idleColor", value: self.idleColorState.key)
+        self.idleColorView?.layer?.backgroundColor = (self.idleColorState.additional as? NSColor)?.cgColor
     }
     @objc private func toggleChartColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.chartColorState = newValue
-        Store.shared.set(key: "\(self.title)_chartColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.chartColorState = SColor.fromString(key, defaultValue: self.chartColorState)
+        Store.shared.set(key: "\(self.title)_chartColor", value: self.chartColorState.key)
+        if let color = self.chartColorState.additional as? NSColor {
             self.lineChart?.setColor(color)
         }
     }
     @objc private func toggleECoresColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.eCoresColorState = newValue
-        Store.shared.set(key: "\(self.title)_eCoresColor", value: key)
-        if let color = (newValue.additional as? NSColor) {
+        guard let key = sender.representedObject as? String else { return }
+        self.eCoresColorState = SColor.fromString(key, defaultValue: self.eCoresColorState)
+        Store.shared.set(key: "\(self.title)_eCoresColor", value: self.eCoresColorState.key)
+        if let color = (self.eCoresColorState.additional as? NSColor) {
             self.eCoresColorView?.layer?.backgroundColor = color.cgColor
             self.eCoresFreqColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func togglePCoresColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.pCoresColorState = newValue
-        Store.shared.set(key: "\(self.title)_pCoresColor", value: key)
-        if let color = (newValue.additional as? NSColor) {
+        guard let key = sender.representedObject as? String else { return }
+        self.pCoresColorState = SColor.fromString(key, defaultValue: self.pCoresColorState)
+        Store.shared.set(key: "\(self.title)_pCoresColor", value: self.pCoresColorState.key)
+        if let color = (self.pCoresColorState.additional as? NSColor) {
             self.pCoresColorView?.layer?.backgroundColor = color.cgColor
             self.pCoresFreqColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func toggleSCoresColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.sCoresColorState = newValue
-        Store.shared.set(key: "\(self.title)_sCoresColor", value: key)
-        if let color = (newValue.additional as? NSColor) {
+        guard let key = sender.representedObject as? String else { return }
+        self.sCoresColorState = SColor.fromString(key, defaultValue: self.sCoresColorState)
+        Store.shared.set(key: "\(self.title)_sCoresColor", value: self.sCoresColorState.key)
+        if let color = (self.sCoresColorState.additional as? NSColor) {
             self.sCoresColorView?.layer?.backgroundColor = color.cgColor
             self.sCoresFreqColorView?.layer?.backgroundColor = color.cgColor
         }

--- a/Modules/Disk/popup.swift
+++ b/Modules/Disk/popup.swift
@@ -203,12 +203,12 @@ internal class Popup: PopupWrapper {
         ]))
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Write color"), component: selectView(
+            PreferencesRow(localizedString("Write color"), component: colorSelectView(
                 action: #selector(self.toggleWriteColor),
                 items: SColor.allColors,
                 selected: self.writeColorState.key
             )),
-            PreferencesRow(localizedString("Read color"), component: selectView(
+            PreferencesRow(localizedString("Read color"), component: colorSelectView(
                 action: #selector(self.toggleReadColor),
                 items: SColor.allColors,
                 selected: self.readColorState.key
@@ -231,13 +231,10 @@ internal class Popup: PopupWrapper {
     }
     
     @objc private func toggleWriteColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.writeColorState = newValue
-        Store.shared.set(key: "\(self.title)_writeColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.writeColorState = SColor.fromString(key, defaultValue: self.writeColorState)
+        Store.shared.set(key: "\(self.title)_writeColor", value: self.writeColorState.key)
+        if let color = self.writeColorState.additional as? NSColor {
             self.processes?.setColor(1, color)
             for view in self.disks.subviews.filter({ $0 is DiskView }).map({ $0 as! DiskView }) {
                 view.setChartColor(write: color)
@@ -245,13 +242,10 @@ internal class Popup: PopupWrapper {
         }
     }
     @objc private func toggleReadColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.readColorState = newValue
-        Store.shared.set(key: "\(self.title)_readColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.readColorState = SColor.fromString(key, defaultValue: self.readColorState)
+        Store.shared.set(key: "\(self.title)_readColor", value: self.readColorState.key)
+        if let color = self.readColorState.additional as? NSColor {
             self.processes?.setColor(0, color)
             for view in self.disks.subviews.filter({ $0 is DiskView }).map({ $0 as! DiskView }) {
                 view.setChartColor(read: color)

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -684,12 +684,12 @@ internal class Popup: PopupWrapper {
         ]))
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("Color of download"), component: selectView(
+            PreferencesRow(localizedString("Color of download"), component: colorSelectView(
                 action: #selector(self.toggleDownloadColor),
                 items: SColor.allColors,
                 selected: self.downloadColorState.key
             )),
-            PreferencesRow(localizedString("Color of upload"), component: selectView(
+            PreferencesRow(localizedString("Color of upload"), component: colorSelectView(
                 action: #selector(self.toggleUploadColor),
                 items: SColor.allColors,
                 selected: self.uploadColorState.key
@@ -738,13 +738,10 @@ internal class Popup: PopupWrapper {
     }
     
     @objc private func toggleUploadColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.uploadColorState = newValue
-        Store.shared.set(key: "\(self.title)_uploadColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.uploadColorState = SColor.fromString(key, defaultValue: self.uploadColorState)
+        Store.shared.set(key: "\(self.title)_uploadColor", value: self.uploadColorState.key)
+        if let color = self.uploadColorState.additional as? NSColor {
             self.processes?.setColor(1, color)
             self.uploadColorView?.layer?.backgroundColor = color.cgColor
             self.uploadStateView?.setColor(color)
@@ -752,13 +749,10 @@ internal class Popup: PopupWrapper {
         }
     }
     @objc private func toggleDownloadColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.downloadColorState = newValue
-        Store.shared.set(key: "\(self.title)_downloadColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.downloadColorState = SColor.fromString(key, defaultValue: self.downloadColorState)
+        Store.shared.set(key: "\(self.title)_downloadColor", value: self.downloadColorState.key)
+        if let color = self.downloadColorState.additional as? NSColor {
             self.processes?.setColor(0, color)
             self.downloadColorView?.layer?.backgroundColor = color.cgColor
             self.downloadStateView?.setColor(color)

--- a/Modules/RAM/popup.swift
+++ b/Modules/RAM/popup.swift
@@ -298,22 +298,22 @@ internal class Popup: PopupWrapper {
         ]))
         
         view.addArrangedSubview(PreferencesSection([
-            PreferencesRow(localizedString("App color"), component: selectView(
+            PreferencesRow(localizedString("App color"), component: colorSelectView(
                 action: #selector(toggleAppColor),
                 items: SColor.allColors,
                 selected: self.appColorState.key
             )),
-            PreferencesRow(localizedString("Wired color"), component: selectView(
+            PreferencesRow(localizedString("Wired color"), component: colorSelectView(
                 action: #selector(toggleWiredColor),
                 items: SColor.allColors,
                 selected: self.wiredColorState.key
             )),
-            PreferencesRow(localizedString("Compressed color"), component: selectView(
+            PreferencesRow(localizedString("Compressed color"), component: colorSelectView(
                 action: #selector(toggleCompressedColor),
                 items: SColor.allColors,
                 selected: self.compressedColorState.key
             )),
-            PreferencesRow(localizedString("Free color"), component: selectView(
+            PreferencesRow(localizedString("Free color"), component: colorSelectView(
                 action: #selector(toggleFreeColor),
                 items: SColor.allColors,
                 selected: self.freeColorState.key
@@ -326,7 +326,7 @@ internal class Popup: PopupWrapper {
             initialValue: "\(Int(self.lineChartFixedScale * 100)) %"
         )
         self.chartPrefSection = PreferencesSection([
-            PreferencesRow(localizedString("Chart color"), component: selectView(
+            PreferencesRow(localizedString("Chart color"), component: colorSelectView(
                 action: #selector(self.toggleChartColor),
                 items: SColor.allColors,
                 selected: self.chartColorState.key
@@ -350,57 +350,42 @@ internal class Popup: PopupWrapper {
     }
     
     @objc private func toggleAppColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.appColorState = newValue
-        Store.shared.set(key: "\(self.title)_appColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.appColorState = SColor.fromString(key, defaultValue: self.appColorState)
+        Store.shared.set(key: "\(self.title)_appColor", value: self.appColorState.key)
+        if let color = self.appColorState.additional as? NSColor {
             self.appColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func toggleWiredColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.wiredColorState = newValue
-        Store.shared.set(key: "\(self.title)_wiredColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.wiredColorState = SColor.fromString(key, defaultValue: self.wiredColorState)
+        Store.shared.set(key: "\(self.title)_wiredColor", value: self.wiredColorState.key)
+        if let color = self.wiredColorState.additional as? NSColor {
             self.wiredColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func toggleCompressedColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.compressedColorState = newValue
-        Store.shared.set(key: "\(self.title)_compressedColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.compressedColorState = SColor.fromString(key, defaultValue: self.compressedColorState)
+        Store.shared.set(key: "\(self.title)_compressedColor", value: self.compressedColorState.key)
+        if let color = self.compressedColorState.additional as? NSColor {
             self.compressedColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func toggleFreeColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.freeColorState = newValue
-        Store.shared.set(key: "\(self.title)_freeColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.freeColorState = SColor.fromString(key, defaultValue: self.freeColorState)
+        Store.shared.set(key: "\(self.title)_freeColor", value: self.freeColorState.key)
+        if let color = self.freeColorState.additional as? NSColor {
             self.freeColorView?.layer?.backgroundColor = color.cgColor
         }
     }
     @objc private func toggleChartColor(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String,
-              let newValue = SColor.allColors.first(where: { $0.key == key }) else {
-            return
-        }
-        self.chartColorState = newValue
-        Store.shared.set(key: "\(self.title)_chartColor", value: key)
-        if let color = newValue.additional as? NSColor {
+        guard let key = sender.representedObject as? String else { return }
+        self.chartColorState = SColor.fromString(key, defaultValue: self.chartColorState)
+        Store.shared.set(key: "\(self.title)_chartColor", value: self.chartColorState.key)
+        if let color = self.chartColorState.additional as? NSColor {
             self.chart?.setColor(color)
         }
     }

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "القيمة الافتراضية"; // translategemma:4b
 "Transparent when no activity" = "شفاف عندما لا يوجد نشاط"; // translategemma:4b
 "Constant color" = "ثابت"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "فتح إعدادات الوحدة";

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "القيمة الافتراضية"; // translategemma:4b
 "Transparent when no activity" = "شفاف عندما لا يوجد نشاط"; // translategemma:4b
 "Constant color" = "ثابت"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "مخصص...";
 
 // Module Kit
 "Open module settings" = "فتح إعدادات الوحدة";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Стойности по подразбиране"; // translategemma:4b
 "Transparent when no activity" = "Прозрачен, когато няма активност"; // translategemma:4b
 "Constant color" = "Постоянен"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Отваряне на настройките на модула";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Стойности по подразбиране"; // translategemma:4b
 "Transparent when no activity" = "Прозрачен, когато няма активност"; // translategemma:4b
 "Constant color" = "Постоянен"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Персонализирано...";
 
 // Module Kit
 "Open module settings" = "Отваряне на настройките на модула";

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Color per determinat";
 "Transparent when no activity" = "Transparent quan no hi hagi activitat";
 "Constant color" = "Color constant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Obre la configuració del mòdul";

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Color per determinat";
 "Transparent when no activity" = "Transparent quan no hi hagi activitat";
 "Constant color" = "Color constant";
-"Custom..." = "Custom...";
+"Custom..." = "Personalitzat...";
 
 // Module Kit
 "Open module settings" = "Obre la configuració del mòdul";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Výchozí"; // translategemma:4b
 "Transparent when no activity" = "Průhledný, když není žádná aktivita"; // translategemma:4b
 "Constant color" = "Konstantní"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Otevřít nastavení modulu";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Výchozí"; // translategemma:4b
 "Transparent when no activity" = "Průhledný, když není žádná aktivita"; // translategemma:4b
 "Constant color" = "Konstantní"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Vlastní...";
 
 // Module Kit
 "Open module settings" = "Otevřít nastavení modulu";

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Standard"; // translategemma:4b
 "Transparent when no activity" = "Gennemsigtig, når der ikke er nogen aktivitet"; // translategemma:4b
 "Constant color" = "Konstant"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Åben indstillinger for moduler";

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Standard"; // translategemma:4b
 "Transparent when no activity" = "Gennemsigtig, når der ikke er nogen aktivitet"; // translategemma:4b
 "Constant color" = "Konstant"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Brugerdefineret...";
 
 // Module Kit
 "Open module settings" = "Åben indstillinger for moduler";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Standard";
 "Transparent when no activity" = "Transparent bei Inaktivität";
 "Constant color" = "Konstant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Modul-Einstellungen öffnen";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Standard";
 "Transparent when no activity" = "Transparent bei Inaktivität";
 "Constant color" = "Konstant";
-"Custom..." = "Custom...";
+"Custom..." = "Benutzerdefiniert...";
 
 // Module Kit
 "Open module settings" = "Modul-Einstellungen öffnen";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Προεπιλεγμένο"; // translategemma:4b
 "Transparent when no activity" = "Διαφανές όταν δεν υπάρχει κάποια δραστηριότητα"; // translategemma:4b
 "Constant color" = "Σταθερός"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Άνοιγμα ρυθμίσεων ενότητας";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Προεπιλεγμένο"; // translategemma:4b
 "Transparent when no activity" = "Διαφανές όταν δεν υπάρχει κάποια δραστηριότητα"; // translategemma:4b
 "Constant color" = "Σταθερός"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Προσαρμοσμένο...";
 
 // Module Kit
 "Open module settings" = "Άνοιγμα ρυθμίσεων ενότητας";

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Default";
 "Transparent when no activity" = "Transparent when no activity";
 "Constant color" = "Constant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Open module settings";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Default";
 "Transparent when no activity" = "Transparent when no activity";
 "Constant color" = "Constant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Open module settings";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Default";
 "Transparent when no activity" = "Transparent when no activity";
 "Constant color" = "Constant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Open module settings";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Color por defecto";
 "Transparent when no activity" = "Transparente cuando no hay actividad";
 "Constant color" = "Color constante";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Abrir la configuración del módulo";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Color por defecto";
 "Transparent when no activity" = "Transparente cuando no hay actividad";
 "Constant color" = "Color constante";
-"Custom..." = "Custom...";
+"Custom..." = "Personalizado...";
 
 // Module Kit
 "Open module settings" = "Abrir la configuración del módulo";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Vaikevärv";
 "Transparent when no activity" = "Läbipaistev, kui pole tegevust";
 "Constant color" = "Ühtlane värv";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Ava mooduli sätted";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Vaikevärv";
 "Transparent when no activity" = "Läbipaistev, kui pole tegevust";
 "Constant color" = "Ühtlane värv";
-"Custom..." = "Custom...";
+"Custom..." = "Kohandatud...";
 
 // Module Kit
 "Open module settings" = "Ava mooduli sätted";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "پیش‌فرض"; // translategemma:4b
 "Transparent when no activity" = "شفاف در زمان عدم فعالیت"; // translategemma:4b
 "Constant color" = "ثابت"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "باز کردن تنظیمات ماژول‌ها";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "پیش‌فرض"; // translategemma:4b
 "Transparent when no activity" = "شفاف در زمان عدم فعالیت"; // translategemma:4b
 "Constant color" = "ثابت"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "سفارشی...";
 
 // Module Kit
 "Open module settings" = "باز کردن تنظیمات ماژول‌ها";

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Oletusväri";
 "Transparent when no activity" = "Läpinäkyvä, kun ei ole toimintaa";
 "Constant color" = "Vakio väri";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Avaa moduulin asetukset";

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Oletusväri";
 "Transparent when no activity" = "Läpinäkyvä, kun ei ole toimintaa";
 "Constant color" = "Vakio väri";
-"Custom..." = "Custom...";
+"Custom..." = "Mukautettu...";
 
 // Module Kit
 "Open module settings" = "Avaa moduulin asetukset";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Par défaut";
 "Transparent when no activity" = "Transparent en l'absence d'activité";
 "Constant color" = "Constante";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Ouvrir les paramètres du module";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Par défaut";
 "Transparent when no activity" = "Transparent en l'absence d'activité";
 "Constant color" = "Constante";
-"Custom..." = "Custom...";
+"Custom..." = "Personnalisé...";
 
 // Module Kit
 "Open module settings" = "Ouvrir les paramètres du module";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "ברירת מחדל"; // translategemma:4b
 "Transparent when no activity" = "שקוף כאשר אין פעילות"; // translategemma:4b
 "Constant color" = "קבוע"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "פתח/י הגדרות מודל";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "ברירת מחדל"; // translategemma:4b
 "Transparent when no activity" = "שקוף כאשר אין פעילות"; // translategemma:4b
 "Constant color" = "קבוע"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "מותאם אישית...";
 
 // Module Kit
 "Open module settings" = "פתח/י הגדרות מודל";

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "डिफ़ॉल्ट"; // translategemma:4b
 "Transparent when no activity" = "जब कोई गतिविधि नहीं होती तो पारदर्शी।"; // translategemma:4b
 "Constant color" = "स्थिर"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "ओपन मॉड्यूल सेटिंग्स";

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "डिफ़ॉल्ट"; // translategemma:4b
 "Transparent when no activity" = "जब कोई गतिविधि नहीं होती तो पारदर्शी।"; // translategemma:4b
 "Constant color" = "स्थिर"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "कस्टम...";
 
 // Module Kit
 "Open module settings" = "ओपन मॉड्यूल सेटिंग्स";

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Predloženo"; // translategemma:4b
 "Transparent when no activity" = "Prozirno kada nema aktivnosti"; // translategemma:4b
 "Constant color" = "Konstanta"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Otvori postavke modula";

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Predloženo"; // translategemma:4b
 "Transparent when no activity" = "Prozirno kada nema aktivnosti"; // translategemma:4b
 "Constant color" = "Konstanta"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Prilagođeno...";
 
 // Module Kit
 "Open module settings" = "Otvori postavke modula";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Alapérték"; // translategemma:4b
 "Transparent when no activity" = "Árnyalatless, ha nincs tevékenység"; // translategemma:4b
 "Constant color" = "Konstans"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Modul beállításainak megnyitása";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Alapérték"; // translategemma:4b
 "Transparent when no activity" = "Árnyalatless, ha nincs tevékenység"; // translategemma:4b
 "Constant color" = "Konstans"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Egyéni...";
 
 // Module Kit
 "Open module settings" = "Modul beállításainak megnyitása";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Nilai default"; // translategemma:4b
 "Transparent when no activity" = "Transparan saat tidak ada aktivitas"; // translategemma:4b
 "Constant color" = "Konstan"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Buka pengaturan modul";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Nilai default"; // translategemma:4b
 "Transparent when no activity" = "Transparan saat tidak ada aktivitas"; // translategemma:4b
 "Constant color" = "Konstan"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Khusus...";
 
 // Module Kit
 "Open module settings" = "Buka pengaturan modul";

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Predefinito"; // translategemma:4b
 "Transparent when no activity" = "Trasparente in assenza di attività";
 "Constant color" = "Costante";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Apri impostazioni modulo";

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Predefinito"; // translategemma:4b
 "Transparent when no activity" = "Trasparente in assenza di attività";
 "Constant color" = "Costante";
-"Custom..." = "Custom...";
+"Custom..." = "Personalizzato...";
 
 // Module Kit
 "Open module settings" = "Apri impostazioni modulo";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "デフォルト"; // translategemma:4b
 "Transparent when no activity" = "活動がないときは透明状態"; // translategemma:4b
 "Constant color" = "一定"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "このモジュールの設定を開く";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "デフォルト"; // translategemma:4b
 "Transparent when no activity" = "活動がないときは透明状態"; // translategemma:4b
 "Constant color" = "一定"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "カスタム...";
 
 // Module Kit
 "Open module settings" = "このモジュールの設定を開く";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "기본값"; // translategemma:4b
 "Transparent when no activity" = "활동이 없을 때 투명하게 표시"; // translategemma:4b
 "Constant color" = "상수"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "모듈 설정 열기";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "기본값"; // translategemma:4b
 "Transparent when no activity" = "활동이 없을 때 투명하게 표시"; // translategemma:4b
 "Constant color" = "상수"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "사용자 지정...";
 
 // Module Kit
 "Open module settings" = "모듈 설정 열기";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Standard"; // translategemma:4b
 "Transparent when no activity" = "Transparent når det ikke er noen aktivitet"; // translategemma:4b
 "Constant color" = "Konstant"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Åpne modulinnstillinger";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Standard"; // translategemma:4b
 "Transparent when no activity" = "Transparent når det ikke er noen aktivitet"; // translategemma:4b
 "Constant color" = "Konstant"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Tilpasset...";
 
 // Module Kit
 "Open module settings" = "Åpne modulinnstillinger";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Standaard"; // translategemma:4b
 "Transparent when no activity" = "Transparant wanneer er geen activiteit is"; // translategemma:4b
 "Constant color" = "Constante"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Open module-instellingen";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Standaard"; // translategemma:4b
 "Transparent when no activity" = "Transparant wanneer er geen activiteit is"; // translategemma:4b
 "Constant color" = "Vaste kleur";
-"Custom..." = "Custom...";
+"Custom..." = "Aangepast...";
 
 // Module Kit
 "Open module settings" = "Open module-instellingen";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Domyślny";
 "Transparent when no activity" = "Przejrzysty gdy nie ma żadnej aktywności";
 "Constant color" = "Stały";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Otwórz ustawienia modułu";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Domyślny";
 "Transparent when no activity" = "Przejrzysty gdy nie ma żadnej aktywności";
 "Constant color" = "Stały";
-"Custom..." = "Custom...";
+"Custom..." = "Niestandardowe...";
 
 // Module Kit
 "Open module settings" = "Otwórz ustawienia modułu";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Padrão"; // translategemma:4b
 "Transparent when no activity" = "Transparente quando não há atividade"; // translategemma:4b
 "Constant color" = "Constante"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Abrir configurações do módulo";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Padrão"; // translategemma:4b
 "Transparent when no activity" = "Transparente quando não há atividade"; // translategemma:4b
 "Constant color" = "Constante"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Personalizado...";
 
 // Module Kit
 "Open module settings" = "Abrir configurações do módulo";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Padrão"; // translategemma:4b
 "Transparent when no activity" = "Transparente quando não há atividade"; // translategemma:4b
 "Constant color" = "Constante"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Abrir definições do módulo";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Padrão"; // translategemma:4b
 "Transparent when no activity" = "Transparente quando não há atividade"; // translategemma:4b
 "Constant color" = "Constante"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Personalizado...";
 
 // Module Kit
 "Open module settings" = "Abrir definições do módulo";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Implicit"; // translategemma:4b
 "Transparent when no activity" = "Transparente când nu există activitate"; // translategemma:4b
 "Constant color" = "Constant";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Deschide setăriile modulului";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Implicit"; // translategemma:4b
 "Transparent when no activity" = "Transparente când nu există activitate"; // translategemma:4b
 "Constant color" = "Constant";
-"Custom..." = "Custom...";
+"Custom..." = "Personalizat...";
 
 // Module Kit
 "Open module settings" = "Deschide setăriile modulului";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "По умолчанию";
 "Transparent when no activity" = "Прозрачный когда нет активности";
 "Constant color" = "Постоянный";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Открыть настройки модуля";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "По умолчанию";
 "Transparent when no activity" = "Прозрачный когда нет активности";
 "Constant color" = "Постоянный";
-"Custom..." = "Custom...";
+"Custom..." = "Пользовательский...";
 
 // Module Kit
 "Open module settings" = "Открыть настройки модуля";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Výchozí"; // translategemma:4b
 "Transparent when no activity" = "Pri absencii aktivity je zobrazené ako transparentné."; // translategemma:4b
 "Constant color" = "Konštant"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Otvoriť nastavenia modulu";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Výchozí"; // translategemma:4b
 "Transparent when no activity" = "Pri absencii aktivity je zobrazené ako transparentné."; // translategemma:4b
 "Constant color" = "Konštant"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "Vlastné...";
 
 // Module Kit
 "Open module settings" = "Otvoriť nastavenia modulu";

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Privzeto";
 "Transparent when no activity" = "Prosojno, ko ni dejavnosti";
 "Constant color" = "Stalna";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Odpri nastavitve modula";

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Privzeto";
 "Transparent when no activity" = "Prosojno, ko ni dejavnosti";
 "Constant color" = "Stalna";
-"Custom..." = "Custom...";
+"Custom..." = "Po meri...";
 
 // Module Kit
 "Open module settings" = "Odpri nastavitve modula";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Standardfärg";
 "Transparent when no activity" = "Genomskinlig vid inaktivitet";
 "Constant color" = "Konstant färg";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Öppna modulinställningar";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Standardfärg";
 "Transparent when no activity" = "Genomskinlig vid inaktivitet";
 "Constant color" = "Konstant färg";
-"Custom..." = "Custom...";
+"Custom..." = "Anpassad...";
 
 // Module Kit
 "Open module settings" = "Öppna modulinställningar";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "ค่าเริ่มต้น"; // translategemma:4b
 "Transparent when no activity" = "โปร่งใสเมื่อไม่มีการใช้งาน"; // translategemma:4b
 "Constant color" = "คงที่"; // translategemma:4b
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "เปิดการตั้งค่าโมดูล";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "ค่าเริ่มต้น"; // translategemma:4b
 "Transparent when no activity" = "โปร่งใสเมื่อไม่มีการใช้งาน"; // translategemma:4b
 "Constant color" = "คงที่"; // translategemma:4b
-"Custom..." = "Custom...";
+"Custom..." = "กำหนดเอง...";
 
 // Module Kit
 "Open module settings" = "เปิดการตั้งค่าโมดูล";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Varsayılan renk";
 "Transparent when no activity" = "Aktif değilse transparan";
 "Constant color" = "Sabit renk";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Modül ayarlarını aç";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Varsayılan renk";
 "Transparent when no activity" = "Aktif değilse transparan";
 "Constant color" = "Sabit renk";
-"Custom..." = "Custom...";
+"Custom..." = "Özel...";
 
 // Module Kit
 "Open module settings" = "Modül ayarlarını aç";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "За замовчуванням";
 "Transparent when no activity" = "Прозорий коли немає активності";
 "Constant color" = "Постійний";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Відкрити налаштування модуля";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "За замовчуванням";
 "Transparent when no activity" = "Прозорий коли немає активності";
 "Constant color" = "Постійний";
-"Custom..." = "Custom...";
+"Custom..." = "Користувацький...";
 
 // Module Kit
 "Open module settings" = "Відкрити налаштування модуля";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "Màu mặc định";
 "Transparent when no activity" = "Trong suốt khi không có hoạt động";
 "Constant color" = "Màu cố định";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "Mở cài đặt module";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "Màu mặc định";
 "Transparent when no activity" = "Trong suốt khi không có hoạt động";
 "Constant color" = "Màu cố định";
-"Custom..." = "Custom...";
+"Custom..." = "Tùy chỉnh...";
 
 // Module Kit
 "Open module settings" = "Mở cài đặt module";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "默认";
 "Transparent when no activity" = "无活动时保持透明";
 "Constant color" = "恒定颜色";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "打开模块设置";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "默认";
 "Transparent when no activity" = "无活动时保持透明";
 "Constant color" = "恒定颜色";
-"Custom..." = "Custom...";
+"Custom..." = "自定义...";
 
 // Module Kit
 "Open module settings" = "打开模块设置";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -227,6 +227,7 @@
 "Default color" = "預設"; // translategemma:4b
 "Transparent when no activity" = "閒置時以透明顯示";
 "Constant color" = "恆定色彩";
+"Custom..." = "Custom...";
 
 // Module Kit
 "Open module settings" = "打開模組設定";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "Default color" = "預設"; // translategemma:4b
 "Transparent when no activity" = "閒置時以透明顯示";
 "Constant color" = "恆定色彩";
-"Custom..." = "Custom...";
+"Custom..." = "自訂...";
 
 // Module Kit
 "Open module settings" = "打開模組設定";

--- a/Tests/RAM.swift
+++ b/Tests/RAM.swift
@@ -10,6 +10,7 @@
 //
 
 import XCTest
+import Kit
 import RAM
 
 class RAM: XCTestCase {
@@ -77,5 +78,36 @@ class RAM: XCTestCase {
         XCTAssertEqual(process.pid, 0)
         XCTAssertEqual(process.name, "Safari")
         XCTAssertEqual(process.usage, 658 * Double(1000 * 1000))
+    }
+}
+
+class ColorTests: XCTestCase {
+    func testCustomColorSerialization() throws {
+        let color = NSColor(deviceRed: CGFloat(0x12) / 255, green: CGFloat(0x34) / 255, blue: CGFloat(0x56) / 255, alpha: CGFloat(0x78) / 255)
+        let custom = SColor.custom(color)
+        
+        XCTAssertEqual(custom.key, "custom:#12345678")
+        XCTAssertEqual((custom.additional as? NSColor)?.hexString, "#12345678")
+    }
+    
+    func testCustomColorParsing() throws {
+        let custom = SColor.fromString("custom:#12345678", defaultValue: .red)
+        
+        XCTAssertTrue(custom.isCustom)
+        XCTAssertEqual(custom.key, "custom:#12345678")
+        XCTAssertEqual((custom.additional as? NSColor)?.hexString, "#12345678")
+    }
+    
+    func testInvalidCustomColorFallsBack() throws {
+        let fallback = SColor.secondBlue
+        let custom = SColor.fromString("custom:not-a-color", defaultValue: fallback)
+        
+        XCTAssertEqual(custom, fallback)
+    }
+    
+    func testBuiltInColorParsingRemainsUnchanged() throws {
+        let color = SColor.fromString("secondBlue", defaultValue: .red)
+        
+        XCTAssertEqual(color, SColor.secondBlue)
     }
 }

--- a/Tests/RAM.swift
+++ b/Tests/RAM.swift
@@ -10,7 +10,6 @@
 //
 
 import XCTest
-import Kit
 import RAM
 
 class RAM: XCTestCase {
@@ -78,36 +77,5 @@ class RAM: XCTestCase {
         XCTAssertEqual(process.pid, 0)
         XCTAssertEqual(process.name, "Safari")
         XCTAssertEqual(process.usage, 658 * Double(1000 * 1000))
-    }
-}
-
-class ColorTests: XCTestCase {
-    func testCustomColorSerialization() throws {
-        let color = NSColor(deviceRed: CGFloat(0x12) / 255, green: CGFloat(0x34) / 255, blue: CGFloat(0x56) / 255, alpha: CGFloat(0x78) / 255)
-        let custom = SColor.custom(color)
-        
-        XCTAssertEqual(custom.key, "custom:#12345678")
-        XCTAssertEqual((custom.additional as? NSColor)?.hexString, "#12345678")
-    }
-    
-    func testCustomColorParsing() throws {
-        let custom = SColor.fromString("custom:#12345678", defaultValue: .red)
-        
-        XCTAssertTrue(custom.isCustom)
-        XCTAssertEqual(custom.key, "custom:#12345678")
-        XCTAssertEqual((custom.additional as? NSColor)?.hexString, "#12345678")
-    }
-    
-    func testInvalidCustomColorFallsBack() throws {
-        let fallback = SColor.secondBlue
-        let custom = SColor.fromString("custom:not-a-color", defaultValue: fallback)
-        
-        XCTAssertEqual(custom, fallback)
-    }
-    
-    func testBuiltInColorParsingRemainsUnchanged() throws {
-        let color = SColor.fromString("secondBlue", defaultValue: .red)
-        
-        XCTAssertEqual(color, SColor.secondBlue)
     }
 }


### PR DESCRIPTION
## Summary
- Add native custom color support to shared `SColor` color pickers.
- Persist custom colors as `custom:#RRGGBBAA` while keeping existing built-in color keys unchanged.
- Apply the custom color picker to widget and CPU/RAM/Disk/Net popup color settings.
- Add localization entries for `Custom...` across all app languages.

Closes #2806