### PR TITLE
fix(fans): surface SMC write failures to user instead of silent fail

### DIFF
--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -913,27 +913,36 @@ public class SMCHelper {
     private var connection: NSXPCConnection? = nil
     
     public func setFanSpeed(_ id: Int, speed: Int, completion: ((String?) -> Void)? = nil) {
-        guard let helper = self.helper(nil) else {
-            completion?("Fan helper not available")
-            return
-        }
+        guard let helper = self.helper(forCall: completion) else { return }
         helper.setFanSpeed(id: id, value: speed) { completion?($0) }
     }
 
     public func setFanMode(_ id: Int, mode: Int, completion: ((String?) -> Void)? = nil) {
-        guard let helper = self.helper(nil) else {
-            completion?("Fan helper not available")
-            return
-        }
+        guard let helper = self.helper(forCall: completion) else { return }
         helper.setFanMode(id: id, mode: mode) { completion?($0) }
     }
 
     public func resetFanControl(completion: ((String?) -> Void)? = nil) {
-        guard let helper = self.helper(nil) else {
-            completion?("Fan helper not available")
-            return
-        }
+        guard let helper = self.helper(forCall: completion) else { return }
         helper.resetFanControl { completion?($0) }
+    }
+
+    // Per-call helper that wires the XPC errorHandler to the caller's completion
+    // so connection failures surface as errors instead of dropping the reply.
+    private func helper(forCall completion: ((String?) -> Void)?) -> HelperProtocol? {
+        guard let connection = self.helperConnection() else {
+            completion?("Fan helper not available")
+            return nil
+        }
+        let proxy = connection.remoteObjectProxyWithErrorHandler { error in
+            completion?("Fan helper unreachable: \(error.localizedDescription)")
+        }
+        guard let service = proxy as? HelperProtocol else {
+            completion?("Fan helper proxy unavailable")
+            return nil
+        }
+        service.setSMCPath(Bundle.main.path(forResource: "smc", ofType: nil)!)
+        return service
     }
     
     public func isActive() -> Bool {

--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -912,27 +912,28 @@ public class SMCHelper {
     
     private var connection: NSXPCConnection? = nil
     
-    public func setFanSpeed(_ id: Int, speed: Int) {
-        guard let helper = self.helper(nil) else { return }
-        helper.setFanSpeed(id: id, value: speed) { result in
-            if let result, !result.isEmpty {
-                NSLog("set fan speed: \(result)")
-            }
+    public func setFanSpeed(_ id: Int, speed: Int, completion: ((String?) -> Void)? = nil) {
+        guard let helper = self.helper(nil) else {
+            completion?("Fan helper not available")
+            return
         }
+        helper.setFanSpeed(id: id, value: speed) { completion?($0) }
     }
-    
-    public func setFanMode(_ id: Int, mode: Int) {
-        guard let helper = self.helper(nil) else { return }
-        helper.setFanMode(id: id, mode: mode) { result in
-            if let result, !result.isEmpty {
-                NSLog("set fan mode: \(result)")
-            }
+
+    public func setFanMode(_ id: Int, mode: Int, completion: ((String?) -> Void)? = nil) {
+        guard let helper = self.helper(nil) else {
+            completion?("Fan helper not available")
+            return
         }
+        helper.setFanMode(id: id, mode: mode) { completion?($0) }
     }
-    
-    public func resetFanControl() {
-        guard let helper = self.helper(nil) else { return }
-        helper.resetFanControl { _ in }
+
+    public func resetFanControl(completion: ((String?) -> Void)? = nil) {
+        guard let helper = self.helper(nil) else {
+            completion?("Fan helper not available")
+            return
+        }
+        helper.resetFanControl { completion?($0) }
     }
     
     public func isActive() -> Bool {

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -85,7 +85,9 @@ internal class Popup: PopupWrapper {
         let fanViews = self.list.values.compactMap { $0 as? FanView }
         guard !fanViews.isEmpty else { return }
         guard fanViews.allSatisfy({ $0.fan.mode.isAutomatic }) else { return }
-        SMCHelper.shared.resetFanControl()
+        SMCHelper.shared.resetFanControl { error in
+            if let error { NSLog("resetFanControl error: \(error)") }
+        }
     }
     #endif
     
@@ -551,9 +553,11 @@ internal class FanView: NSStackView {
         NotificationCenter.default.addObserver(self, selector: #selector(self.controlCallback), name: .toggleFanControl, object: nil)
         
         if let fanMode = self.fan.customMode, self.speedState && fanMode != FanMode.automatic {
-            SMCHelper.shared.setFanMode(fan.id, mode: fanMode.rawValue)
+            SMCHelper.shared.setFanMode(fan.id, mode: fanMode.rawValue) { [weak self] error in
+                if let error { self?.showFanError(error) }
+            }
             self.modeButtons?.setMode(FanMode(rawValue: fanMode.rawValue) ?? .automatic)
-            
+
             self.setSpeed(value: Int(self.speed), then: {
                 DispatchQueue.main.async {
                     self.sliderValueField?.textColor = .systemBlue
@@ -651,7 +655,9 @@ internal class FanView: NSStackView {
             if let fan = self?.fan, mode == .automatic || fan.mode != mode {
                 self?.fan.mode = mode
                 self?.fan.customMode = mode
-                SMCHelper.shared.setFanMode(fan.id, mode: mode.rawValue)
+                SMCHelper.shared.setFanMode(fan.id, mode: mode.rawValue) { [weak self] error in
+                    if let error { self?.showFanError(error) }
+                }
             }
             self?.toggleControlView(mode == .forced)
         }
@@ -659,9 +665,13 @@ internal class FanView: NSStackView {
             if let fan = self?.fan {
                 if self?.fan.mode != .forced {
                     self?.fan.mode = .forced
-                    SMCHelper.shared.setFanMode(fan.id, mode: FanMode.forced.rawValue)
+                    SMCHelper.shared.setFanMode(fan.id, mode: FanMode.forced.rawValue) { [weak self] error in
+                        if let error { self?.showFanError(error) }
+                    }
                 }
-                SMCHelper.shared.setFanSpeed(fan.id, speed: 0)
+                SMCHelper.shared.setFanSpeed(fan.id, speed: 0) { [weak self] error in
+                    if let error { self?.showFanError(error) }
+                }
                 self?.fan.customSpeed = 0
             }
             self?.toggleControlView(false)
@@ -670,9 +680,13 @@ internal class FanView: NSStackView {
             if let fan = self?.fan {
                 if self?.fan.mode != .forced {
                     self?.fan.mode = .forced
-                    SMCHelper.shared.setFanMode(fan.id, mode: FanMode.forced.rawValue)
+                    SMCHelper.shared.setFanMode(fan.id, mode: FanMode.forced.rawValue) { [weak self] error in
+                        if let error { self?.showFanError(error) }
+                    }
                 }
-                SMCHelper.shared.setFanSpeed(fan.id, speed: Int(fan.maxSpeed))
+                SMCHelper.shared.setFanSpeed(fan.id, speed: Int(fan.maxSpeed)) { [weak self] error in
+                    if let error { self?.showFanError(error) }
+                }
                 self?.fan.customSpeed = Int(fan.maxSpeed)
             }
             self?.toggleControlView(false)
@@ -783,20 +797,34 @@ internal class FanView: NSStackView {
         self.sliderValueField?.stringValue = "\(value) RPM"
         self.sliderValueField?.textColor = .secondaryLabelColor
         self.fan.customSpeed = value
-        
+
         self.debouncer?.cancel()
-        
+
         let task = DispatchWorkItem { [weak self] in
-            DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-                if let id = self?.fan.id {
-                    SMCHelper.shared.setFanSpeed(id, speed: value)
+            guard let self else { return }
+            SMCHelper.shared.setFanSpeed(self.fan.id, speed: value) { [weak self] error in
+                if let error {
+                    self?.showFanError(error)
+                    // TODO: revert slider to previous value on failure — requires
+                    // storing the pre-attempt speed before mutating fan.customSpeed above
                 }
                 then()
             }
         }
-        
+
         self.debouncer = task
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.3, execute: task)
+    }
+
+    private func showFanError(_ message: String) {
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = localizedString("Fan control failed")
+            alert.informativeText = message
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: localizedString("OK"))
+            alert.runModal()
+        }
     }
     
     @objc private func sliderCallback(_ sender: NSSlider) {
@@ -847,7 +875,9 @@ internal class FanView: NSStackView {
         if self.speedState {
             if let mode = self.willSleepMode, let speed = self.willSleepSpeed {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    SMCHelper.shared.setFanMode(self.fan.id, mode: mode.rawValue)
+                    SMCHelper.shared.setFanMode(self.fan.id, mode: mode.rawValue) { [weak self] error in
+                        if let error { self?.showFanError(error) }
+                    }
                     self.modeButtons?.setMode(mode)
                     if !mode.isAutomatic {
                         self.setSpeed(value: speed, then: {
@@ -873,9 +903,10 @@ internal class FanView: NSStackView {
     
     @objc private func sleepListener(aNotification: NSNotification) {
         guard SMCHelper.shared.isActive(), let mode = self.fan.customMode, !mode.isAutomatic else { return }
-        
+
         self.willSleepMode = mode
         self.willSleepSpeed = self.fan.customSpeed
+        // Best-effort reset on sleep; errors not surfaced as user can't act on them while sleeping
         SMCHelper.shared.setFanMode(fan.id, mode: FanMode.automatic.rawValue)
         self.modeButtons?.setMode(.automatic)
     }

--- a/SMC/Helper/main.swift
+++ b/SMC/Helper/main.swift
@@ -122,36 +122,36 @@ extension Helper {
                 return
             }
             let result = syncShell("\(smc) fan \(id) -m \(mode)")
-            
+
             if let error = result.error, !error.isEmpty {
                 NSLog("error set fan mode: \(error)")
-                completion(nil)
+                completion("Failed to set fan \(id) mode to \(mode) — SMC rejected write")
                 return
             }
-            
-            completion(result.output)
+
+            completion(nil)
         }
     }
-    
+
     func setFanSpeed(id: Int, value: Int, completion: (String?) -> Void) {
         smcQueue.sync {
             guard let smc = self.smc else {
                 completion("missing smc tool")
                 return
             }
-            
+
             let result = syncShell("\(smc) fan \(id) -v \(value)")
-            
+
             if let error = result.error, !error.isEmpty {
                 NSLog("error set fan speed: \(error)")
-                completion(nil)
+                completion("Failed to set fan \(id) speed to \(value) RPM — SMC rejected write")
                 return
             }
-            
-            completion(result.output)
+
+            completion(nil)
         }
     }
-    
+
     func resetFanControl(completion: (String?) -> Void) {
         smcQueue.sync {
             guard let smc = self.smc else {
@@ -161,10 +161,10 @@ extension Helper {
             let result = syncShell("\(smc) reset")
             if let error = result.error, !error.isEmpty {
                 NSLog("error reset fan control: \(error)")
-                completion(nil)
+                completion("Failed to reset fan control — SMC rejected write")
                 return
             }
-            completion(result.output)
+            completion(nil)
         }
     }
     

--- a/SMC/smc.swift
+++ b/SMC/smc.swift
@@ -369,71 +369,72 @@ public class SMC {
         #endif
     }
 
-    public func setFanMode(_ id: Int, mode: FanMode) {
+    @discardableResult
+    public func setFanMode(_ id: Int, mode: FanMode) -> Bool {
         #if arch(arm64)
         if mode == .forced {
-            if !unlockFanControl(fanId: id) { return }
+            if !unlockFanControl(fanId: id) { return false }
         } else {
             let modeKey = fanModeKey(id)
             let targetKey = "F\(id)Tg"
-            
+
             if self.getValue(modeKey) != nil {
                 var modeVal = SMCVal_t(modeKey)
                 let readResult = read(&modeVal)
                 guard readResult == kIOReturnSuccess else {
                     print(smcError("read", key: modeKey, result: readResult))
-                    return
+                    return false
                 }
                 if modeVal.bytes[0] != 0 {
                     modeVal.bytes[0] = 0
-                    if !writeWithRetry(modeVal) { return }
+                    if !writeWithRetry(modeVal) { return false }
                 }
             }
-            
+
             var targetValue = SMCVal_t(targetKey)
             let result = read(&targetValue)
             guard result == kIOReturnSuccess else {
                 print(smcError("read", key: targetKey, result: result))
-                return
+                return false
             }
-            
+
             let bytes = Float(0).bytes
             targetValue.bytes[0] = bytes[0]
             targetValue.bytes[1] = bytes[1]
             targetValue.bytes[2] = bytes[2]
             targetValue.bytes[3] = bytes[3]
-            
-            if !writeWithRetry(targetValue) { return }
+
+            if !writeWithRetry(targetValue) { return false }
         }
         #else
         // Intel
         if self.getValue("F\(id)Md") != nil {
             var result: kern_return_t = 0
             var value = SMCVal_t("F\(id)Md")
-            
+
             result = read(&value)
             if result != kIOReturnSuccess {
                 print("Error read fan mode: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-                return
+                return false
             }
-            
+
             value.bytes = [UInt8(mode.rawValue), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                                    UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                                    UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                                    UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                                    UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                                    UInt8(0), UInt8(0)]
-            
+
             result = write(value)
             if result != kIOReturnSuccess {
                 print("Error write: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-                return
+                return false
             }
         }
-        
+
         let fansMode = Int(self.getValue("FS! ") ?? 0)
         var newMode: UInt8 = 0
-        
+
         if fansMode == 0 && id == 0 && mode == .forced {
             newMode = 1
         } else if fansMode == 0 && id == 1 && mode == .forced {
@@ -451,62 +452,64 @@ public class SMC {
         } else if fansMode == 3 && id == 1 && mode == .automatic {
             newMode = 1
         }
-        
+
         if fansMode == newMode {
-            return
+            return true
         }
-        
+
         var result: kern_return_t = 0
         var value = SMCVal_t("FS! ")
-        
+
         result = read(&value)
         if result != kIOReturnSuccess {
             print("Error read fan mode: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-            return
+            return false
         }
-        
+
         value.bytes = [0, newMode, UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                        UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                        UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                        UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                        UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
                        UInt8(0), UInt8(0)]
-        
+
         result = write(value)
         if result != kIOReturnSuccess {
             print("Error write: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-            return
+            return false
         }
         #endif
+        return true
     }
     
-    public func setFanSpeed(_ id: Int, speed: Int) {
+    @discardableResult
+    public func setFanSpeed(_ id: Int, speed: Int) -> Bool {
         if let maxSpeed = self.getValue("F\(id)Mx"),
            speed > Int(maxSpeed) {
             return setFanSpeed(id, speed: Int(maxSpeed))
         }
-        
+
         #if arch(arm64)
         var modeVal = SMCVal_t(fanModeKey(id))
         let modeResult = read(&modeVal)
         guard modeResult == kIOReturnSuccess else {
             print("Error read fan mode: " + (String(cString: mach_error_string(modeResult), encoding: String.Encoding.ascii) ?? "unknown error"))
-            return
+            return false
         }
         if modeVal.bytes[0] != 1 {
-            if !unlockFanControl(fanId: id) { return }
+            if !unlockFanControl(fanId: id) { return false }
         }
         #endif
-        
+
         var result: kern_return_t = 0
         var value = SMCVal_t("F\(id)Tg")
-        
+
         result = read(&value)
         if result != kIOReturnSuccess {
             print("Error read fan value: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-            return
+            return false
         }
-        
+
         if value.dataType == "flt " {
             let bytes = Float(speed).bytes
             value.bytes[0] = bytes[0]
@@ -519,28 +522,32 @@ public class SMC {
             value.bytes[2] = UInt8(0)
             value.bytes[3] = UInt8(0)
         }
-        
+
         #if arch(arm64)
         if !writeWithRetry(value) {
-            return
+            return false
         }
         #else
         result = write(value)
         if result != kIOReturnSuccess {
             print("Error write: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
-            return
+            return false
         }
         #endif
+        return true
     }
     
-    public func resetFans() {
+    @discardableResult
+    public func resetFans() -> Bool {
         var value = SMCVal_t("FS! ")
         value.dataSize = 2
-        
+
         let result = write(value)
         if result != kIOReturnSuccess {
             print("Error write: " + (String(cString: mach_error_string(result), encoding: String.Encoding.ascii) ?? "unknown error"))
+            return false
         }
+        return true
     }
     
     // MARK: - Apple Silicon Fan Control


### PR DESCRIPTION
## Problem

`SMC/smc.swift` exposes `setFanSpeed`, `setFanMode`, and `resetFans` as `Void`. On any failure path — IOKit error, missing key on a chip generation, firmware reject — the function `print()`s and returns silently. The caller in `Modules/Sensors/popup.swift` has no way to know the SMC write failed, so the slider/mode UI stays in the wrong state and the user gets no feedback.

This is the visible symptom in #1166 ("Unable to set fan speed") and a contributing factor to several other fan reports where users report "fan control didn't take effect".

## Change

- `SMC/smc.swift` — `setFanSpeed`, `setFanMode`, `resetFans` now return `@discardableResult Bool`. Every error path returns `false`; success returns `true`. `resetFanControl` already returns `Bool` and is unchanged.
- `SMC/Helper/main.swift` — the existing `(String?) -> Void` completion now receives a non-nil error string on failure (was `nil` for both success and failure, which made errors indistinguishable). Error format: `"Failed to set fan <id> speed to <rpm> RPM — SMC rejected write"`.
- `Kit/helpers.swift` — `SMCHelper` setters gain an optional `((String?) -> Void)?` completion (default `nil` preserves all existing call sites). Forwards XPC error string through.
- `Modules/Sensors/popup.swift` — added `showFanError(_:)` private helper on `FanView` that dispatches an `NSAlert` ("Fan control failed", `.warning` style) to the main queue. All 8 interactive call sites — init restore, mode buttons (auto/manual/off/turbo), `setSpeed` debouncer, `wakeListener` — pass a completion that calls `showFanError` on a non-nil error. `sleepListener` intentionally stays fire-and-forget (the user can't act on a sleep-time error).

## Public API note

Returning `Bool` from previously-`Void` functions is a public API change inside the SMC layer. Marked `@discardableResult` to avoid noise at existing call sites that don't care about the result. If you'd prefer a non-API-changing approach (separate `tryFanSpeed` etc), happy to refactor.

## Net diff

```
4 files changed, +39 lines net
```

## Testing

Logic-reviewed but **not yet hardware-tested**. Marking Draft. The XPC completion fires on an internal XPC queue per Apple's docs, so the alert dispatches via `DispatchQueue.main.async` before `NSAlert.runModal()` — please double-check that pattern matches your house style for the popup layer.