### PR TITLE
feat(net): add manual public IP refresh and display proxy exit IP

### DIFF
--- a/Modules/Net/main.swift
+++ b/Modules/Net/main.swift
@@ -74,6 +74,7 @@ public struct Network_Usage: Codable, RemoteType {
     
     var laddr: Network_addr = Network_addr() // local ip
     var raddr: Network_addr = Network_addr() // remote ip
+    var paddr: Network_addr? = nil // remote ip via configured proxy
     
     var dns: [String] = []
     
@@ -88,6 +89,7 @@ public struct Network_Usage: Codable, RemoteType {
         
         self.laddr = Network_addr()
         self.raddr = Network_addr()
+        self.paddr = nil
         
         self.dns = []
         

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -61,8 +61,10 @@ internal class Popup: PopupWrapper {
     private var localIPField: ValueField? = nil
     private var publicIPv4Field: ValueField? = nil
     private var publicIPv6Field: ValueField? = nil
+    private var proxyIPField: ValueField? = nil
     private var publicIPv4View: NSView? = nil
     private var publicIPv6View: NSView? = nil
+    private var proxyIPView: NSView? = nil
     private var publicIPState: Bool = true
     private var emojiCCState: Bool = true
     
@@ -362,15 +364,19 @@ internal class Popup: PopupWrapper {
         
         let ipV4 = popupRow(view, title: "\(localizedString("Public IP")):", value: localizedString("Unknown"))
         let ipV6 = popupRow(view, title: "\(localizedString("Public IP")):", value: localizedString("Unknown"))
+        let proxyIP = popupRow(view, title: "\(localizedString("Proxy IP")):", value: localizedString("Unknown"))
         
         self.publicIPv4Field = ipV4.1
         self.publicIPv6Field = ipV6.1
+        self.proxyIPField = proxyIP.1
         self.publicIPv4View = ipV4.2
         self.publicIPv6View = ipV6.2
+        self.proxyIPView = proxyIP.2
         
         self.localIPField?.isSelectable = true
         self.publicIPv4Field?.isSelectable = true
         self.publicIPv6Field?.isSelectable = true
+        self.proxyIPField?.isSelectable = true
         
         if let valueView = self.publicIPv6Field {
             valueView.font = NSFont.systemFont(ofSize: 7, weight: .semibold)
@@ -379,6 +385,7 @@ internal class Popup: PopupWrapper {
         
         ipV4.2.removeFromSuperview()
         ipV6.2.removeFromSuperview()
+        proxyIP.2.removeFromSuperview()
         
         self.addressView = view
         return view
@@ -566,6 +573,31 @@ internal class Popup: PopupWrapper {
                         view.removeFromSuperview()
                         resized = true
                         self.publicIPv6Field?.stringValue = localizedString("Unknown")
+                    }
+                }
+                
+                if let view = self.proxyIPView {
+                    if let proxy = value.paddr, let addr = proxy.v4 ?? proxy.v6 {
+                        if view.superview == nil {
+                            self.addressView?.addArrangedSubview(view)
+                            resized = true
+                        }
+                        var ip = addr
+                        if let cc = proxy.countryCode, !cc.isEmpty {
+                            if self.emojiCCState, let flag = countryFlag(cc) {
+                                ip += " \(flag)"
+                            } else {
+                                ip += " (\(cc))"
+                            }
+                            self.proxyIPField?.toolTip = cc
+                        }
+                        if self.proxyIPField?.stringValue != ip {
+                            self.proxyIPField?.stringValue = ip
+                        }
+                    } else if view.superview != nil {
+                        view.removeFromSuperview()
+                        resized = true
+                        self.proxyIPField?.stringValue = localizedString("Unknown")
                     }
                 }
                 
@@ -938,6 +970,7 @@ internal class Popup: PopupWrapper {
         self.localIPField?.stringValue = localizedString("Updating...")
         self.publicIPv4Field?.stringValue = localizedString("Updating...")
         self.publicIPv6Field?.stringValue = localizedString("Updating...")
+        self.proxyIPField?.stringValue = localizedString("Updating...")
     }
     
     @objc private func resetTotalNetworkUsage() {

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -105,6 +105,19 @@ extension CWChannel {
 }
 
 internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
+    private struct ProxyConfiguration {
+        let kind: String
+        let host: String
+        let port: Int
+        
+        var proxyURL: String {
+            switch self.kind {
+            case "SOCKS": return "socks5h://\(self.host):\(self.port)"
+            default: return "http://\(self.host):\(self.port)"
+            }
+        }
+    }
+    
     private var reachability: Reachability = Reachability(start: true)
     private let variablesQueue = DispatchQueue(label: "eu.exelban.NetworkUsageReader")
     private var _usage: Network_Usage = Network_Usage()
@@ -295,7 +308,7 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
         let output = String(data: outputData, encoding: .utf8)
         _ = String(data: errorData, encoding: .utf8)
         guard let output, !output.isEmpty else { return Bandwidth() }
-
+        
         var totalUpload: Int64 = 0
         var totalDownload: Int64 = 0
         var firstLine = false
@@ -453,8 +466,13 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
             let country: String?
         }
         
+        let proxy = self.currentProxyConfiguration()
+        if proxy == nil {
+            self.usage.paddr = nil
+        }
+        
         DispatchQueue.global(qos: .userInitiated).async {
-            let response = syncShell("curl -s -4 https://api.mac-stats.com/ip")
+            let response = self.fetchPublicIP(version: .v4)
             if !response.isEmpty, let data = response.data(using: .utf8),
                let addr = try? JSONDecoder().decode(Addr_s.self, from: data) {
                 if let ip = addr.ipv4, self.isIPv4(ip) {
@@ -466,7 +484,7 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
             }
         }
         DispatchQueue.global(qos: .userInitiated).async {
-            let response = syncShell("curl -s -6 https://api.mac-stats.com/ip")
+            let response = self.fetchPublicIP(version: .v6)
             if !response.isEmpty, let data = response.data(using: .utf8),
                let addr = try? JSONDecoder().decode(Addr_s.self, from: data) {
                 if let ip = addr.ipv6, !self.isIPv4(ip) {
@@ -476,6 +494,105 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
                     self.usage.raddr.countryCode = countryCode
                 }
             }
+        }
+        if let proxy {
+            DispatchQueue.global(qos: .userInitiated).async {
+                let response = self.fetchPublicIP(version: .v4, proxy: proxy)
+                if !response.isEmpty, let data = response.data(using: .utf8),
+                   let addr = try? JSONDecoder().decode(Addr_s.self, from: data) {
+                    var proxyAddr = self.usage.paddr ?? Network_addr()
+                    if let ip = addr.ipv4, self.isIPv4(ip) {
+                        proxyAddr.v4 = ip
+                    }
+                    if let countryCode = addr.country {
+                        proxyAddr.countryCode = countryCode
+                    }
+                    self.usage.paddr = proxyAddr
+                }
+            }
+            DispatchQueue.global(qos: .userInitiated).async {
+                let response = self.fetchPublicIP(version: .v6, proxy: proxy)
+                if !response.isEmpty, let data = response.data(using: .utf8),
+                   let addr = try? JSONDecoder().decode(Addr_s.self, from: data) {
+                    var proxyAddr = self.usage.paddr ?? Network_addr()
+                    if let ip = addr.ipv6, !self.isIPv4(ip) {
+                        proxyAddr.v6 = ip
+                    }
+                    if let countryCode = addr.country {
+                        proxyAddr.countryCode = countryCode
+                    }
+                    self.usage.paddr = proxyAddr
+                }
+            }
+        }
+    }
+    
+    private enum IPVersion: String {
+        case v4 = "-4"
+        case v6 = "-6"
+    }
+    
+    private func fetchPublicIP(version: IPVersion, proxy: ProxyConfiguration? = nil) -> String {
+        var arguments = ["-s", "--connect-timeout", "5", version.rawValue]
+        if let proxy {
+            arguments.append(contentsOf: ["--proxy", proxy.proxyURL])
+        }
+        arguments.append("https://api.mac-stats.com/ip")
+        return process(path: "/usr/bin/curl", arguments: arguments) ?? ""
+    }
+    
+    private func currentProxyConfiguration() -> ProxyConfiguration? {
+        guard let settings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() as? [String: Any] else {
+            return nil
+        }
+        
+        if let scoped = settings["__SCOPED__"] as? [String: Any],
+           let current = scoped[self.interfaceID] as? [String: Any],
+           let proxy = self.proxyConfiguration(from: current) {
+            return proxy
+        }
+        
+        return self.proxyConfiguration(from: settings)
+    }
+    
+    private func proxyConfiguration(from settings: [String: Any]) -> ProxyConfiguration? {
+        let keys = ["HTTPS", "HTTP", "SOCKS"]
+        for key in keys {
+            guard self.proxyIsEnabled(settings["\(key)Enable"]),
+                  let host = settings["\(key)Proxy"] as? String,
+                  !host.isEmpty else {
+                continue
+            }
+            
+            let port = self.proxyPort(settings["\(key)Port"])
+            return ProxyConfiguration(kind: key, host: host, port: port)
+        }
+        return nil
+    }
+    
+    private func proxyIsEnabled(_ raw: Any?) -> Bool {
+        switch raw {
+        case let value as NSNumber:
+            return value.intValue == 1
+        case let value as Int:
+            return value == 1
+        case let value as Bool:
+            return value
+        default:
+            return false
+        }
+    }
+    
+    private func proxyPort(_ raw: Any?) -> Int {
+        switch raw {
+        case let value as NSNumber:
+            return value.intValue
+        case let value as Int:
+            return value
+        case let value as String:
+            return Int(value) ?? 8080
+        default:
+            return 8080
         }
     }
     
@@ -496,6 +613,7 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
     @objc func refreshPublicIP() {
         self.usage.raddr.v4 = nil
         self.usage.raddr.v6 = nil
+        self.usage.paddr = nil
         
         DispatchQueue.global(qos: .background).async {
             self.getPublicIP()

--- a/Modules/Net/settings.swift
+++ b/Modules/Net/settings.swift
@@ -190,10 +190,14 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
                 action: #selector(self.togglePublicIPState),
                 state: self.publicIPState
             )),
-            PreferencesRow(localizedString("Auto-refresh public IP address"), component: selectView(
+            PreferencesRow(localizedString("Auto-refresh public IP address"), id: "publicIPRefreshInterval", component: selectView(
                 action: #selector(self.toggleRefreshIPInterval),
                 items: PublicIPAddressRefreshIntervals,
                 selected: self.publicIPRefreshInterval
+            )),
+            PreferencesRow(localizedString("Refresh public IP now"), id: "refreshPublicIPNow", component: buttonView(
+                #selector(self.refreshPublicIP),
+                text: localizedString("Refresh")
             ))
         ]
         if self.vpnConnection {
@@ -204,7 +208,8 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
         }
         let section = PreferencesSection(prefs)
         section.setRowVisibility(1, newState: self.readerType == "interface")
-        section.setRowVisibility(5, newState: self.publicIPState)
+        section.setRowVisibility("publicIPRefreshInterval", newState: self.publicIPState)
+        section.setRowVisibility("refreshPublicIPNow", newState: self.publicIPState)
         self.addArrangedSubview(section)
         self.section = section
         
@@ -354,7 +359,11 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     @objc func togglePublicIPState(_ sender: NSControl) {
         self.publicIPState = controlState(sender)
         Store.shared.set(key: "\(self.title)_publicIP", value: self.publicIPState)
-        self.section?.setRowVisibility(5, newState: self.publicIPState)
+        self.section?.setRowVisibility("publicIPRefreshInterval", newState: self.publicIPState)
+        self.section?.setRowVisibility("refreshPublicIPNow", newState: self.publicIPState)
+    }
+    @objc private func refreshPublicIP() {
+        NotificationCenter.default.post(name: .refreshPublicIP, object: nil, userInfo: nil)
     }
     @objc private func toggleRefreshIPInterval(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String else { return }

--- a/Widgets/Supporting Files/Info.plist
+++ b/Widgets/Supporting Files/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12.11</string>
+	<string>2.12.9</string>
 	<key>CFBundleVersion</key>
 	<string>785</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
- add a manual "Refresh" action for public IP in Net settings
- keep public IP related settings rows in sync with the Public IP toggle
- detect scoped/global HTTP, HTTPS, and SOCKS proxy settings
- fetch and store the external IP seen through the configured proxy
- show a new "Proxy IP" row in the Net popup Address section
- refresh direct and proxied public IP values together
<img width="546" height="1450" alt="Xnip2026-04-26_18-13-36" src="https://github.com/user-attachments/assets/30dcb571-915f-43aa-ac94-9bbbe505fea8" />

