### PR TITLE
Fix combined separator menu bar color

### DIFF
--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -127,9 +127,7 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
             i += 1
             
             if self.separator && i < 2 * self.activeModules.count - 1 {
-                let separator = NSView(frame: NSRect(x: w, y: 3, width: 1, height: Constants.Widget.height-6))
-                separator.wantsLayer = true
-                separator.layer?.backgroundColor = (separator.isDarkMode ? NSColor.white : NSColor.black).cgColor
+                let separator = MenuBarSeparatorView(frame: NSRect(x: w, y: 3, width: 1, height: Constants.Widget.height-6))
                 self.view.addSubview(separator)
                 w += 3 + self.spacing
                 i += 1
@@ -229,6 +227,34 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
                     ])
                 }
             }
+        }
+    }
+}
+
+private final class MenuBarSeparatorView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.wantsLayer = true
+        self.updateSeparatorColor()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        self.updateSeparatorColor()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        self.updateSeparatorColor()
+    }
+
+    private func updateSeparatorColor() {
+        self.effectiveAppearance.performAsCurrentDrawingAppearance {
+            self.layer?.backgroundColor = NSColor.labelColor.cgColor
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3139 by making the combined menu bar separator use the current effective AppKit appearance instead of a fixed black/white color decision.

The separator now updates its layer color from `NSColor.labelColor` when it is created, moved into a window, or when the effective appearance changes.

## Validation

- `gh issue view 3139`
- Duplicate PR searches for related separator/color issues
- `swiftc -parse Stats/Views/CombinedView.swift`
- AppKit API snippet for `viewDidChangeEffectiveAppearance` and `performAsCurrentDrawingAppearance`
- `git show --check HEAD`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -list -project Stats.xcodeproj`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Stats.xcodeproj -scheme Stats -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/stats-xcodebuild CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`

The Xcode build completed successfully with Xcode 26.4.1. The only warning observed was the existing optional SwiftLint warning when SwiftLint is not installed.
