### PR TITLE
Add thermal pressure state and CPU speed limit to Apple Silicon CPU popup

### DIFF
--- a/Modules/CPU/main.swift
+++ b/Modules/CPU/main.swift
@@ -44,6 +44,13 @@ public struct CPU_Limit: Codable {
     var speed: Int = 0
 }
 
+public struct CPU_ThermalState: Codable {
+    var thermalPressure: Int = ProcessInfo.ThermalState.nominal.rawValue
+    var schedulerLimit: Int = 100
+    var cpus: Int = 0
+    var speedLimit: Int = 100
+}
+
 public struct CPU_AverageLoad: Codable, RemoteType {
     var load1: Double = 0
     var load5: Double = 0
@@ -68,6 +75,7 @@ public class CPU: Module {
     private var frequencyReader: FrequencyReader? = nil
     private var limitReader: LimitReader? = nil
     private var averageLoadReader: AverageLoadReader? = nil
+    private var thermalStateReader: ThermalStateReader? = nil
     
     private var usagePerCoreState: Bool {
         Store.shared.bool(key: "\(self.config.name)_usagePerCore", defaultValue: false)
@@ -164,6 +172,9 @@ public class CPU: Module {
             self?.popupView.frequencyCallback(value)
             self?.previewView.frequencyCallback(value)
         }
+        self.thermalStateReader = ThermalStateReader(.CPU, popup: true) { [weak self] value in
+            self?.thermalStateCallback(value)
+        }
         #endif
         
         self.settingsView.callback = { [weak self] in
@@ -188,10 +199,16 @@ public class CPU: Module {
             self.temperatureReader,
             self.frequencyReader,
             self.limitReader,
-            self.averageLoadReader
+            self.averageLoadReader,
+            self.thermalStateReader
         ])
     }
     
+    private func thermalStateCallback(_ raw: CPU_ThermalState?) {
+        guard let value = raw, self.enabled else { return }
+        self.popupView.thermalStateCallback(value)
+    }
+
     private func loadCallback(_ raw: CPU_Load?) {
         guard let value = raw, self.enabled else { return }
         

--- a/Modules/CPU/popup.swift
+++ b/Modules/CPU/popup.swift
@@ -17,7 +17,7 @@ internal class Popup: PopupWrapper {
     private let chartHeight: CGFloat = 120 + Constants.Popup.separatorHeight
     private var detailsHeight: CGFloat {
         get {
-            var count: CGFloat = isARM ? 4 : 6
+            var count: CGFloat = 6
             if SystemKit.shared.device.info.cpu?.eCores != nil {
                 count += 1
             }
@@ -51,6 +51,8 @@ internal class Popup: PopupWrapper {
     private var systemField: NSTextField? = nil
     private var userField: NSTextField? = nil
     private var idleField: NSTextField? = nil
+    private var thermalPressureColorView: NSView? = nil
+    private var thermalPressureField: NSTextField? = nil
     private var shedulerLimitField: NSTextField? = nil
     private var speedLimitField: NSTextField? = nil
     private var eCoresField: NSTextField? = nil
@@ -88,6 +90,7 @@ internal class Popup: PopupWrapper {
     private var initializedFrequency: Bool = false
     private var initializedProcesses: Bool = false
     private var initializedLimits: Bool = false
+    private var initializedThermal: Bool = false
     private var initializedAverage: Bool = false
     
     private var processes: ProcessesView? = nil
@@ -290,7 +293,10 @@ internal class Popup: PopupWrapper {
         (self.userColorView, _, self.userField) = popupWithColorRow(container, color: self.userColor, title: "\(localizedString("User")):", value: "")
         (self.idleColorView, _, self.idleField) = popupWithColorRow(container, color: self.idleColor.withAlphaComponent(0.5), title: "\(localizedString("Idle")):", value: "")
         
-        if !isARM {
+        if isARM {
+            (self.thermalPressureColorView, _, self.thermalPressureField) = popupWithColorRow(container, color: NSColor.systemGreen, title: "\(localizedString("Thermal pressure")):", value: "")
+            self.speedLimitField = popupRow(container, title: "\(localizedString("Speed limit")):", value: "").1
+        } else {
             self.shedulerLimitField = popupRow(container, title: "\(localizedString("Scheduler limit")):", value: "").1
             self.speedLimitField = popupRow(container, title: "\(localizedString("Speed limit")):", value: "").1
         }
@@ -518,6 +524,44 @@ internal class Popup: PopupWrapper {
         })
     }
     
+    public func thermalStateCallback(_ value: CPU_ThermalState?) {
+        guard let value else { return }
+
+        DispatchQueue.main.async(execute: {
+            if !(self.window?.isVisible ?? false) && self.initializedThermal {
+                return
+            }
+
+            let pressure = ProcessInfo.ThermalState(rawValue: value.thermalPressure) ?? .nominal
+            let label: String
+            let color: NSColor
+            switch pressure {
+            case .nominal:
+                label = localizedString("Nominal")
+                color = NSColor.systemGreen
+            case .fair:
+                label = localizedString("Fair")
+                color = NSColor.systemYellow
+            case .serious:
+                label = localizedString("Serious")
+                color = NSColor.systemOrange
+            case .critical:
+                label = localizedString("Critical")
+                color = NSColor.systemRed
+            @unknown default:
+                label = localizedString("Unknown")
+                color = NSColor.systemGray
+            }
+
+            self.thermalPressureField?.stringValue = label
+            self.thermalPressureColorView?.layer?.backgroundColor = color.cgColor
+
+            self.speedLimitField?.stringValue = "\(value.speedLimit)%"
+
+            self.initializedThermal = true
+        })
+    }
+
     public func limitCallback(_ value: CPU_Limit?) {
         guard let value else { return }
         

--- a/Modules/CPU/readers.swift
+++ b/Modules/CPU/readers.swift
@@ -583,6 +583,54 @@ public class LimitReader: Reader<CPU_Limit> {
     }
 }
 
+public class ThermalStateReader: Reader<CPU_ThermalState> {
+    private var state: CPU_ThermalState = CPU_ThermalState()
+
+    public override func setup() {
+        self.popup = true
+        self.setInterval(5)
+    }
+
+    public override func read() {
+        self.state.thermalPressure = ProcessInfo.processInfo.thermalState.rawValue
+
+        let task = Process()
+        task.launchPath = "/usr/bin/pmset"
+        task.arguments = ["-g", "therm"]
+        let pipe = Pipe()
+        let errorPipe = Pipe()
+        defer {
+            pipe.fileHandleForReading.closeFile()
+            errorPipe.fileHandleForReading.closeFile()
+        }
+        task.standardOutput = pipe
+        task.standardError = errorPipe
+
+        do {
+            try task.run()
+        } catch let err {
+            error("error reading pmset for thermal state: \(err.localizedDescription)", log: self.log)
+            self.callback(self.state)
+            return
+        }
+
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let allLines = output.split(separator: "\n")
+        let lines = allLines.count > 3 ? allLines.dropFirst(3) : []
+
+        self.state.schedulerLimit = 100
+        self.state.speedLimit = 100
+        lines.forEach { line in
+            guard let value = Int(line.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()) else { return }
+            if line.contains("Scheduler") { self.state.schedulerLimit = value }
+            else if line.contains("CPUs") { self.state.cpus = value }
+            else if line.contains("Speed") { self.state.speedLimit = value }
+        }
+
+        self.callback(self.state)
+    }
+}
+
 public class AverageLoadReader: Reader<CPU_AverageLoad> {
     private let title: String = "CPU"
     private var load: CPU_AverageLoad = CPU_AverageLoad()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+# Stats (Apple Silicon thermal fork)
+
+> **This is a fork of [exelban/stats](https://github.com/exelban/stats) with one addition: thermal pressure and CPU speed limit visibility for Apple Silicon Macs.**
+> See [What's different](#whats-different) below. For everything else, refer to the original project.
+
+---
+
+## What's different
+
+On Apple Silicon (M1–M5), the upstream Stats app reads CPU speed limit data via `pmset` but never surfaces it in the UI — that code path was Intel-only. This fork re-enables it for ARM and adds macOS thermal pressure state alongside it.
+
+**New rows in the CPU popup → Details section (Apple Silicon only):**
+
+| Row | What it shows |
+|---|---|
+| Thermal pressure | `Nominal` / `Fair` / `Serious` / `Critical` with a colour-coded dot (green → yellow → orange → red), polled every 5 seconds via `ProcessInfo.thermalState` |
+| Speed limit | CPU speed limit % from `pmset -g therm` — drops below 100% when the chip is thermally throttled |
+
+**Files changed:** `Modules/CPU/readers.swift`, `Modules/CPU/main.swift`, `Modules/CPU/popup.swift`  
+**Architectures affected:** arm64 only. Intel behaviour is unchanged.  
+**APIs used:** `ProcessInfo.processInfo.thermalState` (public macOS API) and `/usr/bin/pmset -g therm` (same tool the upstream app already uses on Intel).
+
+No code was copied from any other project. This was developed and tested on a MacBook Pro M4 Max running macOS 26.
+
+---
+
 # Stats
 
 <a href="https://github.com/exelban/stats/releases"><p align="center"><img src="https://github.com/exelban/stats/raw/master/Stats/Supporting%20Files/Assets.xcassets/AppIcon.appiconset/icon_256x256.png" width="120"></p></a>


### PR DESCRIPTION
Stats covers a lot of ground that other free monitors don't — the Sensors module depth, per-core frequency breakdowns, unified memory breakdown, and GPU and power figures all in one app made it the clear choice for Apple Silicon monitoring. Thanks for maintaining it. This PR builds on that with a small addition for M-series users.

---

### What this adds

On Apple Silicon, `pmset -g therm` is already called by the existing `LimitReader` — but that reader is wrapped in `#if arch(x86_64)`, so on M-series chips the speed limit data is read and discarded. Separately, `ProcessInfo.thermalState` (nominal/fair/serious/critical pressure state) isn't called anywhere in the CPU module.

This PR surfaces both on ARM, adding two new rows to the CPU popup's Details section:

| Row | Source |
|---|---|
| **Thermal pressure** — `Nominal` / `Fair` / `Serious` / `Critical` with a colour-coded dot | `ProcessInfo.processInfo.thermalState`, polled every 5s |
| **Speed limit** — drops below 100% when the chip is thermally throttled | `/usr/bin/pmset -g therm`, same tool already used on Intel |

Intel behaviour is completely unchanged.

### What it looks like

\`\`\`
● Thermal pressure:   Fair
  Speed limit:        95%
\`\`\`

The dot shifts green → yellow → orange → red as pressure increases.

### Implementation

Three files, ~112 lines added:

- **`readers.swift`** — new `ThermalStateReader` class, polls both sources every 5 seconds into a `CPU_ThermalState` struct
- **`main.swift`** — struct definition, reader instantiation in the `#else` arm alongside `FrequencyReader`, callback routing to popup
- **`popup.swift`** — two new rows in `initDetails()` for ARM, `thermalStateCallback` with colour logic, `detailsHeight` unified to 6 base rows for both architectures

No private APIs. No new dependencies.

### Tested on

MacBook Pro M4 Max, 48GB, macOS 26.