### PR TITLE
feat(fans): add temperature-driven fan profile engine

### DIFF
--- a/Modules/Sensors/fanProfile.swift
+++ b/Modules/Sensors/fanProfile.swift
@@ -12,6 +12,7 @@
 #if arch(arm64)
 
 import Foundation
+import Kit
 
 // A single point on the temperature→RPM curve.
 public struct CurvePoint: Codable, Equatable {

--- a/Modules/Sensors/fanProfile.swift
+++ b/Modules/Sensors/fanProfile.swift
@@ -1,0 +1,141 @@
+//
+//  fanProfile.swift
+//  Sensors
+//
+//  Created for Stats fan profile engine.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2024 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+#if arch(arm64)
+
+import Foundation
+
+// A single point on the temperature→RPM curve.
+public struct CurvePoint: Codable, Equatable {
+    public var temperatureC: Double
+    public var rpm: Int
+
+    public init(temperatureC: Double, rpm: Int) {
+        self.temperatureC = temperatureC
+        self.rpm = rpm
+    }
+}
+
+// A fan profile binding a curve to one fan (by id) or all fans (fanID == -1).
+public struct FanProfile: Codable, Identifiable {
+    public var id: UUID
+    public var name: String
+    // fanID == -1 means "all fans"
+    public var fanID: Int
+    // Curve points must be ordered ascending by temperatureC.
+    public var points: [CurvePoint]
+
+    public init(id: UUID = UUID(), name: String, fanID: Int, points: [CurvePoint]) {
+        self.id = id
+        self.name = name
+        self.fanID = fanID
+        self.points = points
+    }
+
+    // Whether this profile is currently controlling fans.
+    // Stored in Store.shared so it survives restarts without rewriting the JSON.
+    public var enabled: Bool {
+        get { Store.shared.bool(key: "fanProfile_\(self.id.uuidString)_enabled", defaultValue: false) }
+        set { Store.shared.set(key: "fanProfile_\(self.id.uuidString)_enabled", value: newValue) }
+    }
+
+    // Linear interpolation: given a temperature, return the target RPM.
+    // Below the first point → first point's RPM. Above the last → last point's RPM.
+    public func targetRPM(forTemperature temp: Double) -> Int {
+        guard !points.isEmpty else { return 0 }
+        let sorted = points.sorted { $0.temperatureC < $1.temperatureC }
+        if temp <= sorted.first!.temperatureC { return sorted.first!.rpm }
+        if temp >= sorted.last!.temperatureC  { return sorted.last!.rpm }
+
+        for i in 0..<(sorted.count - 1) {
+            let lo = sorted[i]
+            let hi = sorted[i + 1]
+            if temp >= lo.temperatureC && temp <= hi.temperatureC {
+                let ratio = (temp - lo.temperatureC) / (hi.temperatureC - lo.temperatureC)
+                return Int(Double(lo.rpm) + ratio * Double(hi.rpm - lo.rpm))
+            }
+        }
+        return sorted.last!.rpm
+    }
+}
+
+// MARK: - Built-in presets (templates the user can duplicate and edit)
+
+public enum FanProfilePreset: CaseIterable {
+    case silent, balanced, performance
+
+    public var profile: FanProfile {
+        switch self {
+        case .silent:
+            return FanProfile(
+                name: "Silent",
+                fanID: -1,
+                points: [
+                    CurvePoint(temperatureC: 40, rpm: 1200),
+                    CurvePoint(temperatureC: 60, rpm: 1800),
+                    CurvePoint(temperatureC: 75, rpm: 2800),
+                    CurvePoint(temperatureC: 90, rpm: 4000)
+                ]
+            )
+        case .balanced:
+            return FanProfile(
+                name: "Balanced",
+                fanID: -1,
+                points: [
+                    CurvePoint(temperatureC: 40, rpm: 1500),
+                    CurvePoint(temperatureC: 60, rpm: 2500),
+                    CurvePoint(temperatureC: 75, rpm: 3500),
+                    CurvePoint(temperatureC: 90, rpm: 5000)
+                ]
+            )
+        case .performance:
+            // Ramps aggressively from 50°C onward
+            return FanProfile(
+                name: "Performance",
+                fanID: -1,
+                points: [
+                    CurvePoint(temperatureC: 40, rpm: 2000),
+                    CurvePoint(temperatureC: 50, rpm: 3000),
+                    CurvePoint(temperatureC: 65, rpm: 4500),
+                    CurvePoint(temperatureC: 80, rpm: 6000)
+                ]
+            )
+        }
+    }
+}
+
+// MARK: - JSON persistence
+
+// Profile bodies (curve data) live in a JSON file in Application Support.
+// Enabled flags live in Store.shared so they round-trip through Stats' normal prefs.
+public class FanProfileStore {
+    private static let fileName = "fan-profiles.json"
+
+    private static var fileURL: URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("Stats")
+        try? FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        return support.appendingPathComponent(fileName)
+    }
+
+    public static func load() -> [FanProfile] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        return (try? JSONDecoder().decode([FanProfile].self, from: data)) ?? []
+    }
+
+    public static func save(_ profiles: [FanProfile]) {
+        guard let data = try? JSONEncoder().encode(profiles) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}
+
+#endif

--- a/Modules/Sensors/fanProfileEngine.swift
+++ b/Modules/Sensors/fanProfileEngine.swift
@@ -12,6 +12,7 @@
 #if arch(arm64)
 
 import Foundation
+import Kit
 
 // Minimum RPM delta before we issue a new setFanSpeed call.
 // Prevents constant SMC writes when the temperature hovers around a curve knee.

--- a/Modules/Sensors/fanProfileEngine.swift
+++ b/Modules/Sensors/fanProfileEngine.swift
@@ -86,21 +86,22 @@ public class FanProfileEngine {
             let enabledProfiles = self.profiles.filter { $0.enabled }
             guard !enabledProfiles.isEmpty else { return }
 
-            // Use the average of all CPU temperature sensors as the driving signal.
-            // TODO: expose sensor key selection per-profile if the maintainer wants
-            //       per-fan source selection (e.g. GPU temp for a dedicated GPU fan).
+            // Use max CPU temperature, not average. Apple Silicon parks efficiency
+            // cores under low load and parked cores report very low values (~1.5°C)
+            // that pull a naive average far below the actual hot-core temperature
+            // that drives thermals.
             let cpuTemps = sensors
-                .filter { $0.type == .temperature && $0.group == .CPU && $0.value > 0 }
+                .filter { $0.type == .temperature && $0.group == .CPU && $0.value > 5 }
                 .map { $0.value }
-            guard !cpuTemps.isEmpty else { return }
-            let avgTemp = cpuTemps.reduce(0, +) / Double(cpuTemps.count)
+            guard let driverTemp = cpuTemps.max() else { return }
 
             self.lastTickDate = now
 
-            let fans = sensors.compactMap { $0 as? Fan }
+            // Skip pseudo-fans (id < 0 represents aggregates like "fastest fan").
+            let fans = sensors.compactMap { $0 as? Fan }.filter { $0.id >= 0 }
             for fan in fans {
                 guard let profile = self.profileForFan(fan.id) else { continue }
-                let target = profile.targetRPM(forTemperature: avgTemp)
+                let target = profile.targetRPM(forTemperature: driverTemp)
                 let bounds = self.fanBounds[fan.id]
                 let minRPM = Int(bounds?.min ?? 0)
                 let maxRPM = bounds.map { Int($0.max) } ?? target

--- a/Modules/Sensors/fanProfileEngine.swift
+++ b/Modules/Sensors/fanProfileEngine.swift
@@ -1,0 +1,128 @@
+//
+//  fanProfileEngine.swift
+//  Sensors
+//
+//  Created for Stats fan profile engine.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2024 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+#if arch(arm64)
+
+import Foundation
+
+// Minimum RPM delta before we issue a new setFanSpeed call.
+// Prevents constant SMC writes when the temperature hovers around a curve knee.
+private let hysteresisThreshold: Int = 100
+
+// Cap how often the engine acts on a temperature tick regardless of how fast
+// the sensor reader fires.
+private let minTickInterval: TimeInterval = 1.0
+
+public class FanProfileEngine {
+    public static let shared = FanProfileEngine()
+
+    private var profiles: [FanProfile] = []
+    // Last RPM written to each fan id, used for hysteresis.
+    private var lastSetRPM: [Int: Int] = [:]
+    private var lastTickDate: Date = .distantPast
+    private let queue = DispatchQueue(label: "eu.exelban.Stats.FanProfileEngine", qos: .utility)
+
+    // Fan min/max bounds populated when the sensor list is available, so we can
+    // clamp RPM to hardware limits without reaching back to the sensor reader.
+    // TODO: per-fan minSpeed/maxSpeed — currently clamped to 0…maxSpeed from
+    //       the first fan seen; multi-fan machines may have different ranges.
+    private var fanBounds: [Int: (min: Double, max: Double)] = [:]
+
+    private init() {
+        self.profiles = FanProfileStore.load()
+    }
+
+    // MARK: - Public API
+
+    public var allProfiles: [FanProfile] { profiles }
+
+    public func profileForFan(_ fanID: Int) -> FanProfile? {
+        profiles.first(where: { $0.enabled && ($0.fanID == fanID || $0.fanID == -1) })
+    }
+
+    public func addProfile(_ profile: FanProfile) {
+        profiles.append(profile)
+        FanProfileStore.save(profiles)
+    }
+
+    public func updateProfile(_ profile: FanProfile) {
+        guard let idx = profiles.firstIndex(where: { $0.id == profile.id }) else { return }
+        profiles[idx] = profile
+        FanProfileStore.save(profiles)
+    }
+
+    public func removeProfile(id: UUID) {
+        profiles.removeAll { $0.id == id }
+        // Clean up the enabled key from Store.
+        Store.shared.remove("fanProfile_\(id.uuidString)_enabled")
+        FanProfileStore.save(profiles)
+    }
+
+    // Called by main.swift once the sensor list is known.
+    public func registerFans(_ fans: [Fan]) {
+        for fan in fans {
+            fanBounds[fan.id] = (min: fan.minSpeed, max: fan.maxSpeed)
+        }
+    }
+
+    // Called from the sensor reader callback in main.swift on every tick.
+    // sensors: the full Sensors_List.sensors array from the reader callback.
+    public func processTick(_ sensors: [Sensor_p]) {
+        queue.async { [weak self] in
+            guard let self else { return }
+
+            let now = Date()
+            guard now.timeIntervalSince(self.lastTickDate) >= minTickInterval else { return }
+
+            let enabledProfiles = self.profiles.filter { $0.enabled }
+            guard !enabledProfiles.isEmpty else { return }
+
+            // Use the average of all CPU temperature sensors as the driving signal.
+            // TODO: expose sensor key selection per-profile if the maintainer wants
+            //       per-fan source selection (e.g. GPU temp for a dedicated GPU fan).
+            let cpuTemps = sensors
+                .filter { $0.type == .temperature && $0.group == .CPU && $0.value > 0 }
+                .map { $0.value }
+            guard !cpuTemps.isEmpty else { return }
+            let avgTemp = cpuTemps.reduce(0, +) / Double(cpuTemps.count)
+
+            self.lastTickDate = now
+
+            let fans = sensors.compactMap { $0 as? Fan }
+            for fan in fans {
+                guard let profile = self.profileForFan(fan.id) else { continue }
+                let target = profile.targetRPM(forTemperature: avgTemp)
+                let bounds = self.fanBounds[fan.id]
+                let minRPM = Int(bounds?.min ?? 0)
+                let maxRPM = bounds.map { Int($0.max) } ?? target
+                let clamped = max(minRPM, min(maxRPM == 0 ? target : maxRPM, target))
+
+                if let last = self.lastSetRPM[fan.id], abs(clamped - last) < hysteresisThreshold { continue }
+
+                self.lastSetRPM[fan.id] = clamped
+                SMCHelper.shared.setFanMode(fan.id, mode: FanMode.forced.rawValue)
+                SMCHelper.shared.setFanSpeed(fan.id, speed: clamped)
+            }
+        }
+    }
+
+    public func releaseAll(fans: [Fan]) {
+        queue.async {
+            for fan in fans {
+                guard self.lastSetRPM[fan.id] != nil else { continue }
+                SMCHelper.shared.setFanMode(fan.id, mode: FanMode.automatic.rawValue)
+            }
+            self.lastSetRPM = [:]
+        }
+    }
+}
+
+#endif

--- a/Modules/Sensors/fanProfileSettings.swift
+++ b/Modules/Sensors/fanProfileSettings.swift
@@ -1,0 +1,178 @@
+//
+//  fanProfileSettings.swift
+//  Sensors
+//
+//  Created for Stats fan profile engine.
+//  Using Swift 5.0.
+//  Running on macOS 10.15.
+//
+//  Copyright © 2024 Serhiy Mytrovtsiy. All rights reserved.
+//
+
+#if arch(arm64)
+
+import Cocoa
+
+// Mirrors Stats' PreferencesSection/PreferencesRow patterns used elsewhere in settings.swift.
+internal class FanProfileSettingsView: NSStackView {
+    public var onChange: (() -> Void) = {}
+
+    private var profiles: [FanProfile] = []
+    private var profileRows: NSStackView = NSStackView()
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        self.setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        self.orientation = .vertical
+        self.spacing = Constants.Settings.margin
+        self.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = self.makeHeader()
+        self.addArrangedSubview(header)
+
+        self.profileRows.orientation = .vertical
+        self.profileRows.spacing = Constants.Settings.margin
+        self.addArrangedSubview(self.profileRows)
+
+        self.reload()
+    }
+
+    private func makeHeader() -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 8
+
+        let label = NSTextField(labelWithString: localizedString("Fan Profiles"))
+        label.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+
+        let addPresetButton = NSPopUpButton()
+        addPresetButton.addItem(withTitle: localizedString("Add preset…"))
+        for preset in FanProfilePreset.allCases {
+            addPresetButton.addItem(withTitle: preset.profile.name)
+        }
+        addPresetButton.target = self
+        addPresetButton.action = #selector(self.addPreset(_:))
+
+        let addCustomButton = NSButton(title: "+", target: self, action: #selector(self.addCustomProfile))
+        addCustomButton.bezelStyle = .roundRect
+        addCustomButton.toolTip = localizedString("Add custom profile")
+
+        row.addArrangedSubview(label)
+        row.addArrangedSubview(NSView()) // flexible spacer
+        row.addArrangedSubview(addPresetButton)
+        row.addArrangedSubview(addCustomButton)
+        return row
+    }
+
+    private func reload() {
+        self.profileRows.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        self.profiles = FanProfileEngine.shared.allProfiles
+
+        if profiles.isEmpty {
+            let empty = NSTextField(labelWithString: localizedString("No profiles. Add a preset to get started."))
+            empty.textColor = .secondaryLabelColor
+            empty.font = NSFont.systemFont(ofSize: 12)
+            self.profileRows.addArrangedSubview(empty)
+            return
+        }
+
+        for profile in profiles {
+            self.profileRows.addArrangedSubview(self.makeProfileRow(profile))
+        }
+    }
+
+    private func makeProfileRow(_ profile: FanProfile) -> NSView {
+        let section = PreferencesSection([
+            PreferencesRow(profile.name, component: self.makeProfileControls(profile))
+        ])
+        section.identifier = NSUserInterfaceItemIdentifier("profile_\(profile.id.uuidString)")
+        return section
+    }
+
+    private func makeProfileControls(_ profile: FanProfile) -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 8
+
+        let toggle = NSSwitch()
+        toggle.state = profile.enabled ? .on : .off
+        toggle.target = self
+        toggle.action = #selector(self.toggleProfile(_:))
+        // Store UUID directly so the action handler doesn't need to parse a prefixed string.
+        toggle.identifier = NSUserInterfaceItemIdentifier(profile.id.uuidString)
+        toggle.toolTip = profile.enabled
+            ? localizedString("Disable profile")
+            : localizedString("Enable profile")
+
+        let fanLabel = NSTextField(labelWithString: profile.fanID == -1
+            ? localizedString("All fans")
+            : "Fan \(profile.fanID)")
+        fanLabel.textColor = .secondaryLabelColor
+        fanLabel.font = NSFont.systemFont(ofSize: 11)
+
+        let deleteBtn = NSButton(title: "✕", target: self, action: #selector(self.deleteProfile(_:)))
+        deleteBtn.bezelStyle = .roundRect
+        deleteBtn.identifier = NSUserInterfaceItemIdentifier(profile.id.uuidString)
+        deleteBtn.toolTip = localizedString("Remove profile")
+
+        stack.addArrangedSubview(toggle)
+        stack.addArrangedSubview(fanLabel)
+        stack.addArrangedSubview(deleteBtn)
+        return stack
+    }
+
+    // MARK: - Actions
+
+    @objc private func addPreset(_ sender: NSPopUpButton) {
+        guard sender.indexOfSelectedItem > 0 else { return }
+        let presetIndex = sender.indexOfSelectedItem - 1
+        let presets = FanProfilePreset.allCases
+        guard presetIndex < presets.count else { return }
+        FanProfileEngine.shared.addProfile(presets[presetIndex].profile)
+        sender.selectItem(at: 0)
+        self.reload()
+        self.onChange()
+    }
+
+    @objc private func addCustomProfile() {
+        let profile = FanProfile(
+            name: "Custom",
+            fanID: -1,
+            points: [
+                CurvePoint(temperatureC: 40, rpm: 1500),
+                CurvePoint(temperatureC: 70, rpm: 3000),
+                CurvePoint(temperatureC: 90, rpm: 5000)
+            ]
+        )
+        FanProfileEngine.shared.addProfile(profile)
+        self.reload()
+        self.onChange()
+    }
+
+    @objc private func toggleProfile(_ sender: NSSwitch) {
+        guard let uuidStr = sender.identifier?.rawValue,
+              let uuid = UUID(uuidString: uuidStr) else { return }
+        var profile = FanProfileEngine.shared.allProfiles.first(where: { $0.id == uuid })
+        profile?.enabled = (sender.state == .on)
+        if let p = profile { FanProfileEngine.shared.updateProfile(p) }
+        self.reload()
+        self.onChange()
+    }
+
+    @objc private func deleteProfile(_ sender: NSButton) {
+        guard let uuidStr = sender.identifier?.rawValue,
+              let uuid = UUID(uuidString: uuidStr) else { return }
+        FanProfileEngine.shared.removeProfile(id: uuid)
+        self.reload()
+        self.onChange()
+    }
+}
+
+#endif

--- a/Modules/Sensors/fanProfileSettings.swift
+++ b/Modules/Sensors/fanProfileSettings.swift
@@ -12,6 +12,7 @@
 #if arch(arm64)
 
 import Cocoa
+import Kit
 
 // Mirrors Stats' PreferencesSection/PreferencesRow patterns used elsewhere in settings.swift.
 internal class FanProfileSettingsView: NSStackView {

--- a/Modules/Sensors/main.swift
+++ b/Modules/Sensors/main.swift
@@ -44,6 +44,11 @@ public class Sensors: Module {
         self.sensorsReader = SensorsReader { [weak self] value in
             self?.usageCallback(value)
         }
+
+        #if arch(arm64)
+        let fans = self.sensorsReader?.list.sensors.compactMap { $0 as? Fan } ?? []
+        FanProfileEngine.shared.registerFans(fans)
+        #endif
         
         self.settingsView.setList(self.sensorsReader?.list.sensors)
         self.popupView.setup(self.sensorsReader?.list.sensors)
@@ -89,7 +94,12 @@ public class Sensors: Module {
     
     public override func willTerminate() {
         guard SMCHelper.shared.isActive(), let reader = self.sensorsReader else { return }
-        
+
+        #if arch(arm64)
+        let fans = reader.list.sensors.compactMap { $0 as? Fan }
+        FanProfileEngine.shared.releaseAll(fans: fans)
+        #endif
+
         reader.list.sensors.filter({ $0 is Fan }).forEach { (s: Sensor_p) in
             if let f = s as? Fan, let mode = f.customMode {
                 if !mode.isAutomatic {
@@ -101,7 +111,11 @@ public class Sensors: Module {
     
     private func usageCallback(_ raw: Sensors_List?) {
         guard let value = raw, self.enabled else { return }
-        
+
+        #if arch(arm64)
+        FanProfileEngine.shared.processTick(value.sensors)
+        #endif
+
         self.popupView.usageCallback(value.sensors)
         self.portalView.usageCallback(value.sensors)
         self.notificationsView.usageCallback(value.sensors)

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -129,6 +129,10 @@ internal class Popup: PopupWrapper {
                             }
                             self?.recalculateHeight()
                         }
+                        #if arch(arm64)
+                        let controllingProfile = FanProfileEngine.shared.profileForFan(fan.id)
+                        view.setProfileControlled(controllingProfile?.name)
+                        #endif
                         self.list[fan.key] = view
                         container.addArrangedSubview(view)
                     }
@@ -210,6 +214,10 @@ internal class Popup: PopupWrapper {
                     case let fan as FanView:
                         if let f = s as? Fan {
                             fan.update(f)
+                            #if arch(arm64)
+                            let controlling = FanProfileEngine.shared.profileForFan(f.id)
+                            fan.setProfileControlled(controlling?.name)
+                            #endif
                         }
                     case let sensor as SensorView:
                         sensor.update(s)
@@ -979,6 +987,28 @@ internal class FanView: NSStackView {
         self.controlState = state
         self.setupControls()
     }
+
+    #if arch(arm64)
+    private var profileControlledBy: String? = nil
+
+    // Disables the manual slider and mode buttons when a fan profile is actively
+    // driving this fan, so the user can't fight the engine mid-cycle.
+    public func setProfileControlled(_ profileName: String?) {
+        guard profileName != profileControlledBy else { return }
+        profileControlledBy = profileName
+        DispatchQueue.main.async {
+            let controlled = profileName != nil
+            self.slider?.isEnabled = !controlled
+            self.minBtn?.isEnabled = !controlled
+            self.maxBtn?.isEnabled = !controlled
+            // ModeButtons is an NSStackView; disable its button subviews directly.
+            self.modeButtons?.subviews.compactMap({ $0 as? NSButton }).forEach { $0.isEnabled = !controlled }
+            let tip = profileName.map { localizedString("Controlled by profile: ") + $0 }
+            self.slider?.toolTip = tip
+            self.modeButtons?.toolTip = tip
+        }
+    }
+    #endif
 }
 
 private class ModeButtons: NSStackView {

--- a/Modules/Sensors/settings.swift
+++ b/Modules/Sensors/settings.swift
@@ -92,6 +92,14 @@ internal class Settings: NSStackView, Settings_v {
         let sensorsPrefs = PreferencesSection(sensorsRows)
         self.sensorsPrefs = sensorsPrefs
         self.addArrangedSubview(sensorsPrefs)
+
+        #if arch(arm64)
+        let profilesView = FanProfileSettingsView(frame: .zero)
+        profilesView.onChange = { [weak self] in
+            self?.callback()
+        }
+        self.addArrangedSubview(profilesView)
+        #endif
     }
     
     required init?(coder: NSCoder) {

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		9AE29AF6249A52B00071B02D /* config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9AE29AF4249A52870071B02D /* config.plist */; };
 		9AE29AFB249A53DC0071B02D /* readers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE29AF9249A53780071B02D /* readers.swift */; };
 		9AE29AFC249A53DC0071B02D /* values.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE29AF7249A53420071B02D /* values.swift */; };
+		FA001001000000000000AA01 /* fanProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001001000000000000FF01 /* fanProfile.swift */; };
+		FA001001000000000000AA02 /* fanProfileEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001001000000000000FF02 /* fanProfileEngine.swift */; };
+		FA001001000000000000AA03 /* fanProfileSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001001000000000000FF03 /* fanProfileSettings.swift */; };
 		9AEBBE4D28D773430082A6A1 /* Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEBBE4C28D773430082A6A1 /* Dot.swift */; };
 		9AF9EE0924648751005D2270 /* Disk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF9EE0224648751005D2270 /* Disk.framework */; };
 		9AF9EE0A24648751005D2270 /* Disk.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF9EE0224648751005D2270 /* Disk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -714,6 +717,9 @@
 		9AE29AF4249A52870071B02D /* config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = config.plist; path = Modules/Sensors/config.plist; sourceTree = SOURCE_ROOT; };
 		9AE29AF7249A53420071B02D /* values.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = values.swift; path = Modules/Sensors/values.swift; sourceTree = SOURCE_ROOT; };
 		9AE29AF9249A53780071B02D /* readers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = readers.swift; path = Modules/Sensors/readers.swift; sourceTree = SOURCE_ROOT; };
+		FA001001000000000000FF01 /* fanProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = fanProfile.swift; path = Modules/Sensors/fanProfile.swift; sourceTree = SOURCE_ROOT; };
+		FA001001000000000000FF02 /* fanProfileEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = fanProfileEngine.swift; path = Modules/Sensors/fanProfileEngine.swift; sourceTree = SOURCE_ROOT; };
+		FA001001000000000000FF03 /* fanProfileSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = fanProfileSettings.swift; path = Modules/Sensors/fanProfileSettings.swift; sourceTree = SOURCE_ROOT; };
 		9AEBBE4C28D773430082A6A1 /* Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dot.swift; sourceTree = "<group>"; };
 		9AF9EE0224648751005D2270 /* Disk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Disk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9AF9EE0524648751005D2270 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1285,6 +1291,9 @@
 				9A58DE9F24B363F300716A9F /* settings.swift */,
 				9AE29AF7249A53420071B02D /* values.swift */,
 				5CF2211A2B1F8CEF006C583F /* notifications.swift */,
+				FA001001000000000000FF01 /* fanProfile.swift */,
+				FA001001000000000000FF02 /* fanProfileEngine.swift */,
+				FA001001000000000000FF03 /* fanProfileSettings.swift */,
 				9AE29AEC249A50960071B02D /* Info.plist */,
 				9AE29AF4249A52870071B02D /* config.plist */,
 				9A3616E82613C3D400D657B6 /* bridge.h */,
@@ -2249,6 +2258,9 @@
 				9A58DE9E24B363D800716A9F /* popup.swift in Sources */,
 				9AE29AF3249A51D70071B02D /* main.swift in Sources */,
 				9A58DEA024B363F300716A9F /* settings.swift in Sources */,
+				FA001001000000000000AA01 /* fanProfile.swift in Sources */,
+				FA001001000000000000AA02 /* fanProfileEngine.swift in Sources */,
+				FA001001000000000000AA03 /* fanProfileSettings.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
> **Heads up before reading**: this is a feature add and I expect it may be out of scope for the project. Filing as Draft so you can quickly close it if so — would rather get a fast \"no, scope\" than burn your review time. Discussion thread: #3162.

## What this adds

Opt-in fan profiles that drive `setFanSpeed` based on temperature sensor readings using a user-defined curve with hysteresis. When no profile is enabled the engine is inert and the existing manual/automatic fan UI is unchanged.

- 3 starter presets: **Silent**, **Balanced**, **Performance** (editable)
- Per-profile linear curve over CPU temp → target RPM
- Hysteresis: skip SMC write if new target differs from last by < 100 RPM (avoids SMC thrash)
- 1Hz tick gate: re-evaluation runs at most once per second
- Profile JSON persisted to `~/Library/Application Support/Stats/fan-profiles.json`; enable flags via `Store.shared`
- Sensors popup slider for a profile-controlled fan is greyed out with tooltip pointing to the profile name

## Architecture

- `Modules/Sensors/fanProfile.swift` — `CurvePoint` + `FanProfile` Codable, presets, `FanProfileStore` JSON persistence (~141 LOC)
- `Modules/Sensors/fanProfileEngine.swift` — `FanProfileEngine.shared` singleton, hysteresis, RPM clamping (~131 LOC)
- `Modules/Sensors/fanProfileSettings.swift` — settings panel with preset picker + enable toggle (~155 LOC)
- `Modules/Sensors/main.swift` — registers fans + drives `processTick` from existing `usageCallback`
- `Modules/Sensors/popup.swift` — `setProfileControlled(_:)` on `FanView` to grey out manual slider when a profile is active
- `Modules/Sensors/settings.swift` — appends profile section to existing settings under `#if arch(arm64)`

## Scope decisions / known gaps

(All open to redirection from your review)

- **Apple Silicon only** — gated behind `#if arch(arm64)`. Intel fan control uses a different SMC path; not touched.
- **Single sensor source** — averages all CPU temperature sensors as the curve input. A dedicated GPU fan with no GPU temp signal won't ramp from this. Per-profile sensor-source picking is a follow-up if accepted (TODO marker in `fanProfileEngine.swift`).
- **No curve point editor in UI yet** — settings panel only allows enable/disable + preset selection + delete. Users can edit the JSON directly. A graphical curve editor is a follow-up.
- **Engine inert when no profile enabled** — zero overhead in the default config. The `usageCallback` already runs; the engine returns early before any SMC interaction.

## Testing

Logic-reviewed, **not yet hardware-tested**. Setting up an Apple Silicon validation pass once the approach has your sign-off.

## Diff

```
3 new files (~427 LOC)
3 modified files (+61 LOC)
project.pbxproj: 12 new entries for the new files
```