### PR TITLE
Fix some Dutch translations

### DIFF
--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -399,7 +399,7 @@
 "Interface based" = "Interface-gebaseerd";
 "Processes based" = "Proces-gebaseerd";
 "Reset data usage" = "Reset dataverbruik"; // translategemma:4b
-"VPN mode" = "VPM modus";
+"VPN mode" = "VPN modus";
 "Standard" = "Standaard"; // translategemma:4b
 "Security" = "Beveiliging"; // translategemma:4b
 "Channel" = "Kanaal"; // translategemma:4b

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "Open Battery settings" = "Open battery instellingen";
 "Bluetooth" = "Bluetooth";
 "Open Bluetooth settings" = "Open bluetooth instellingen";
-"Clock" = "Uur"; // translategemma:4b
+"Clock" = "Klok";
 "Open Clock settings" = "Open de instellingen voor de klok"; // translategemma:4b
 
 // Words
@@ -63,28 +63,28 @@
 "Disabled" = "Uitgeschakeld";
 "Silent" = "Stil"; // translategemma:4b
 "Units" = "Eenheden"; // translategemma:4b
-"Fans" = "Fans";
-"Scaling" = "Schaalbaarheid"; // translategemma:4b
+"Fans" = "Ventilatoren";
+"Scaling" = "Schaal";
 "Linear" = "Lineair"; // translategemma:4b
-"Square" = "Vierkant"; // translategemma:4b
-"Cube" = "Kubus"; // translategemma:4b
+"Square" = "Kwadratisch";
+"Cube" = "Kubiek";
 "Logarithmic" = "Logaritmisch"; // translategemma:4b
-"Fixed scale" = "Opgelost"; // translategemma:4b
-"Cores" = "Kernen"; // translategemma:4b
-"Core" = "Kern"; // translategemma:4b
+"Fixed scale" = "Vaste schaal";
+"Cores" = "Cores";
+"Core" = "Core";
 "Settings" = "Instellingen"; // translategemma:4b
 "Name" = "Naam"; // translategemma:4b
 "Format" = "Formaat"; // translategemma:4b
 "Turn off" = "Uitschakelen"; // translategemma:4b
 "Normal" = "Normaal"; // translategemma:4b
 "Warning" = "Waarschuwing"; // translategemma:4b
-"Critical" = "Cruciaal"; // translategemma:4b
+"Critical" = "Kritiek";
 "Usage" = "Gebruik"; // translategemma:4b
 "2 minutes" = "2 minuten"; // translategemma:4b
 "3 minutes" = "3 minuten"; // translategemma:4b
 "10 minutes" = "10 minuten"; // translategemma:4b
 "Import" = "Importeren"; // translategemma:4b
-"Export" = "Exporter"; // translategemma:4b
+"Export" = "Exporteren";
 "Separator" = "Scheiding"; // translategemma:4b
 "Read" = "Lees"; // translategemma:4b
 "Write" = "Schrijf"; // translategemma:4b
@@ -94,16 +94,16 @@
 "Stop" = "Stoppen"; // translategemma:4b
 "Uninstall" = "Verwijderen"; // translategemma:4b
 "1 sec" = "1 seconde"; // translategemma:4b
-"2 sec" = "2 second"; // translategemma:4b
+"2 sec" = "2 seconden"; // translategemma:4b
 "3 sec" = "3 seconden"; // translategemma:4b
 "5 sec" = "5 seconden"; // translategemma:4b
 "10 sec" = "10 seconden"; // translategemma:4b
-"15 sec" = "15 sec";
+"15 sec" = "15 seconden";
 "30 sec" = "30 seconden"; // translategemma:4b
 "60 sec" = "60 seconden"; // translategemma:4b
 
 // Setup
-"Stats Setup" = "Instellingen instellen"; // translategemma:4b
+"Stats Setup" = "Stats Installatie"; // translategemma:4b
 "Previous" = "Vorige"; // translategemma:4b
 "Previous page" = "Vorige pagina"; // translategemma:4b
 "Next" = "Volgende"; // translategemma:4b
@@ -141,9 +141,9 @@
 "Close application" = "Applicatie sluiten";
 "Open application settings" = "Open de applicatie-instellingen";
 "Open dashboard" = "Dashboard openen"; // translategemma:4b
-"No notifications available in this module" = "Geen meldingen beschikbaar in dit module"; // translategemma:4b
-"Open Calendar" = "Open Kalender"; // translategemma:4b
-"Toggle the module" = "Activeer/deactiveer het module"; // translategemma:4b
+"No notifications available in this module" = "Geen meldingen beschikbaar in deze module";
+"Open Calendar" = "Open kalender";
+"Toggle the module" = "Activeer/deactiveer de module";
 
 // Application settings
 "Update application" = "Applicatie bijwerken";
@@ -158,12 +158,12 @@
 "Start at login" = "Starten bij inloggen";
 "Build number" = "Bouwnummer"; // translategemma:4b
 "Import settings" = "Importer instellingen"; // translategemma:4b
-"Export settings" = "Exporteerinstellingen"; // translategemma:4b
+"Export settings" = "Exporteer instellingen";
 "Reset settings" = "Instellingen herstellen"; // translategemma:4b
 "Pause the Stats" = "Pauzeer de statistieken"; // translategemma:4b
-"Resume the Stats" = "Herhaal de statistieken"; // translategemma:4b
+"Resume the Stats" = "Hervat de statistieken";
 "Combined modules" = "Gecombineerde modules"; // translategemma:4b
-"Combined details" = "Gezamenlijke details"; // translategemma:4b
+"Combined details" = "Gecombineerde details";
 "Spacing" = "Ruimte"; // translategemma:4b
 "Share anonymous telemetry" = "Deel anonieme telemetriegegevens"; // translategemma:4b
 "Choose file" = "Kies bestand"; // translategemma:4b
@@ -174,10 +174,10 @@
 "Model identifier" = "Model-identificatie"; // translategemma:4b
 "Production year" = "Jaar van productie"; // translategemma:4b
 "Uptime" = "Beschikbaarheid";
-"Number of cores" = "%0 kernen"; // translategemma:4b
+"Number of cores" = "%0 cores";
 "Number of threads" = "%0 threads";
-"Number of e-cores" = "%0 efficiënte kernen"; // translategemma:4b
-"Number of p-cores" = "%0 prestatiecores"; // translategemma:4b
+"Number of e-cores" = "%0 efficiëntiecores";
+"Number of p-cores" = "%0 prestatiecores";
 "Number of s-cores" = "%0 supercores"; // translategemma:4b
 "Disks" = "Schijven"; // translategemma:4b
 "Display" = "Weergave"; // translategemma:4b
@@ -192,10 +192,10 @@
 "Color" = "Kleur";
 "Label" = "Label";
 "Box" = "Doos"; // translategemma:4b
-"Frame" = "Frame";
+"Frame" = "Rand";
 "Value" = "Waarde";
 "Colorize" = "Inkleuren";
-"Colorize value" = "Inkleuren waarde";
+"Colorize value" = "Waarde inkleuren";
 "Additional information" = "Extra informatie";
 "Reverse values order" = "Waarden in omgekeerde volgorde";
 "Base" = "Basis";
@@ -219,14 +219,14 @@
 "Show symbols" = "Toon symbolen";
 "Label widget" = "Label";
 "Number of reads in the chart" = "Aantal keer gelezen in de grafiek";
-"Color of download" = "Kleur van download";
-"Color of upload" = "Kleur van upload";
+"Color of download" = "Kleur voor download";
+"Color of upload" = "Kleur voor upload";
 "Monospaced font" = "Monospaced lettertype";
 "Reverse order" = "Omgekeerde volgorde"; // translategemma:4b
 "Chart history" = "Historie van de grafiek"; // translategemma:4b
 "Default color" = "Standaard"; // translategemma:4b
 "Transparent when no activity" = "Transparant wanneer er geen activiteit is"; // translategemma:4b
-"Constant color" = "Constante"; // translategemma:4b
+"Constant color" = "Vaste kleur";
 
 // Module Kit
 "Open module settings" = "Open module-instellingen";
@@ -243,7 +243,7 @@
 "Notifications" = "Meldingen";
 "Merge widgets" = "Widgets samenvoegen";
 "No available widgets to configure" = "Geen beschikbare widgets om te configureren";
-"No options to configure for the popup in this module" = "Meervoudige configuratie voor pop-op-vinduet en deze module";
+"No options to configure for the popup in this module" = "Geen opties in te stellen voor de pop-up in deze module";
 "Process" = "Proces"; // translategemma:4b
 "Kill process" = "Beëindig proces"; // translategemma:4b
 "Keyboard shortcut" = "Sneltoets"; // translategemma:4b
@@ -253,8 +253,8 @@
 "Number of top processes" = "Aantal topprocessen";
 "Update interval for top processes" = "Bewerk interval voor top processen";
 "Notification level" = "Meldingsniveau";
-"Chart color" = "Kortfarve";
-"Main chart scaling" = "Hoofdschaal schaal"; // translategemma:4b
+"Chart color" = "Grafiekkleur";
+"Main chart scaling" = "Schaal van algemene grafiek";
 "Scale value" = "Waarde"; // translategemma:4b
 "Text widget value" = "Waarde van het tekstwidget-element"; // translategemma:4b
 "Combined processes" = "Gecombineerde processen"; // translategemma:4b
@@ -268,33 +268,33 @@
 "Idle" = "Inactief";
 "Show usage per core" = "Gebruik per core weergeven";
 "Show hyper-threading cores" = "Hyperthreading cores weergeven";
-"Split the value (System/User)" = "Opdel værdien (Systeem/Gebruiker)";
+"Split the value (System/User)" = "Splits waarden (Systeem/Gebruiker)";
 "Scheduler limit" = "Planner limiet";
 "Speed limit" = "Snelheidslimiet";
-"Average load" = "Gemiddelde belasting ";
+"Average load" = "Gemiddelde belasting";
 "1 minute" = "1 minuut";
 "5 minutes" = "5 minuten";
 "15 minutes" = "15 minuten";
 "CPU usage threshold" = "Drempelwaarde voor CPU-gebruik"; // translategemma:4b
 "CPU usage is" = "Het CPU-gebruik is %0"; // translategemma:4b
-"Efficiency cores" = "Efficiënte kernen"; // translategemma:4b
-"Performance cores" = "Prestatie-cores"; // translategemma:4b
-"System color" = "Kleur van het systeem"; // translategemma:4b
-"User color" = "Kleur van de gebruiker"; // translategemma:4b
-"Idle color" = "Kleur in ruststand"; // translategemma:4b
+"Efficiency cores" = "Efficiëntiecores";
+"Performance cores" = "Prestatiecores";
+"System color" = "Kleur voor systeembelasting";
+"User color" = "Kleur voor gebruikersbelasting";
+"Idle color" = "Kleur voor inactief";
 "Cluster grouping" = "Groeperen van clusters"; // translategemma:4b
-"Efficiency cores color" = "Kleuren van de kernen voor efficiëntie"; // translategemma:4b
-"Performance cores color" = "Kleur van de prestatie-cores"; // translategemma:4b
+"Efficiency cores color" = "Kleur voor efficiëntiecores";
+"Performance cores color" = "Kleur voor prestatiecores";
 "Total load" = "Totale belasting"; // translategemma:4b
-"System load" = "Laad op het systeem"; // translategemma:4b
+"System load" = "Systeembelasting";
 "User load" = "Gebruikersbelasting"; // translategemma:4b
-"Efficiency cores load" = "Efficiëntie-cores laden"; // translategemma:4b
-"Performance cores load" = "Laad van de prestatie-cores"; // translategemma:4b
-"All cores" = "Alle kernen"; // translategemma:4b
-"Load per core" = "Laad per kern"; // translategemma:4b
-"Efficiency core" = "Kern van de efficiëntie"; // translategemma:4b
-"Performance core" = "Kernprestaties"; // translategemma:4b
-"Super core" = "Zeer krachtig"; // translategemma:4b
+"Efficiency cores load" = "Belasting van efficiëntiecores";
+"Performance cores load" = "Belasting van prestatiecores";
+"All cores" = "Alle cores";
+"Load per core" = "Belasting per core";
+"Efficiency core" = "Efficiëntiecore";
+"Performance core" = "Prestatiecore";
+"Super core" = "Supercore";
 
 // GPU
 "GPU to show" = "GPU om te laten zien";
@@ -311,9 +311,9 @@
 "Fan speed" = "Ventilatorsneelheid";
 "Core clock" = "Core klok";
 "Memory clock" = "Geheugen klok";
-"Utilization" = "Benutting";
+"Utilization" = "Gebruik";
 "Render utilization" = "Gebruik van render-resources"; // translategemma:4b
-"Tiler utilization" = "Optimal gebruik van tegelwerk"; // translategemma:4b
+"Tiler utilization" = "Gebruik van tegelrenderer";
 "GPU usage threshold" = "Drempelwaarde voor GPU-gebruik"; // translategemma:4b
 "GPU usage is" = "Het gebruik van de GPU bedraagt %0"; // translategemma:4b
 
@@ -327,16 +327,16 @@
 "Compressed" = "Gecomprimeerd";
 "Free" = "Vrij";
 "Swap" = "Swap";
-"Split the value (App/Wired/Compressed)" = "Opdel værdien (App/Wired/Gecomprimeerd)";
+"Split the value (App/Wired/Compressed)" = "Splits waarden (App/Wired/Gecomprimeerd)";
 "RAM utilization threshold" = "Drempelwaarde voor het gebruik van RAM"; // translategemma:4b
 "RAM utilization is" = "Het gebruik van RAM bedraagt %0"; // translategemma:4b
-"App color" = "Kleur van de app"; // translategemma:4b
-"Wired color" = "Gestructureerde kleur"; // translategemma:4b
-"Compressed color" = "Gecodeerde kleur"; // translategemma:4b
-"Free color" = "Gratis kleur"; // translategemma:4b
+"App color" = "Kleur voor app";
+"Wired color" = "Kleur voor bedraad";
+"Compressed color" = "Kleur voor gecomprimeerd";
+"Free color" = "Kleur voor vrij";
 "Free memory (less than)" = "Vrij geheugen (minder dan)"; // translategemma:4b
-"Swap size" = "Grootte van het uitwisselingsgebied"; // translategemma:4b
-"Free RAM is" = "Gratis RAM is %0"; // translategemma:4b
+"Swap size" = "Grootte van het swap";
+"Free RAM is" = "Vrije RAM is %0";
 
 // Disk
 "Show removable disks" = "Toon verwijderbare schijven";
@@ -347,13 +347,13 @@
 "Switch view" = "Wissel weergave";
 "Disk utilization threshold" = "Drempelwaarde voor het gebruik van schijfruimte"; // translategemma:4b
 "Disk utilization is" = "Het gebruik van de schijf is %0"; // translategemma:4b
-"Read color" = "Lees de kleur"; // translategemma:4b
-"Write color" = "Schrijf kleur"; // translategemma:4b
+"Read color" = "Kleur voor lezen";
+"Write color" = "Kleur voor schrijven";
 "Disk usage" = "Gebruikte schijfruimte"; // translategemma:4b
 "Total read" = "Totaal gelezen"; // translategemma:4b
-"Total written" = "Totale hoeveelheid geschreven"; // translategemma:4b
-"Write speed" = "Schrijf"; // translategemma:4b
-"Read speed" = "Lees"; // translategemma:4b
+"Total written" = "Totaal geschreven";
+"Write speed" = "Schrijfsnelheid";
+"Read speed" = "Leessnelheid";
 "Drives" = "Schijven"; // translategemma:4b
 "SMART data" = "SMART-gegevens"; // translategemma:4b
 
@@ -363,21 +363,21 @@
 "Fahrenheit" = "Fahrenheit";
 "Save the fan speed" = "Ventilatorsnelheid opslaan";
 "Fan" = "Ventilator";
-"HID sensors" = "Sensoren voor het meten van de hoogte"; // translategemma:4b
+"HID sensors" = "HID-Sensoren";
 "Synchronize fan's control" = "Synchroniseer de bediening van de ventilatoren"; // translategemma:4b
-"Current" = "Huidige"; // translategemma:4b
+"Current" = "Huidig";
 "Energy" = "Energie"; // translategemma:4b
 "Show unknown sensors" = "Toon onbekende sensoren"; // translategemma:4b
-"Install fan helper" = "Installeer de ventilator-assistent"; // translategemma:4b
-"Uninstall fan helper" = "Verwijder de fan helper."; // translategemma:4b
+"Install fan helper" = "Installeer het ventilator-hulpprogramma";
+"Uninstall fan helper" = "Verwijder het ventilator-hulpprogramma.";
 "Fan value" = "Waarde van de ventilator"; // translategemma:4b
 "Turn off fan" = "Zet de ventilator uit"; // translategemma:4b
 "You are going to turn off the fan. This is not recommended action that can damage your mac, are you sure you want to do that?" = "U gaat de ventilator uitschakelen. Dit is een onaanbevolen actie die uw Mac kan beschadigen. Bent u er zeker van dat u dit wilt doen?"; // translategemma:4b
 "Sensor threshold" = "Grenswaarde sensor"; // translategemma:4b
-"Left fan" = "Links"; // translategemma:4b
-"Right fan" = "Correct"; // translategemma:4b
-"Fastest fan" = "Snelst"; // translategemma:4b
-"Sensor to show" = "Sensor om weer te laten zien"; // translategemma:4b
+"Left fan" = "Linker ventilator";
+"Right fan" = "Rechter ventilator";
+"Fastest fan" = "Snelste ventilator";
+"Sensor to show" = "Sensor om weer te geven";
 
 // Network
 "Uploading" = "Uploaden";
@@ -399,37 +399,37 @@
 "Interface based" = "Interface-gebaseerd";
 "Processes based" = "Proces-gebaseerd";
 "Reset data usage" = "Reset dataverbruik"; // translategemma:4b
-"VPN mode" = "Modus VPN"; // translategemma:4b
+"VPN mode" = "VPM modus";
 "Standard" = "Standaard"; // translategemma:4b
 "Security" = "Beveiliging"; // translategemma:4b
 "Channel" = "Kanaal"; // translategemma:4b
-"Common scale" = "Veelgebruikte schaal"; // translategemma:4b
+"Common scale" = "Algemene schaal";
 "Autodetection" = "Automatische detectie"; // translategemma:4b
 "Widget activation threshold" = "Drempelwaarde voor het activeren van een widget"; // translategemma:4b
 "Internet connection" = "Internetverbinding"; // translategemma:4b
-"Active state color" = "Kleur in de actieve toestand"; // translategemma:4b
+"Active state color" = "Kleur voor de actieve toestand";
 "Nonactive state color" = "Kleur voor de niet-actieve toestand"; // translategemma:4b
 "Connectivity host" = "Host voor verbinding"; // translategemma:4b
-"Leave empty to disable the check" = "Laat dit vel leeg, om de controle uit te schakelen."; // translategemma:4b
-"Connectivity history" = "Historie van verbindingen"; // translategemma:4b
-"Auto-refresh public IP address" = "Automatisch IP-adres van het publieke netwerk herstellen"; // translategemma:4b
-"Every hour" = "Elke uur"; // translategemma:4b
+"Leave empty to disable the check" = "Laat dit veld leeg, om de controle uit te schakelen.";
+"Connectivity history" = "Verbindingshistorie";
+"Auto-refresh public IP address" = "Automatisch openbaar IP-adres verversen";
+"Every hour" = "Elk uur";
 "Every 12 hours" = "Elke 12 uur"; // translategemma:4b
 "Every 24 hours" = "Elke 24 uur"; // translategemma:4b
 "Network activity" = "Netwerkactiviteit"; // translategemma:4b
 "Last reset" = "Laatste reset %0 geleden"; // translategemma:4b
 "Latency" = "Vertraging"; // translategemma:4b
-"Upload speed" = "Uploaden"; // translategemma:4b
-"Download speed" = "Download";
+"Upload speed" = "Uploadsnelheid";
+"Download speed" = "Downloadsnelheid";
 "Address" = "Adres"; // translategemma:4b
 "WiFi network" = "WiFi-netwerk"; // translategemma:4b
 "Local IP changed" = "Het lokale IP-adres is veranderd"; // translategemma:4b
-"Public IP changed" = "Het openbare IP-adres is gewijzigd."; // translategemma:4b
+"Public IP changed" = "Het openbare IP-adres is veranderd";
 "Previous IP" = "Vorige IP-adres: %0"; // translategemma:4b
 "New IP" = "Nieuw IP-adres: %0"; // translategemma:4b
-"Internet connection lost" = "Verbinding met het internet is verloren gegaan"; // translategemma:4b
-"Internet connection established" = "Internetverbinding is opgezet"; // translategemma:4b
-"Show country code instead of emoji" = "Toon het landencode in plaats van een emoji"; // translategemma:4b
+"Internet connection lost" = "Internetverbinding verbroken";
+"Internet connection established" = "Internetverbinding tot stand gebracht";
+"Show country code instead of emoji" = "Toon landencode in plaats van een emoji";
 
 // Battery
 "Level" = "Niveau";
@@ -464,9 +464,9 @@
 "Last charge" = "Laatste oplading";
 "Capacity" = "Capaciteit"; // translategemma:4b
 "current / maximum / designed" = "huidig / maximum / ontworpen"; // translategemma:4b
-"Low power mode" = "Standaardmodus met laag stroomverbruik"; // translategemma:4b
+"Low power mode" = "Modues met laag stroomverbruik";
 "Percentage inside the icon" = "Percentage binnen het icoon"; // translategemma:4b
-"Colorize battery" = "Kleuren de batterij"; // translategemma:4b
+"Colorize battery" = "Batterij kleuren"; // translategemma:4b
 "Charging current" = "Laadstroom"; // translategemma:4b
 "Charging Voltage" = "Laadspanning"; // translategemma:4b
 "Charger state inside the battery" = "Status van de oplaadunit binnenin de batterij"; // translategemma:4b
@@ -480,7 +480,7 @@
 "Local" = "Lokaal"; // translategemma:4b
 "Calendar" = "Agenda"; // translategemma:4b
 "Show week numbers" = "Toon de weeknummers"; // translategemma:4b
-"Local time" = "Lokaan tijd"; // translategemma:4b
+"Local time" = "Lokale tijd";
 "Add new clock" = "Voeg een nieuwe klok toe"; // translategemma:4b
 "Delete selected clock" = "Verwijder de geselecteerde klok"; // translategemma:4b
 "Help with datetime format" = "Hulp bij het formatteren van datums en tijden"; // translategemma:4b
@@ -489,7 +489,7 @@
 // Colors
 "Based on utilization" = "Gebaseerd op gebruik";
 "Based on pressure" = "Gebaseerd op druk";
-"Based on cluster" = "Op basis van een cluster"; // translategemma:4b
+"Based on cluster" = "Gebaseerd op cluster";
 "System accent" = "Systeemaccent"; // translategemma:4b
 "Monochrome accent" = "Monochroom accent"; // translategemma:4b
 "Clear" = "Helder";
@@ -513,8 +513,8 @@
 "Second purple" = "Tweede paars";
 "Brown" = "Bruin";
 "Second brown" = "Tweede bruin";
-"Cyan" = "Lichtblauw2";
+"Cyan" = "Cyaan";
 "Magenta" = "Paars";
 "Pink" = "Roze";
-"Teal" = "Teal";
+"Teal" = "Turkoois";
 "Indigo" = "Indigo";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -464,7 +464,7 @@
 "Last charge" = "Laatste oplading";
 "Capacity" = "Capaciteit"; // translategemma:4b
 "current / maximum / designed" = "huidig / maximum / ontworpen"; // translategemma:4b
-"Low power mode" = "Modues met laag stroomverbruik";
+"Low power mode" = "Modus met laag stroomverbruik";
 "Percentage inside the icon" = "Percentage binnen het icoon"; // translategemma:4b
 "Colorize battery" = "Batterij kleuren";
 "Charging current" = "Laadstroom"; // translategemma:4b

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "60 sec" = "60 seconden"; // translategemma:4b
 
 // Setup
-"Stats Setup" = "Stats Installatie"; // translategemma:4b
+"Stats Setup" = "Stats Installatie";
 "Previous" = "Vorige"; // translategemma:4b
 "Previous page" = "Vorige pagina"; // translategemma:4b
 "Next" = "Volgende"; // translategemma:4b
@@ -466,7 +466,7 @@
 "current / maximum / designed" = "huidig / maximum / ontworpen"; // translategemma:4b
 "Low power mode" = "Modues met laag stroomverbruik";
 "Percentage inside the icon" = "Percentage binnen het icoon"; // translategemma:4b
-"Colorize battery" = "Batterij kleuren"; // translategemma:4b
+"Colorize battery" = "Batterij kleuren";
 "Charging current" = "Laadstroom"; // translategemma:4b
 "Charging Voltage" = "Laadspanning"; // translategemma:4b
 "Charger state inside the battery" = "Status van de oplaadunit binnenin de batterij"; // translategemma:4b

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -240,7 +240,7 @@
 "Module" = "Module";
 "Widgets" = "Widgets";
 "Popup" = "Pop-up";
-"Notifications" = "Meddelelser";
+"Notifications" = "Meldingen";
 "Merge widgets" = "Widgets samenvoegen";
 "No available widgets to configure" = "Geen beschikbare widgets om te configureren";
 "No options to configure for the popup in this module" = "Meervoudige configuratie voor pop-op-vinduet en deze module";


### PR DESCRIPTION
I went through all the Dutch translations and updated them for correctness, consistency and clarity. I removed the ` // translategemma:4b`-annotation from the translations I touched.