### PR TITLE
refactor(helper): migrate to SMAppService for macOS 13+ helper install

### DIFF
--- a/Kit/helpers.swift
+++ b/Kit/helpers.swift
@@ -905,9 +905,24 @@ public class SettingsContainerView: NSStackView {
 
 public class SMCHelper {
     public static let shared = SMCHelper()
-    
+
+    // On macOS 13+ the daemon is managed by SMAppService; the old
+    // PrivilegedHelperTools path is never populated by that API.
     public var isInstalled: Bool {
-        syncShell("ls /Library/PrivilegedHelperTools/").contains("eu.exelban.Stats.SMC.Helper")
+        if #available(macOS 13.0, *) {
+            let status = SMAppService.daemon(plistName: "eu.exelban.Stats.SMC.Helper.plist").status
+            return status == .enabled || status == .requiresApproval
+        } else {
+            return syncShell("ls /Library/PrivilegedHelperTools/").contains("eu.exelban.Stats.SMC.Helper")
+        }
+    }
+
+    // Returns true when the daemon is fully enabled (XPC calls will succeed).
+    // requiresApproval means registered but the user hasn't approved it yet in
+    // System Settings → Login Items & Extensions → Background Items.
+    @available(macOS 13.0, *)
+    public var requiresApproval: Bool {
+        SMAppService.daemon(plistName: "eu.exelban.Stats.SMC.Helper.plist").status == .requiresApproval
     }
     
     private var connection: NSXPCConnection? = nil
@@ -960,38 +975,60 @@ public class SMCHelper {
     }
     
     public func install(completion: @escaping (_ installed: Bool) -> Void) {
+        if #available(macOS 13.0, *) {
+            installSMAppService(completion: completion)
+        } else {
+            installSMJobBless(completion: completion)
+        }
+    }
+
+    @available(macOS 13.0, *)
+    private func installSMAppService(completion: @escaping (_ installed: Bool) -> Void) {
+        let service = SMAppService.daemon(plistName: "eu.exelban.Stats.SMC.Helper.plist")
+        do {
+            try service.register()
+            completion(true)
+        } catch let error as NSError {
+            // errAuthorizationDenied (-60006) means the user needs to approve in
+            // System Settings → Login Items & Extensions → Background Items.
+            NSLog("SMAppService daemon register failed: %@", error.localizedDescription)
+            completion(false)
+        }
+    }
+
+    private func installSMJobBless(completion: @escaping (_ installed: Bool) -> Void) {
         var authRef: AuthorizationRef?
         var authStatus = AuthorizationCreate(nil, nil, [.preAuthorize], &authRef)
-        
+
         guard authStatus == errAuthorizationSuccess else {
             print("Unable to get a valid empty authorization reference to load Helper daemon")
             completion(false)
             return
         }
-        
+
         let authItem = kSMRightBlessPrivilegedHelper.withCString { authorizationString in
             AuthorizationItem(name: authorizationString, valueLength: 0, value: nil, flags: 0)
         }
-        
+
         let pointer = UnsafeMutablePointer<AuthorizationItem>.allocate(capacity: 1)
         pointer.initialize(to: authItem)
-        
+
         defer {
             pointer.deinitialize(count: 1)
             pointer.deallocate()
         }
-        
+
         var authRights = AuthorizationRights(count: 1, items: pointer)
-        
+
         let flags: AuthorizationFlags = [.interactionAllowed, .extendRights, .preAuthorize]
         authStatus = AuthorizationCreate(&authRights, nil, flags, &authRef)
-        
+
         guard authStatus == errAuthorizationSuccess else {
             print("Unable to get a valid loading authorization reference to load Helper daemon")
             completion(false)
             return
         }
-        
+
         var error: Unmanaged<CFError>?
         if SMJobBless(kSMDomainSystemLaunchd, "eu.exelban.Stats.SMC.Helper" as CFString, authRef, &error) == false {
             let blessError = error!.takeRetainedValue() as Error
@@ -999,7 +1036,7 @@ public class SMCHelper {
             completion(false)
             return
         }
-        
+
         AuthorizationFree(authRef!, [])
         completion(true)
     }
@@ -1048,8 +1085,17 @@ public class SMCHelper {
                 self.setFanMode(i, mode: 0)
             }
         }
-        guard let helper = self.helper(nil) else { return }
-        helper.uninstall()
+        if #available(macOS 13.0, *) {
+            let service = SMAppService.daemon(plistName: "eu.exelban.Stats.SMC.Helper.plist")
+            do {
+                try service.unregister()
+            } catch {
+                NSLog("SMAppService daemon unregister failed: %@", error.localizedDescription)
+            }
+        } else {
+            guard let helper = self.helper(nil) else { return }
+            helper.uninstall()
+        }
         if !silent {
             NotificationCenter.default.post(name: .fanHelperState, object: nil, userInfo: ["state": false])
         }

--- a/SMC/Helper/eu.exelban.Stats.SMC.Helper.plist
+++ b/SMC/Helper/eu.exelban.Stats.SMC.Helper.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>eu.exelban.Stats.SMC.Helper</string>
+	<key>MachServices</key>
+	<dict>
+		<key>eu.exelban.Stats.SMC.Helper</key>
+		<true/>
+	</dict>
+	<key>BundleProgram</key>
+	<string>Contents/Library/LaunchServices/eu.exelban.Stats.SMC.Helper</string>
+</dict>
+</plist>

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		5CFE492A29264DF1000F2856 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFE492929264DF1000F2856 /* main.swift */; };
 		5CFE493929265055000F2856 /* protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFE493829265055000F2856 /* protocol.swift */; };
 		5CFE493D2926513E000F2856 /* eu.exelban.Stats.SMC.Helper in Copy Files */ = {isa = PBXBuildFile; fileRef = 5CFE492729264DF1000F2856 /* eu.exelban.Stats.SMC.Helper */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		5CFE4A0129265500000F2856 /* eu.exelban.Stats.SMC.Helper.plist in Copy Files */ = {isa = PBXBuildFile; fileRef = 5CFE4A0029265500000F2856 /* eu.exelban.Stats.SMC.Helper.plist */; };
 		5CFE494229265418000F2856 /* uninstall.sh in Resources */ = {isa = PBXBuildFile; fileRef = 5CFE494129265418000F2856 /* uninstall.sh */; };
 		5CFE494429265421000F2856 /* changelog.py in Resources */ = {isa = PBXBuildFile; fileRef = 5CFE494329265421000F2856 /* changelog.py */; };
 		5EC1B2E52E2FEAFB007042A6 /* UnitedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC1B2E42E2FEAFB007042A6 /* UnitedWidget.swift */; };
@@ -439,6 +440,17 @@
 			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5CFE4A0229265500000F2856 /* Copy LaunchDaemons Plist */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LaunchDaemons;
+			dstSubfolderSpec = 1;
+			files = (
+				5CFE4A0129265500000F2856 /* eu.exelban.Stats.SMC.Helper.plist in Copy Files */,
+			);
+			name = "Copy LaunchDaemons Plist";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A46BF89266D7CFA001A1117 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -580,6 +592,7 @@
 		5CFE493829265055000F2856 /* protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = protocol.swift; sourceTree = "<group>"; };
 		5CFE493A292650BD000F2856 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5CFE493B292650F8000F2856 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Launchd.plist; sourceTree = "<group>"; };
+		5CFE4A0029265500000F2856 /* eu.exelban.Stats.SMC.Helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "eu.exelban.Stats.SMC.Helper.plist"; sourceTree = "<group>"; };
 		5CFE494129265418000F2856 /* uninstall.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = uninstall.sh; sourceTree = "<group>"; };
 		5CFE494329265421000F2856 /* changelog.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = changelog.py; sourceTree = "<group>"; };
 		5EC1B2E42E2FEAFB007042A6 /* UnitedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitedWidget.swift; sourceTree = "<group>"; };
@@ -950,6 +963,7 @@
 				5CFE493829265055000F2856 /* protocol.swift */,
 				5CFE493A292650BD000F2856 /* Info.plist */,
 				5CFE493B292650F8000F2856 /* Launchd.plist */,
+				5CFE4A0029265500000F2856 /* eu.exelban.Stats.SMC.Helper.plist */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1497,6 +1511,7 @@
 				9A88E2672659002E00E2B7B0 /* ShellScript */,
 				9A46BF89266D7CFA001A1117 /* CopyFiles */,
 				5CFE493C29265130000F2856 /* Copy Files */,
+				5CFE4A0229265500000F2856 /* Copy LaunchDaemons Plist */,
 				5CE7E79D2C318513006BC92C /* Embed Foundation Extensions */,
 			);
 			buildRules = (


### PR DESCRIPTION
## Why

SMJobBless was deprecated in macOS 13. As of macOS 26.4.1 the OS-level smd daemon now rejects SMJobBless installs that previously worked, silently breaking fan control for end users on the latest macOS:

\`\`\`
smd: App "eu.exelban.Stats" did not pass helper check "eu.exelban.Stats.SMC.Helper".
\`\`\`

Reproduces consistently on a fresh macOS 26.4.1 install — clicking **Install fan helper** silently fails, no helper files land at \`/Library/PrivilegedHelperTools/\`, and the popup keeps showing the placeholder forever. Affects every user who upgrades to macOS 26.

## Change

Migrate the install/uninstall flow to the modern \`SMAppService\` API (macOS 13+) while keeping the existing SMJobBless code path intact as a fallback for macOS 11/12.

- New \`SMC/Helper/eu.exelban.Stats.SMC.Helper.plist\` — bundled launchd plist with \`Label\`, \`MachServices\`, and \`BundleProgram\` pointing to the helper binary at its existing \`Contents/Library/LaunchServices/...\` path (binary location unchanged).
- New \`PBXCopyFilesBuildPhase\` in the Stats target copies the plist to \`Contents/Library/LaunchDaemons/\` in the app bundle — where \`SMAppService\` daemons must live.
- \`Kit/helpers.swift\`:
  - \`install(completion:)\` branches on \`#available(macOS 13.0, *)\`. macOS 13+ calls \`SMAppService.daemon(plistName:).register()\`. Older macOS keeps the existing SMJobBless + \`AuthorizationCreate\` flow.
  - \`uninstall()\` branches to \`service.unregister()\` on 13+, helper-side XPC uninstall on older.
  - \`isInstalled\` queries \`service.status\` on 13+.
  - New \`requiresApproval\` computed property surfaces the SMAppService \`.requiresApproval\` status so the popup can show "approve in System Settings → Login Items & Extensions" guidance instead of the generic Install button. **(UI wiring not in this PR — kept minimal; happy to add as a follow-up if you'd like the UX in the same change.)**
- Helper code (\`SMC/Helper/main.swift\`) and existing \`SMC/Helper/Launchd.plist\` left untouched. The legacy plist is still consumed by the SMJobBless path.

## User flow on macOS 13+

1. User clicks **Install fan helper** in the popup
2. \`SMAppService.daemon(plistName:).register()\` is called
3. macOS adds an entry to System Settings → Login Items & Extensions → Background Items, status \`.requiresApproval\`
4. User approves the toggle in System Settings
5. Daemon bootstraps, helper goes \`.enabled\`, fan control comes alive

## Net diff

\`\`\`
3 files changed, +89 lines net
 SMC/Helper/eu.exelban.Stats.SMC.Helper.plist  | +14 (new)
 Kit/helpers.swift                              | +55
 Stats.xcodeproj/project.pbxproj                | +14 (PBXFileReference, PBXBuildFile, PBXCopyFilesBuildPhase, group children, build phase wiring)
\`\`\`

## Testing — important caveat

Compile-verified (\`BUILD SUCCEEDED\`, plist lands at \`Contents/Library/LaunchDaemons/eu.exelban.Stats.SMC.Helper.plist\` in the built bundle). Direct API probe of \`SMAppService.daemon(plistName:).register()\` against the dev build returns \`SMAppServiceErrorDomain code 3 — Codesigning failure loading plist (-67028)\`, which is the **expected** rejection of unsigned dev builds — \`SMAppService\` strictly requires a Developer ID signature.

**Behavioural verification therefore requires a Developer ID-signed build, which I don't have locally.** The PR is filed as Draft so you can build with your signing cert, register the daemon once, and confirm the user-side flow (System Settings prompt → approval → helper bootstraps).

If the registration call succeeds and the System Settings approval prompt appears, the migration is good. If \`register()\` throws on a properly-signed build, the most likely culprits are:
- Plist filename mismatch — the file in the bundle must be exactly \`eu.exelban.Stats.SMC.Helper.plist\` (the file is named that way in the source and the Copy Files phase preserves it).
- Helper not actually present at the \`BundleProgram\` path inside the bundle.
- Notarization needs to include the new plist (no extra resource, but worth a sanity check on the first signed build).

Happy to iterate on any of the above.

## Pre-13 fallback

\`installSMJobBless()\` and the older uninstall path are unchanged — verbatim from main. Any users on macOS 11/12 see no behavioural difference.