### PR TITLE
feat: added latency history widget and popup chart to the Network module

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -327,3 +327,341 @@ public class BarChart: WidgetWrapper {
         self.redraw()
     }
 }
+
+public class LatencyBarsWidget: WidgetWrapper {
+    private static let sizeOptions: [Int] = [15, 25, 35, 50, 70]
+    private static let barPitch: Int = 3 // 2px bar + 1px spacing
+
+    private var widthPx: Int = 35
+    private var thresholds: LatencyThresholds = .default
+    private var boxState: Bool = false
+    private var frameState: Bool = false
+    private var showValueState: Bool = false
+
+    private var boxSettingsView: NSSwitch? = nil
+    private var frameSettingsView: NSSwitch? = nil
+
+    private var _bars: [LatencyBucket] = []
+    private var _latestLatency: Double? = nil
+    private var _latestOnline: Bool = true
+
+    public init(title: String, config: NSDictionary?, preview: Bool = false) {
+        var widgetTitle: String = title
+        if let titleFromConfig = config?["Title"] as? String {
+            widgetTitle = titleFromConfig
+        }
+
+        super.init(.latencyBars, title: widgetTitle, frame: CGRect(
+            x: Constants.Widget.margin.x,
+            y: Constants.Widget.margin.y,
+            width: 35 + (2*Constants.Widget.margin.x),
+            height: Constants.Widget.height - (2*Constants.Widget.margin.y)
+        ))
+
+        self.canDrawConcurrently = true
+
+        if !preview {
+            self.widthPx = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_size", defaultValue: self.widthPx)
+            self.boxState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_box", defaultValue: self.boxState)
+            self.frameState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_frame", defaultValue: self.frameState)
+            self.showValueState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_showValue", defaultValue: self.showValueState)
+            self.thresholds = currentLatencyThresholds(module: self.title)
+        }
+
+        self._bars = Array(repeating: .empty, count: self.barCount)
+
+        if preview {
+            let pattern: [Double] = [30, 45, 80, 60, 40, 55, 90, 120, 250, 180, 90, 50, 70, 30, 40]
+            for i in 0..<self._bars.count {
+                self._bars[i] = LatencyBucket(latency: pattern[i % pattern.count], online: true, hasData: true)
+            }
+            self.display()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var barCount: Int {
+        max(1, self.widthPx / Self.barPitch)
+    }
+
+    public override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        var bars: [LatencyBucket] = []
+        var latestLatency: Double? = nil
+        var latestOnline: Bool = true
+        self.queue.sync {
+            bars = self._bars
+            latestLatency = self._latestLatency
+            latestOnline = self._latestOnline
+        }
+        guard !bars.isEmpty else {
+            self.setWidth(0)
+            return
+        }
+
+        let lineWidth = 1 / (NSScreen.main?.backingScaleFactor ?? 1)
+        let offset = lineWidth / 2
+        let contentWidth = CGFloat(self.widthPx)
+
+        var labelWidth: CGFloat = 0
+        var valueStr: NSAttributedString? = nil
+        var unitStr: NSAttributedString? = nil
+        if self.showValueState {
+            let valueText: String
+            let unitText: String
+            var color: NSColor = .textColor
+            if !latestOnline {
+                valueText = "!!"
+                unitText = ""
+                color = .systemRed
+            } else if let l = latestLatency, l > 0 {
+                valueText = "\(Int(l.rounded()))"
+                unitText = "ms"
+                color = latencyColor(for: l, thresholds: self.thresholds)
+            } else {
+                valueText = "—"
+                unitText = ""
+            }
+            let valueFont: NSFont = !latestOnline
+                ? NSFont.systemFont(ofSize: 14, weight: .heavy)
+                : NSFont.systemFont(ofSize: 10, weight: .regular)
+            let valueAttrs: [NSAttributedString.Key: Any] = [
+                .font: valueFont,
+                .foregroundColor: color
+            ]
+            let unitAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 7, weight: .regular),
+                .foregroundColor: color.withAlphaComponent(0.75)
+            ]
+            valueStr = NSAttributedString(string: valueText, attributes: valueAttrs)
+            if !unitText.isEmpty {
+                unitStr = NSAttributedString(string: unitText, attributes: unitAttrs)
+            }
+            let vW = valueStr?.size().width ?? 0
+            let uW = unitStr?.size().width ?? 0
+            let refAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 10, weight: .regular)
+            ]
+            let refWidth = NSAttributedString(string: "000", attributes: refAttrs).size().width
+            labelWidth = ceil(max(refWidth, vW, uW))
+        }
+
+        let labelGap: CGFloat = (labelWidth > 0) ? Constants.Widget.spacing : 0
+        let totalWidth: CGFloat = labelWidth + labelGap + contentWidth + (Constants.Widget.margin.x * 2) + (offset * 2)
+        let labelOriginX = offset + contentWidth + labelGap
+
+        if let valueStr {
+            let frameH = self.frame.size.height
+            let vSize = valueStr.size()
+            if let unitStr {
+                let uSize = unitStr.size()
+                let vGap: CGFloat = -2
+                let totalH = ceil(vSize.height) + ceil(uSize.height) + vGap
+                let yBottom = (frameH - totalH) / 2
+                let xUnit = labelOriginX + (labelWidth - uSize.width) / 2
+                unitStr.draw(at: CGPoint(x: xUnit, y: yBottom))
+                let xValue = labelOriginX + (labelWidth - vSize.width) / 2
+                valueStr.draw(at: CGPoint(x: xValue, y: yBottom + ceil(uSize.height) + vGap))
+            } else {
+                let yCenter = (frameH - vSize.height) / 2
+                let xValue = labelOriginX + (labelWidth - vSize.width) / 2
+                valueStr.draw(at: CGPoint(x: xValue, y: yCenter))
+            }
+        }
+
+        let boxRect = NSRect(
+            x: offset,
+            y: offset,
+            width: contentWidth,
+            height: self.frame.size.height - (offset * 2)
+        )
+        let box = NSBezierPath(roundedRect: boxRect, xRadius: 2, yRadius: 2)
+
+        if self.boxState {
+            (isDarkMode ? NSColor.white : NSColor.black).set()
+            box.fill()
+        }
+
+        renderLatencyBars(in: boxRect, bars: bars, thresholds: self.thresholds)
+
+        if self.boxState || self.frameState {
+            (isDarkMode ? NSColor.white : NSColor.black).set()
+            box.lineWidth = lineWidth
+            box.stroke()
+        }
+
+        self.setWidth(totalWidth)
+    }
+
+    public func setValue(latency: Double?, online: Bool) {
+        let bucket = LatencyBucket(LatencySample(latency: latency, online: online))
+        self.queue.async(flags: .barrier) { [weak self] in
+            guard let self else { return }
+            guard !self._bars.isEmpty else { return }
+            self._bars.removeFirst()
+            self._bars.append(bucket)
+            self._latestLatency = bucket.hasData ? bucket.latency : nil
+            self._latestOnline = bucket.online
+            self.redraw()
+        }
+    }
+
+    private func resampleBars(newCount: Int) {
+        let newSize = max(newCount, 1)
+        self.queue.async(flags: .barrier) { [weak self] in
+            guard let self else { return }
+            if newSize == self._bars.count { return }
+            if self._bars.isEmpty {
+                self._bars = Array(repeating: .empty, count: newSize)
+            } else if self._bars.count >= newSize {
+                self._bars = Array(self._bars.suffix(newSize))
+            } else {
+                self._bars = Array(repeating: .empty, count: newSize - self._bars.count) + self._bars
+            }
+        }
+    }
+
+    public override func settings() -> NSView {
+        let view = SettingsContainerView()
+
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Size"), component: selectView(
+                action: #selector(self.toggleSize),
+                items: Self.sizeOptions.map { KeyValue_t(key: "\($0)", value: "\($0) px") },
+                selected: "\(self.widthPx)"
+            ))
+        ]))
+
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Thresholds (ms)"), component: self.buildThresholdsRow())
+        ]))
+
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Value"), component: switchView(
+                action: #selector(self.toggleShowValue),
+                state: self.showValueState
+            )),
+            PreferencesRow(localizedString("Box"), component: self.installedBoxSwitch()),
+            PreferencesRow(localizedString("Frame"), component: self.installedFrameSwitch())
+        ]))
+
+        return view
+    }
+
+    private func installedBoxSwitch() -> NSSwitch {
+        let s = switchView(action: #selector(self.toggleBox), state: self.boxState)
+        self.boxSettingsView = s
+        return s
+    }
+
+    private func installedFrameSwitch() -> NSSwitch {
+        let s = switchView(action: #selector(self.toggleFrame), state: self.frameState)
+        self.frameSettingsView = s
+        return s
+    }
+
+    @objc private func toggleShowValue(_ sender: NSControl) {
+        self.showValueState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_showValue", value: self.showValueState)
+        self.redraw()
+    }
+
+    private static let thresholdInputWidth: CGFloat = 100
+    private static let thresholdSpecs: [(key: String, color: NSColor, value: (LatencyThresholds) -> Double)] = [
+        ("green",  .systemGreen,  { $0.green }),
+        ("yellow", .systemYellow, { $0.yellow }),
+        ("red",    .systemRed,    { $0.red })
+    ]
+
+    private func buildThresholdsRow() -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.distribution = .fill
+        row.spacing = 6
+        for spec in Self.thresholdSpecs {
+            row.addArrangedSubview(self.thresholdInput(color: spec.color, key: spec.key, value: Int(spec.value(self.thresholds))))
+        }
+        return row
+    }
+
+    private func thresholdInput(color: NSColor, key: String, value: Int) -> NSView {
+        let container = NSStackView()
+        container.orientation = .horizontal
+        container.spacing = 3
+        container.alignment = .centerY
+
+        let dot = NSView()
+        dot.wantsLayer = true
+        dot.layer?.backgroundColor = color.cgColor
+        dot.layer?.cornerRadius = 4
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        dot.widthAnchor.constraint(equalToConstant: 8).isActive = true
+        dot.heightAnchor.constraint(equalToConstant: 8).isActive = true
+
+        let le = NSTextField(labelWithString: "\u{2264}")
+        le.font = NSFont.systemFont(ofSize: 11, weight: .regular)
+        le.textColor = .secondaryLabelColor
+
+        let stepper = StepperInput(
+            value,
+            range: NSRange(location: 1, length: 4999),
+            unit: "",
+            callback: { [weak self] v in self?.setThreshold(key: key, value: v) }
+        )
+
+        container.addArrangedSubview(dot)
+        container.addArrangedSubview(le)
+        container.addArrangedSubview(stepper)
+        container.widthAnchor.constraint(equalToConstant: Self.thresholdInputWidth).isActive = true
+        return container
+    }
+
+    @objc private func toggleSize(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String,
+              let px = Int(key), Self.sizeOptions.contains(px) else { return }
+        self.widthPx = px
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_size", value: px)
+        self.resampleBars(newCount: self.barCount)
+        self.redraw()
+    }
+
+    private func setThreshold(key: String, value: Int) {
+        let v = Double(value)
+        switch key {
+        case "green":  self.thresholds.green  = min(v, self.thresholds.yellow - 1)
+        case "yellow": self.thresholds.yellow = min(max(v, self.thresholds.green + 1), self.thresholds.red - 1)
+        case "red":    self.thresholds.red    = max(v, self.thresholds.yellow + 1)
+        default: return
+        }
+        Store.shared.set(key: "\(self.title)_latencyThreshold_green",  value: Int(self.thresholds.green))
+        Store.shared.set(key: "\(self.title)_latencyThreshold_yellow", value: Int(self.thresholds.yellow))
+        Store.shared.set(key: "\(self.title)_latencyThreshold_red",    value: Int(self.thresholds.red))
+        self.redraw()
+    }
+
+    @objc private func toggleBox(_ sender: NSControl) {
+        self.boxState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_box", value: self.boxState)
+        if self.boxState && self.frameState {
+            self.frameState = false
+            self.frameSettingsView?.state = .off
+            Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_frame", value: self.frameState)
+        }
+        self.redraw()
+    }
+
+    @objc private func toggleFrame(_ sender: NSControl) {
+        self.frameState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_frame", value: self.frameState)
+        if self.frameState && self.boxState {
+            self.boxState = false
+            self.boxSettingsView?.state = .off
+            Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_box", value: self.boxState)
+        }
+        self.redraw()
+    }
+}

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -27,6 +27,7 @@ public enum widget_t: String {
     case tachometer = "tachometer"
     case state = "state"
     case text = "text"
+    case latencyBars = "latency_bars"
     
     public func new(module: String, config: NSDictionary, defaultWidget: widget_t) -> SWidget? {
         guard let widgetConfig: NSDictionary = config[self.rawValue] as? NSDictionary else { return nil }
@@ -78,6 +79,9 @@ public enum widget_t: String {
         case .text:
             preview = TextWidget(title: module, config: widgetConfig, preview: true)
             item = TextWidget(title: module, config: widgetConfig, preview: false)
+        case .latencyBars:
+            preview = LatencyBarsWidget(title: module, config: widgetConfig, preview: true)
+            item = LatencyBarsWidget(title: module, config: widgetConfig, preview: false)
         default: break
         }
         
@@ -142,6 +146,7 @@ public enum widget_t: String {
         case .tachometer: return localizedString("Tachometer widget")
         case .state: return localizedString("State widget")
         case .text: return localizedString("Text widget")
+        case .latencyBars: return localizedString("Latency history")
         default: return ""
         }
     }

--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -1180,6 +1180,363 @@ public class GridChartView: ChartView {
     }
 }
 
+public struct LatencySample {
+    public let latency: Double?
+    public let online: Bool
+    public init(latency: Double? = nil, online: Bool = true) {
+        self.latency = latency
+        self.online = online
+    }
+}
+
+internal struct LatencyBucket {
+    var latency: Double
+    var online: Bool
+    var hasData: Bool
+    static let empty = LatencyBucket(latency: 0, online: true, hasData: false)
+    init(latency: Double, online: Bool, hasData: Bool) {
+        self.latency = latency
+        self.online = online
+        self.hasData = hasData
+    }
+    init(_ sample: LatencySample) {
+        let v = sample.latency ?? 0
+        self.init(latency: v, online: sample.online, hasData: v > 0)
+    }
+}
+
+public struct LatencyThresholds {
+    public var green: Double
+    public var yellow: Double
+    public var red: Double
+    public static let `default` = LatencyThresholds(green: 50, yellow: 100, red: 200)
+    public init(green: Double, yellow: Double, red: Double) {
+        self.green = green
+        self.yellow = yellow
+        self.red = red
+    }
+}
+
+public func currentLatencyThresholds(module: String) -> LatencyThresholds {
+    return LatencyThresholds(
+        green:  Double(Store.shared.int(key: "\(module)_latencyThreshold_green",  defaultValue: Int(LatencyThresholds.default.green))),
+        yellow: Double(Store.shared.int(key: "\(module)_latencyThreshold_yellow", defaultValue: Int(LatencyThresholds.default.yellow))),
+        red:    Double(Store.shared.int(key: "\(module)_latencyThreshold_red",    defaultValue: Int(LatencyThresholds.default.red)))
+    )
+}
+
+internal func latencyColor(for latency: Double, thresholds: LatencyThresholds) -> NSColor {
+    if latency <= thresholds.green  { return .systemGreen }
+    if latency <= thresholds.yellow { return .systemYellow }
+    return .systemRed
+}
+
+// Auto-scale floor (ms): the chart's vertical range never goes below this even
+// on a perfectly idle link, so small fluctuations stay readable.
+private let latencyAutoScaleFloorMs: Double = 50
+// Inactive bar fill (no-data buckets) as a fraction of the chart height.
+private let latencyInactiveFillRatio: CGFloat = 0.08
+// When yellow or red appear inside a bar, each band gets at least this fraction
+// of the bar height so a threshold crossing reads clearly rather than as a 1-pixel tip.
+private let latencyBandAccentFraction: CGFloat = 0.3
+// Bar pitch (px per bar including spacing) used by the latency widget and popup.
+internal let latencyBarSpacing: CGFloat = 1
+
+// Returns (barWidth, spacing) that exactly fits `count` bars in `width`.
+// Drops spacing to 0 when bars become too dense to fit with normal spacing.
+internal func latencyBarLayout(width: CGFloat, count: Int) -> (barWidth: CGFloat, spacing: CGFloat) {
+    guard count > 0, width > 0 else { return (0, 0) }
+    let perBarWithSpacing = width / CGFloat(count)
+    let spacing: CGFloat = perBarWithSpacing >= 2 + latencyBarSpacing ? latencyBarSpacing : 0
+    let barWidth = max((width - spacing * CGFloat(count - 1)) / CGFloat(count), 0.5)
+    return (barWidth, spacing)
+}
+
+internal func renderLatencyBars(
+    in rect: NSRect,
+    bars: [LatencyBucket],
+    thresholds: LatencyThresholds
+) {
+    guard !bars.isEmpty, rect.width > 0, rect.height > 0 else { return }
+
+    let (barWidth, spacing) = latencyBarLayout(width: rect.width, count: bars.count)
+
+    // Fixed scale based on the red threshold. Keeps bar heights stable across
+    // redraws (no auto-rescale flicker as the visible-max changes). Bars above
+    // the red threshold are clipped to full height — which matches the "above
+    // bad" semantic of the threshold itself.
+    let scaleMax = max(thresholds.red, latencyAutoScaleFloorMs)
+
+    func heightFor(_ v: Double) -> CGFloat {
+        let capped = min(max(v, 0), scaleMax)
+        return rect.height * max(min(CGFloat(capped / scaleMax), 1), 0)
+    }
+
+    var x: CGFloat = rect.minX
+    for b in bars {
+        if !b.online {
+            NSColor.systemRed.setFill()
+            NSBezierPath(roundedRect: NSRect(x: x, y: rect.minY, width: barWidth, height: rect.height),
+                         xRadius: 1, yRadius: 1).fill()
+        } else if b.hasData {
+            let barHeight = max(heightFor(b.latency), rect.height * latencyInactiveFillRatio)
+            let barRect = NSRect(x: x, y: rect.minY, width: barWidth, height: barHeight)
+            let clip = NSBezierPath(roundedRect: barRect, xRadius: 1, yRadius: 1)
+
+            var greenTop  = min(heightFor(thresholds.green),  barHeight)
+            var yellowTop = min(heightFor(thresholds.yellow), barHeight)
+
+            if barHeight > yellowTop {
+                let minRed = barHeight * latencyBandAccentFraction
+                if barHeight - yellowTop < minRed { yellowTop = barHeight - minRed }
+            }
+            if yellowTop > greenTop {
+                let minYellow = barHeight * latencyBandAccentFraction
+                if yellowTop - greenTop < minYellow { greenTop = max(0, yellowTop - minYellow) }
+            }
+
+            NSGraphicsContext.current?.saveGraphicsState()
+            clip.addClip()
+            if greenTop > 0 {
+                NSColor.systemGreen.setFill()
+                NSRect(x: x, y: rect.minY, width: barWidth, height: greenTop).fill()
+            }
+            if yellowTop > greenTop {
+                NSColor.systemYellow.setFill()
+                NSRect(x: x, y: rect.minY + greenTop, width: barWidth, height: yellowTop - greenTop).fill()
+            }
+            if barHeight > yellowTop {
+                NSColor.systemRed.setFill()
+                NSRect(x: x, y: rect.minY + yellowTop, width: barWidth, height: barHeight - yellowTop).fill()
+            }
+            NSGraphicsContext.current?.restoreGraphicsState()
+        }
+        // Empty buckets: render nothing so the chart's filled length matches
+        // the usage chart's filled length when accumulating after launch.
+        x += barWidth + spacing
+    }
+}
+
+public class LatencyBarChartView: ChartView {
+    private static let tooltipWidth: CGFloat = 78
+    private static let rawSampleLimit: Int = 600
+    private static let tooltipDateFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "HH:mm:ss"; return f
+    }()
+
+    private var bars: [LatencyBucket]
+    private var barTimes: [Date?]
+    private var rawBars: [LatencyBucket] = []
+    private var rawTimes: [Date?] = []
+    private var hoverIdx: Int? = nil
+    private var thresholds: LatencyThresholds = .default
+
+    private var samplesPerBar: Int
+    // Counts new raw samples accumulated since the last bar commit.
+    // When this reaches samplesPerBar, a new bar is committed (once, fixed value).
+    private var pendingCount: Int = 0
+
+    // Main-thread cache to skip redundant write+redraw on intra-bar mouseMoved events.
+    private var lastHoverIdx: Int? = nil
+
+    public init(frame: NSRect, barCount: Int, samplesPerBar: Int = 1) {
+        let count = max(barCount, 1)
+        self.bars = Array(repeating: .empty, count: count)
+        self.barTimes = Array(repeating: nil, count: count)
+        self.samplesPerBar = max(samplesPerBar, 1)
+        super.init(frame: frame, queueLabel: "eu.exelban.Stats.Charts.LatencyBars")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func draw(_ dirtyRect: NSRect) {
+        var bars: [LatencyBucket] = []
+        var barTimes: [Date?] = []
+        var thresholds: LatencyThresholds = .default
+        var hoverIdx: Int? = nil
+        self.read {
+            bars = self.bars
+            barTimes = self.barTimes
+            thresholds = self.thresholds
+            hoverIdx = self.hoverIdx
+        }
+        renderLatencyBars(in: self.bounds, bars: bars, thresholds: thresholds)
+
+        guard let idx = hoverIdx, idx >= 0, idx < bars.count else { return }
+        let b = bars[idx]
+        guard b.hasData || !b.online else { return }
+
+        let (barWidth, spacing) = latencyBarLayout(width: self.bounds.width, count: bars.count)
+        let xCenter = CGFloat(idx) * (barWidth + spacing) + barWidth / 2
+        let vLine = NSBezierPath()
+        vLine.setLineDash([4, 4], count: 2, phase: 0)
+        vLine.move(to: CGPoint(x: xCenter, y: 0))
+        vLine.line(to: CGPoint(x: xCenter, y: self.bounds.height))
+        NSColor.tertiaryLabelColor.set()
+        vLine.lineWidth = 1 / (NSScreen.main?.backingScaleFactor ?? 1)
+        vLine.stroke()
+
+        let latencyText = b.online ? "\(Int(b.latency.rounded())) ms" : localizedString("Offline")
+        let timeText = barTimes[idx].map { Self.tooltipDateFormatter.string(from: $0) } ?? ""
+        let w = Self.tooltipWidth
+        let tooltipX = xCenter + 4 + w > self.bounds.width ? xCenter - w - 4 : xCenter + 4
+        drawToolTip(self.frame, CGPoint(x: tooltipX, y: self.bounds.height / 2),
+                    CGSize(width: w, height: self.bounds.height),
+                    value: latencyText, subtitle: timeText)
+    }
+
+    public func addValue(_ sample: LatencySample) {
+        self.write {
+            self.rawBars.append(LatencyBucket(sample))
+            self.rawTimes.append(Date())
+            if self.rawBars.count > Self.rawSampleLimit {
+                self.rawBars.removeFirst(self.rawBars.count - Self.rawSampleLimit)
+                self.rawTimes.removeFirst(self.rawTimes.count - Self.rawSampleLimit)
+            }
+
+            // Commit-once aggregation: once enough raw samples have accumulated for
+            // a bar, commit it as the rightmost bar with a fixed value. Older bars
+            // never recompute, eliminating per-sample height/color flicker.
+            self.pendingCount += 1
+            guard self.pendingCount >= self.samplesPerBar else { return }
+            let chunkStart = self.rawBars.count - self.samplesPerBar
+            let bucket = self.aggregate(self.rawBars[chunkStart..<self.rawBars.count])
+            let time = self.aggregateTime(self.rawTimes[chunkStart..<self.rawTimes.count])
+            self.bars.removeFirst()
+            self.bars.append(bucket)
+            self.barTimes.removeFirst()
+            self.barTimes.append(time)
+            self.pendingCount = 0
+            self.displayIfVisible()
+        }
+    }
+
+    public func setThresholds(_ thresholds: LatencyThresholds) {
+        self.write {
+            self.thresholds = thresholds
+            self.displayIfVisible()
+        }
+    }
+
+    // Aggregate a slice of raw samples into a single bucket. Latency is the
+    // arithmetic mean of samples that produced data. Any single offline sample
+    // in the slice marks the whole bucket as offline — by design, favouring
+    // visibility of brief outages over averaging them away. Result: a 1-of-10
+    // dropped ping at chartHistory=10min still paints a visible red bar.
+    private func aggregate(_ buckets: ArraySlice<LatencyBucket>) -> LatencyBucket {
+        var latency: Double = 0
+        var count: Int = 0
+        var online = true
+        var hasState = false
+        for b in buckets {
+            if b.hasData {
+                latency += b.latency
+                count += 1
+                hasState = true
+            }
+            if !b.online {
+                online = false
+                hasState = true
+            }
+        }
+        guard hasState else { return .empty }
+        return LatencyBucket(latency: count > 0 ? latency / Double(count) : 0, online: online, hasData: count > 0)
+    }
+
+    private func aggregateTime(_ times: ArraySlice<Date?>) -> Date? {
+        for t in times.reversed() {
+            if let t { return t }
+        }
+        return nil
+    }
+
+    private func resampleBars(
+        _ bars: [LatencyBucket],
+        _ times: [Date?],
+        to newCount: Int,
+        samplesPerBar: Int
+    ) -> (bars: [LatencyBucket], times: [Date?]) {
+        let newPerBar = max(samplesPerBar, 1)
+        let sampleCount = max(newCount * newPerBar, 1)
+        var samples = bars
+        var sampleTimes = times
+        if samples.count > sampleCount {
+            samples = Array(samples.suffix(sampleCount))
+            sampleTimes = Array(sampleTimes.suffix(sampleCount))
+        } else if samples.count < sampleCount {
+            samples = Array(repeating: .empty, count: sampleCount - samples.count) + samples
+            sampleTimes = Array(repeating: nil, count: sampleCount - sampleTimes.count) + sampleTimes
+        }
+
+        var resultBars: [LatencyBucket] = []
+        var resultTimes: [Date?] = []
+        for idx in 0..<newCount {
+            let start = idx * newPerBar
+            let range = start..<start + newPerBar
+            resultBars.append(self.aggregate(samples[range]))
+            resultTimes.append(self.aggregateTime(sampleTimes[range]))
+        }
+        return (resultBars, resultTimes)
+    }
+
+    public func reinit(barCount: Int, samplesPerBar: Int = 1) {
+        let count = max(barCount, 1)
+        let perBar = max(samplesPerBar, 1)
+        self.write {
+            // Re-aggregate from raw history so the chart's content reflects the new
+            // bucketing. The in-progress accumulator is reset since its prior chunking
+            // assumption no longer applies.
+            let resampled = self.resampleBars(self.rawBars, self.rawTimes, to: count, samplesPerBar: perBar)
+            self.bars = resampled.bars
+            self.barTimes = resampled.times
+            self.samplesPerBar = perBar
+            self.pendingCount = 0
+            self.hoverIdx = nil
+            self.displayIfVisible()
+        }
+        self.lastHoverIdx = nil
+    }
+
+    public override func updateTrackingAreas() {
+        self.trackingAreas.forEach { self.removeTrackingArea($0) }
+        self.addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .inVisibleRect],
+            owner: self, userInfo: nil
+        ))
+        super.updateTrackingAreas()
+    }
+
+    private func barIndex(at point: CGPoint, count: Int) -> Int? {
+        guard count > 0, self.bounds.contains(point) else { return nil }
+        let (barWidth, spacing) = latencyBarLayout(width: self.bounds.width, count: count)
+        return min(max(Int(point.x / (barWidth + spacing)), 0), count - 1)
+    }
+
+    private func updateHover(_ idx: Int?) {
+        if idx == self.lastHoverIdx { return }
+        self.lastHoverIdx = idx
+        self.write {
+            self.hoverIdx = idx
+            self.displayIfVisible()
+        }
+    }
+
+    public override func mouseEntered(with event: NSEvent) {
+        let count = self.read { self.bars.count }
+        self.updateHover(self.barIndex(at: self.convert(event.locationInWindow, from: nil), count: count))
+    }
+    public override func mouseMoved(with event: NSEvent) {
+        let count = self.read { self.bars.count }
+        self.updateHover(self.barIndex(at: self.convert(event.locationInWindow, from: nil), count: count))
+    }
+    public override func mouseExited(with event: NSEvent) {
+        self.updateHover(nil)
+    }
+}
+
 public class BarChartView: ChartView {
     private var values: [ColorValue] = []
     private var cursor: CGPoint? = nil

--- a/Modules/Net/config.plist
+++ b/Modules/Net/config.plist
@@ -75,6 +75,13 @@
 				<string>192.168.0.1</string>
 			</dict>
 		</dict>
+		<key>latency_bars</key>
+		<dict>
+			<key>Default</key>
+			<false/>
+			<key>Order</key>
+			<integer>5</integer>
+		</dict>
 	</dict>
 	<key>Settings</key>
 	<dict>

--- a/Modules/Net/main.swift
+++ b/Modules/Net/main.swift
@@ -355,6 +355,8 @@ public class Network: Module {
             case let widget as DotWidget:
                 let value = value.status ? SColor.secondGreen : SColor.secondRed
                 widget.setValue(value.additional as? NSColor ?? .systemGray)
+            case let widget as LatencyBarsWidget:
+                widget.setValue(latency: value.status ? value.latency : nil, online: value.status)
             default: break
             }
         }

--- a/Modules/Net/popup.swift
+++ b/Modules/Net/popup.swift
@@ -77,6 +77,14 @@ internal class Popup: PopupWrapper {
     private var chartFixedScaleSize: SizeUnit = .MB
     private var chartPrefSection: PreferencesSection? = nil
     private var connectivityChart: GridChartView? = nil
+    private var latencyChart: LatencyBarChartView? = nil
+    private var connectivitySection: NSView? = nil
+    private var latencySection: NSView? = nil
+    private var chartsMode: String = "connectivity"
+    private static let chartsOptions: [(key: String, label: String)] = [
+        ("connectivity", "Connectivity history"),
+        ("latency",      "Latency history")
+    ]
     
     private var initialized: Bool = false
     private var processesInitialized: Bool = false
@@ -129,10 +137,13 @@ internal class Popup: PopupWrapper {
         self.publicIPState = Store.shared.bool(key: "\(self.title)_publicIP", defaultValue: self.publicIPState)
         self.interfaceDetailsState = Store.shared.bool(key: "\(self.title)_interfaceDetails", defaultValue: self.interfaceDetailsState)
         self.emojiCCState = Store.shared.bool(key: "\(self.title)_emojiCC", defaultValue: self.emojiCCState)
+        let storedChartsMode = Store.shared.string(key: "\(self.title)_chartsMode", defaultValue: self.chartsMode)
+        self.chartsMode = Self.chartsOptions.contains(where: { $0.key == storedChartsMode }) ? storedChartsMode : self.chartsMode
         
         self.addArrangedSubview(self.initDashboard())
         self.addArrangedSubview(self.initChart())
         self.addArrangedSubview(self.initConnectivityChart())
+        self.addArrangedSubview(self.initLatencyChart())
         self.addArrangedSubview(self.initDetails())
         self.addArrangedSubview(self.initInterface())
         self.addArrangedSubview(self.initAddress())
@@ -141,6 +152,8 @@ internal class Popup: PopupWrapper {
         if !self.publicIPState {
             self.addressView?.removeFromSuperview()
         }
+        if self.chartsMode == "latency" { self.connectivitySection?.removeFromSuperview() }
+        if self.chartsMode == "connectivity" { self.latencySection?.removeFromSuperview() }
         
         self.recalculateHeight()
         
@@ -236,7 +249,57 @@ internal class Popup: PopupWrapper {
         let chart = GridChartView(frame: NSRect(x: 0, y: 1, width: container.frame.width, height: container.frame.height - 2), grid: (30, 3))
         container.addSubview(chart)
         self.connectivityChart = chart
+        self.connectivitySection = view
         
+        view.addSubview(separator)
+        view.addSubview(container)
+        
+        return view
+    }
+
+    // Popup latency chart pitch (chart_width / popupLatencyBarPitch = max bar count).
+    // Chosen wider than the menu-bar widget pitch so individual bars stay legible
+    // in the larger popup canvas.
+    private static let popupLatencyBarPitch: CGFloat = 4
+
+    // When chartHistory exceeds the visual cap, ICMP samples aggregate into each
+    // bar (running mean) so the chart still covers the full requested time window
+    // — same wall-clock span as the usage chart, but with chunkier bars.
+    private func popupLatencyLayout(in width: CGFloat) -> (barCount: Int, samplesPerBar: Int) {
+        let history = max(self.chartHistory, 1)
+        let maxBars = max(1, Int(width / Self.popupLatencyBarPitch))
+        guard history > maxBars else { return (history, 1) }
+
+        let minSamplesPerBar = Int(ceil(Double(history) / Double(maxBars)))
+        for samplesPerBar in minSamplesPerBar...history {
+            if history % samplesPerBar == 0 {
+                return (history / samplesPerBar, samplesPerBar)
+            }
+        }
+        return (maxBars, minSamplesPerBar)
+    }
+
+    private func initLatencyChart() -> NSView {
+        let view: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: 30 + Constants.Popup.separatorHeight))
+        view.heightAnchor.constraint(equalToConstant: view.bounds.height).isActive = true
+        let separator = separatorView(localizedString("Latency history"), origin: NSPoint(x: 0, y: 30), width: self.frame.width)
+        let container: NSView = NSView(frame: NSRect(x: 0, y: 0, width: self.frame.width, height: separator.frame.origin.y))
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor.lightGray.withAlphaComponent(0.1).cgColor
+        container.layer?.cornerRadius = 3
+
+        let chartFrame = NSRect(x: 0, y: 1, width: container.frame.width, height: container.frame.height - 2)
+        let layout = self.popupLatencyLayout(in: chartFrame.width)
+        let chart = LatencyBarChartView(
+            frame: chartFrame,
+            barCount: layout.barCount,
+            samplesPerBar: layout.samplesPerBar
+        )
+        chart.setThresholds(currentLatencyThresholds(module: self.title))
+        container.addSubview(chart)
+        self.latencyChart = chart
+        self.latencySection = view
+
         view.addSubview(separator)
         view.addSubview(container)
         
@@ -645,6 +708,10 @@ internal class Popup: PopupWrapper {
             if let value, let chart = self.connectivityChart {
                 chart.addValue(value.status)
             }
+            self.latencyChart?.addValue(LatencySample(
+                latency: value?.status == true ? value?.latency : nil,
+                online: value?.status ?? true
+            ))
         })
     }
     
@@ -700,6 +767,11 @@ internal class Popup: PopupWrapper {
             PreferencesRow(localizedString("Reverse order"), component: switchView(
                 action: #selector(self.toggleReverseOrder),
                 state: self.reverseOrderState
+            )),
+            PreferencesRow(localizedString("Display mode"), component: selectView(
+                action: #selector(self.toggleChartsMode),
+                items: Self.chartsOptions.map { KeyValue_t(key: $0.key, value: localizedString($0.label)) },
+                selected: self.chartsMode
             ))
         ]))
         
@@ -771,11 +843,30 @@ internal class Popup: PopupWrapper {
         Store.shared.set(key: "\(self.title)_reverseOrder", value: self.reverseOrderState)
         self.display()
     }
+    @objc private func toggleChartsMode(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String,
+              Self.chartsOptions.contains(where: { $0.key == key }) else { return }
+        self.chartsMode = key
+        Store.shared.set(key: "\(self.title)_chartsMode", value: key)
+
+        DispatchQueue.main.async {
+            self.connectivitySection?.removeFromSuperview()
+            self.latencySection?.removeFromSuperview()
+            // Insert the selected chart after Dashboard (0) and Usage chart (1).
+            let section = self.chartsMode == "latency" ? self.latencySection : self.connectivitySection
+            if let section { self.insertArrangedSubview(section, at: 2) }
+            self.recalculateHeight()
+        }
+    }
     @objc private func togglechartHistory(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String, let value = Int(key) else { return }
         self.chartHistory = value
         Store.shared.set(key: "\(self.title)_chartHistory", value: value)
         self.chart?.reinit(self.chartHistory)
+        if let chart = self.latencyChart {
+            let layout = self.popupLatencyLayout(in: chart.frame.width)
+            chart.reinit(barCount: layout.barCount, samplesPerBar: layout.samplesPerBar)
+        }
     }
     @objc private func toggleChartScale(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String,

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -412,6 +412,9 @@
 "Connectivity host" = "Connectivity host";
 "Leave empty to disable the check" = "Leave empty to disable the check";
 "Connectivity history" = "Connectivity history";
+"Size" = "Size";
+"Thresholds (ms)" = "Thresholds (ms)";
+"Latency history" = "Latency history";
 "Auto-refresh public IP address" = "Auto-refresh public IP address";
 "Every hour" = "Every hour";
 "Every 12 hours" = "Every 12 hours";


### PR DESCRIPTION
Adds a latency visualisation to the existing Network module — both as a new
menu-bar widget and as an additional chart in the popup. Reuses the existing
`ConnectivityReader` ICMP stream; no new ping traffic is introduced.

## Widget — `Latency history`

A new menu-bar widget rendering recent ICMP latency as colored vertical bars,
with multi-band stacking inside each bar (green / yellow / red, thresholds
configurable). Optional value label to the right shows the latest ping in ms,
color-coded; "!!" in red when the link is offline. Width reserved for a 3-digit
value so the menu bar doesn't shift when latency crosses 99↔100 ms.

Settings: Size · Thresholds (ms) · Value · Box · Frame.

## Popup — `Latency history` chart

A new chart in the Network popup, rendered with the same multi-band styling as
the widget. Includes a hover tooltip (latency in ms + timestamp) reusing the
existing `drawToolTip` helper.

A new "View mode" row in the popup settings lets the user pick between
`Connectivity history` (existing chart) and `Latency history` (new). Default
is `Connectivity history` so existing users see no behavioural change unless
they opt in.

The latency chart respects the existing `Chart history` setting and stays
time-aligned with the usage history chart at every history value via per-bar
aggregation when needed.

## Screenshots

### Widget

| Sample Default Look | Default | With Value | Offline |
|---|---|---|---|
| <img width="247" height="27" alt="CleanShot 2026-04-26 at 22 57 31" src="https://github.com/user-attachments/assets/6c422664-50ab-40d3-a897-10110657a488" /> | <img width="43" height="26" alt="CleanShot 2026-04-26 at 22 57 41" src="https://github.com/user-attachments/assets/980d17d7-01d3-4ad1-a22d-9cc2988370c9" /> | <img width="66" height="27" alt="CleanShot 2026-04-26 at 22 59 05" src="https://github.com/user-attachments/assets/0d9ec5c5-e850-4b0b-89e2-44751bd053e0" /> | <img width="67" height="29" alt="CleanShot 2026-04-26 at 23 01 09" src="https://github.com/user-attachments/assets/f7e58f20-0699-43c6-a311-fba5ba096699" /> |

### Popup

<img width="280" height="492" alt="CleanShot 2026-04-26 at 23 12 30" src="https://github.com/user-attachments/assets/6c892c79-d80e-4e1e-96b7-7888aa87f9fa" />

### Settings

| Widget settings | Popup settings |
|---|---|
| <img width="823" height="480" alt="CleanShot 2026-04-26 at 22 58 46" src="https://github.com/user-attachments/assets/bec54c42-d84c-44c5-a323-c6f188cdd64f" /> | <img width="823" height="480" alt="CleanShot 2026-04-26 at 22 58 36" src="https://github.com/user-attachments/assets/9f79e218-0284-49bf-a57a-9492a807a1a5" /> |

## Implementation notes

- **Pure-additions PR**: no existing line is modified or removed across all 7
  files (`git diff master | grep -E "^-[^-]" | wc -l` returns 0).
- **No new ping traffic**: the new widget and popup chart consume the existing
  `connectivityCallback` stream emitted by `ConnectivityReader`. ICMP cadence
  is still controlled by `Network_updateICMPInterval`.
- **Threshold values** (default 50 / 100 / 200 ms) are stored under
  `Network_latencyThreshold_{green,yellow,red}` so the widget and popup chart
  share the same color bands. Clamped on write to enforce green < yellow < red.
- **Aggregation** for chart histories longer than the visual bar count uses
  a running mean on commit (`samplesPerBar`), with raw samples retained up to
  600 (~10 min) so changing chart history re-aggregates from real data rather
  than starting fresh.
- **Bar rendering** is a small reusable function (`renderLatencyBars`) shared
  by both the widget and the popup chart, so the visual style stays consistent.
- **Threading** follows the existing `ChartView` / `WidgetWrapper` patterns
  (concurrent state queue, barrier writes, sync reads). No new threading model.

## Localization

Adds 3 new English keys (`"Size"`, `"Thresholds (ms)"`, `"Latency history"`).
Other strings reuse existing keys. Other languages will fall back to English at
runtime — happy to leave the bulk-translation pass to your usual tooling.

## Files changed

- `Kit/Widgets/BarChart.swift` — new `LatencyBarsWidget` class (appended)
- `Kit/plugins/Charts.swift` — new types + `LatencyBarChartView` (appended)
- `Kit/module/widget.swift` — new `widget_t.latencyBars` enum case
- `Modules/Net/config.plist` — registers the new widget under Network
- `Modules/Net/main.swift` — dispatches `connectivityCallback` to the widget
- `Modules/Net/popup.swift` — adds the latency chart section + View mode setting
- `Stats/Supporting Files/en.lproj/Localizable.strings` — 3 new keys

## Defaults (first-run behaviour)

- Widget is **off by default** (consistent with how new widgets are introduced
  to a module — user opts in via `Settings → Network → Widgets`).
- Popup `View mode` defaults to `Connectivity history` so the existing layout
  is unchanged for upgraders.
- Widget Size defaults to 35 px; Box and Frame default to off; Value label
  default to off.
