### PR TITLE
Liquid Glass / Tahoe menu bar look: pill widgets, glass dropdowns, RoundedBarChart

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -15,6 +15,30 @@ public class BarChart: WidgetWrapper {
     private var labelState: Bool = false
     private var boxState: Bool = true
     private var frameState: Bool = false
+    // Liquid Glass / macOS Tahoe pill style: full-radius capsule, thicker outline,
+    // single accent color used for both stroke and fill, fully transparent empty space.
+    // Default is on for macOS 26 (Tahoe) and later, off on older systems so the
+    // widget keeps its classic appearance there.
+    public var liquidGlassState: Bool = Constants.isTahoe
+    // When the Liquid Glass style is on with the default (system accent)
+    // color, the existing `colorZones` thresholds are reused to tint a row
+    // yellow / red as it approaches saturation. The toggle below lets the
+    // user disable that behavior; the actual breakpoints come from the
+    // shared `_colorZones` ivar.
+    private var liquidGlassWarningState: Bool = true
+    // Liquid Glass cosmetic options. Width is the per-pill horizontal size,
+    // outline draws the stroke offset slightly from the fill (battery-style)
+    // and outlineColor lets the user color-code the stroke independently of
+    // the fill (e.g. orange CPU outline vs blue GPU outline).
+    public var liquidGlassPillWidth: Int = 28
+    // Per-row pill height. Default of 8pt sits between the historical
+    // multi-row (6pt) and single-row (10pt) caps; the slider lets the
+    // user push it shorter for a slimmer indicator or taller (up to 14pt)
+    // for a beefier one.
+    public var liquidGlassPillHeight: Int = 8
+    private var liquidGlassOutlineState: Bool = false
+    // "same" is a sentinel meaning "use the same color as the fill".
+    private var liquidGlassOutlineColorKey: String = "same"
     public var colorState: SColor = .systemAccent
     private var colors: [SColor] = SColor.allCases
     
@@ -24,6 +48,7 @@ public class BarChart: WidgetWrapper {
     
     private var boxSettingsView: NSSwitch? = nil
     private var frameSettingsView: NSSwitch? = nil
+    private var liquidGlassSettingsView: NSSwitch? = nil
     
     public var NSLabelCharts: [NSAttributedString] = []
     
@@ -74,6 +99,18 @@ public class BarChart: WidgetWrapper {
             self.boxState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_box", defaultValue: self.boxState)
             self.frameState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_frame", defaultValue: self.frameState)
             self.labelState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_label", defaultValue: self.labelState)
+            self.liquidGlassState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", defaultValue: self.liquidGlassState)
+            self.liquidGlassWarningState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlassWarning", defaultValue: self.liquidGlassWarningState)
+            // `colorZones` is persisted as two integer percentages so it
+            // survives relaunches. Modules may still override these with
+            // `setColorZones(_:)` for their domain-specific defaults.
+            let storedOrange = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_colorZones_orange", defaultValue: Int(self._colorZones.orange * 100))
+            let storedRed = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_colorZones_red", defaultValue: Int(self._colorZones.red * 100))
+            self._colorZones = (Double(storedOrange) / 100.0, Double(storedRed) / 100.0)
+            self.liquidGlassPillWidth = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillWidth", defaultValue: self.liquidGlassPillWidth)
+            self.liquidGlassPillHeight = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillHeight", defaultValue: self.liquidGlassPillHeight)
+            self.liquidGlassOutlineState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutline", defaultValue: self.liquidGlassOutlineState)
+            self.liquidGlassOutlineColorKey = Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutlineColor", defaultValue: self.liquidGlassOutlineColorKey)
             self.colorState = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_color", defaultValue: self.colorState.key))
         }
         
@@ -118,6 +155,11 @@ public class BarChart: WidgetWrapper {
         
         guard !value.isEmpty else {
             self.setWidth(0)
+            return
+        }
+        
+        if self.liquidGlassState {
+            self.drawLiquidGlass(value: value, pressureLevel: pressureLevel, colorZones: colorZones)
             return
         }
         
@@ -222,6 +264,163 @@ public class BarChart: WidgetWrapper {
         self.setWidth(width)
     }
     
+    // MARK: - Liquid Glass (macOS Tahoe) draw path
+    
+    /// Resolves the color to use for an individual bar segment when the
+    /// pill style is enabled. If a per-value color is specified it is used
+    /// verbatim; otherwise the user's color preference is honored.
+    /// Liquid Glass defaults to white when no explicit accent has been chosen,
+    /// matching the monochrome glyphs in the Tahoe menu bar.
+    private func liquidGlassColor(_ partition: ColorValue, pressureLevel: RAMPressure, colorZones: colorZones) -> NSColor {
+        if let c = partition.color { return c }
+        switch self.colorState {
+        case .systemAccent: return Constants.liquidGlassInk
+        case .utilization:  return partition.value.usageColor(zones: colorZones, reversed: self.title == "Battery")
+        case .pressure:     return pressureLevel.pressureColor()
+        case .monochrome:   return Constants.liquidGlassInk
+        default:            return self.colorState.additional as? NSColor ?? Constants.liquidGlassInk
+        }
+    }
+    
+    /// Resolve the ink color for a single Liquid Glass row, applying the
+    /// per-widget warning / critical thresholds when the user has enabled
+    /// them and is using the default (system accent) color. The row's total
+    /// fill is what's evaluated against the thresholds, so multi-segment
+    /// stacks light up based on the combined utilization.
+    private func liquidGlassRowColor(rowTotal: Double) -> NSColor? {
+        guard self.liquidGlassWarningState, self.colorState == .systemAccent else { return nil }
+        return Constants.liquidGlassWarningColor(
+            value: rowTotal,
+            warning: self._colorZones.orange,
+            critical: self._colorZones.red
+        )
+    }
+    
+    /// Resolve the outline color for a Liquid Glass row. Returns the user's
+    /// chosen `liquidGlassOutlineColorKey` (if it maps to a real `SColor`),
+    /// otherwise falls back to the same color as the fill so the legacy
+    /// look is preserved by default.
+    private func resolvedOutlineColor(fallback: NSColor) -> NSColor {
+        guard self.liquidGlassOutlineColorKey != "same",
+              let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
+              let color = picked.additional as? NSColor
+        else { return fallback }
+        return color.withAlphaComponent(0.85)
+    }
+    
+    /// Tahoe-style rendering: each value becomes a *horizontal* pill stacked
+    /// vertically. The pill outline is thick and the fill grows left-to-right
+    /// in the same color, transparent interior — like the new menu bar
+    /// indicators in macOS Tahoe.
+    private func drawLiquidGlass(value: [[ColorValue]], pressureLevel: RAMPressure, colorZones: colorZones) {
+        let strokeWidth: CGFloat = 1.25
+        let interRowSpacing: CGFloat = 2.0
+        let outerMargin: CGFloat = Constants.Widget.margin.x
+        
+        // Single-row layouts get a noticeably wider pill so the lone capsule
+        // reads as a horizontal progress bar (not a circle). Multi-row widths
+        // were unchanged historically; now the user can override either
+        // through the settings slider.
+        let count = max(value.count, 1)
+        let pillWidth: CGFloat = CGFloat(self.liquidGlassPillWidth)
+        
+        var x: CGFloat = outerMargin
+        var totalWidth: CGFloat = (outerMargin * 2) + pillWidth
+        
+        // Optional title-letter column (matches classic mode for consistency).
+        if self.labelState {
+            let letterHeight = self.frame.height / 3
+            let letterWidth: CGFloat = 6.0
+            var yMargin: CGFloat = 0
+            for char in self.NSLabelCharts {
+                char.draw(with: CGRect(x: x - outerMargin, y: yMargin, width: letterWidth, height: letterHeight))
+                yMargin += letterHeight
+            }
+            x += letterWidth + Constants.Widget.spacing
+            totalWidth += letterWidth + Constants.Widget.spacing
+        }
+        
+        // Stack pills vertically. Multi-row layouts keep the original 6pt
+        // cap so CPU-style stacks look identical to before. Single-row
+        // layouts (e.g. GPU usage) get a taller cap so the lone pill fills
+        // the available menu bar height nicely.
+        let availableHeight = self.frame.size.height - (strokeWidth * 2)
+        let totalSpacing = interRowSpacing * CGFloat(max(count - 1, 0))
+        let rawRowHeight = (availableHeight - totalSpacing) / CGFloat(count)
+        let maxRowHeight: CGFloat = CGFloat(self.liquidGlassPillHeight)
+        let rowHeight = max(3.0, min(rawRowHeight, maxRowHeight))
+        let stackHeight = (rowHeight * CGFloat(count)) + totalSpacing
+        let stackOriginY = ((self.frame.size.height - stackHeight) / 2)
+        // Rounded-rectangle corners (not full capsule). Cap the radius so the
+        // ends look softly chamfered rather than perfectly round.
+        let radius = min(rowHeight / 2, 1.5)
+        
+        for i in 0..<count {
+            // Top row should reflect the first value, so iterate downward.
+            let segments = value[i]
+            let rowY = stackOriginY + CGFloat(count - 1 - i) * (rowHeight + interRowSpacing)
+            
+            let rowTotal = segments.reduce(0.0) { $0 + $1.value }
+            // When the warning thresholds are active, the row's fill flips
+            // to the warning / critical hue. The outline color picker takes
+            // priority for the outline itself so user-assigned color codes
+            // stay stable across alert states.
+            let warningColor = self.liquidGlassRowColor(rowTotal: rowTotal)
+            let baseColor = self.liquidGlassColor(
+                segments.last ?? ColorValue(0),
+                pressureLevel: pressureLevel,
+                colorZones: colorZones
+            )
+            let outlineColor = self.resolvedOutlineColor(fallback: warningColor ?? baseColor)
+            
+            let trackRect = NSRect(x: x + strokeWidth/2, y: rowY, width: pillWidth - strokeWidth, height: rowHeight)
+            let track = NSBezierPath(roundedRect: trackRect, xRadius: radius, yRadius: radius)
+            
+            // When the outline mode is on, the fill is inset slightly inside
+            // the stroke (battery-style gap) and given the same corner
+            // radius as the outer track so the inner bar mirrors the outer
+            // pill / rounded-rect. When off, the fill spans the full track
+            // and is clipped to the outer shape (legacy look).
+            let useInsetFill = self.liquidGlassOutlineState
+            let fillInset: CGFloat = useInsetFill ? max(strokeWidth + 0.75, 1.5) : 0
+            let innerRect = trackRect.insetBy(dx: fillInset, dy: fillInset)
+            let innerRadius = useInsetFill
+                ? max(radius - fillInset/2, 0)
+                : radius
+            
+            NSGraphicsContext.saveGraphicsState()
+            if useInsetFill {
+                // Clip to the inner pill shape so per-segment rectangles
+                // get the same rounded ends as the outer outline.
+                NSBezierPath(roundedRect: innerRect, xRadius: innerRadius, yRadius: innerRadius).addClip()
+            } else {
+                // Legacy behavior: clip to the outer track.
+                track.addClip()
+            }
+            var segX = useInsetFill ? innerRect.origin.x : trackRect.origin.x
+            let fillBaseWidth = useInsetFill ? innerRect.width : trackRect.width
+            let fillBaseY = useInsetFill ? innerRect.origin.y : rowY
+            let fillBaseHeight = useInsetFill ? innerRect.height : rowHeight
+            for seg in segments {
+                let segWidth = fillBaseWidth * CGFloat(min(max(seg.value, 0), 1))
+                guard segWidth > 0 else { continue }
+                let fillRect = NSRect(x: segX, y: fillBaseY, width: segWidth, height: fillBaseHeight)
+                let color = warningColor ?? self.liquidGlassColor(seg, pressureLevel: pressureLevel, colorZones: colorZones)
+                color.setFill()
+                NSBezierPath(rect: fillRect).fill()
+                segX += segWidth
+            }
+            NSGraphicsContext.restoreGraphicsState()
+            
+            // Thick outline, transparent interior.
+            outlineColor.setStroke()
+            track.lineWidth = strokeWidth
+            track.stroke()
+        }
+        
+        self.setWidth(totalWidth)
+    }
+    
     public func setValue(_ newValue: [[ColorValue]]) {
         DispatchQueue.main.async(execute: {
             let tolerance: CGFloat = 0.01
@@ -245,6 +444,15 @@ public class BarChart: WidgetWrapper {
     }
     
     public func setColorZones(_ newColorZones: colorZones) {
+        // Module-supplied defaults must not clobber user choices made via the
+        // settings sliders. The slider handlers `set(...)` the keys below on
+        // every change, so their presence in Store marks the value as
+        // user-customized and we skip the override.
+        let userKeyOrange = "\(self.title)_\(self.type.rawValue)_colorZones_orange"
+        let userKeyRed = "\(self.title)_\(self.type.rawValue)_colorZones_red"
+        if Store.shared.exist(key: userKeyOrange) || Store.shared.exist(key: userKeyRed) {
+            return
+        }
         DispatchQueue.main.async(execute: {
             guard self._colorZones != newColorZones else { return }
             self._colorZones = newColorZones
@@ -267,8 +475,28 @@ public class BarChart: WidgetWrapper {
             state: self.frameState
         )
         self.frameSettingsView = frame
+        let liquid = switchView(
+            action: #selector(self.toggleLiquidGlass),
+            state: self.liquidGlassState
+        )
+        self.liquidGlassSettingsView = liquid
         
+        // Build the outline color picker: only real hues are exposed, so
+        // semantic SColors like "Utilization", "Pressure", "System accent"
+        // and "Monochrome" (which only make sense as a fill mode) are
+        // filtered out. A "Same as fill" sentinel is the default.
+        let outlineExcluded: Set<String> = ["system", "monochrome", "utilization", "pressure", "cluster", "clear"]
+        var outlineColors: [KeyValue_t] = [KeyValue_t(key: "same", value: "Same as fill")]
+        for c in self.colors where !outlineExcluded.contains(c.key) && !c.key.contains("separator") {
+            outlineColors.append(KeyValue_t(key: c.key, value: c.value))
+        }
+        
+        // Section 1: appearance — every control that affects how the bar
+        // looks. Box/Frame is classic-mode only and Bar width / Outline /
+        // Outline color is Liquid Glass only; they're grouped here so the
+        // user has a single place to tune visual style.
         view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Liquid Glass (Tahoe)"), component: liquid),
             PreferencesRow(localizedString("Label"), component: switchView(
                 action: #selector(self.toggleLabel),
                 state: self.labelState
@@ -278,8 +506,51 @@ public class BarChart: WidgetWrapper {
                 items: self.colors,
                 selected: self.colorState.key
             )),
+            PreferencesRow(localizedString("Bar width"), component: sliderView(
+                action: #selector(self.changeLiquidGlassPillWidth),
+                value: self.liquidGlassPillWidth,
+                initialValue: "\(self.liquidGlassPillWidth)",
+                min: 16,
+                max: 60
+            )),
+            PreferencesRow(localizedString("Bar height"), component: sliderView(
+                action: #selector(self.changeLiquidGlassPillHeight),
+                value: self.liquidGlassPillHeight,
+                initialValue: "\(self.liquidGlassPillHeight)",
+                min: 4,
+                max: 14
+            )),
+            PreferencesRow(localizedString("Outline"), component: switchView(
+                action: #selector(self.toggleLiquidGlassOutline),
+                state: self.liquidGlassOutlineState
+            )),
+            PreferencesRow(localizedString("Outline color"), component: selectView(
+                action: #selector(self.toggleLiquidGlassOutlineColor),
+                items: outlineColors,
+                selected: self.liquidGlassOutlineColorKey
+            )),
             PreferencesRow(localizedString("Box"), component: box),
             PreferencesRow(localizedString("Frame"), component: frame)
+        ]))
+        
+        // Section 2: warning thresholds. Reuses the existing `_colorZones`
+        // tuple so the same breakpoints feed both the classic Utilization
+        // color mode and the Liquid Glass warning hues.
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Warning colors"), component: switchView(
+                action: #selector(self.toggleLiquidGlassWarning),
+                state: self.liquidGlassWarningState
+            )),
+            PreferencesRow(localizedString("Warning threshold"), component: sliderView(
+                action: #selector(self.changeWarningThreshold),
+                value: Int(self._colorZones.orange * 100),
+                initialValue: "\(Int(self._colorZones.orange * 100))%"
+            )),
+            PreferencesRow(localizedString("Critical threshold"), component: sliderView(
+                action: #selector(self.changeCriticalThreshold),
+                value: Int(self._colorZones.red * 100),
+                initialValue: "\(Int(self._colorZones.red * 100))%"
+            ))
         ]))
         
         return view
@@ -324,6 +595,92 @@ public class BarChart: WidgetWrapper {
         }
         
         Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_color", value: key)
+        self.redraw()
+    }
+    
+    @objc private func toggleLiquidGlass(_ sender: NSControl) {
+        self.liquidGlassState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", value: self.liquidGlassState)
+        // When enabling Liquid Glass, the classic Box/Frame chrome would
+        // double-stroke the capsule, so silently turn them off.
+        if self.liquidGlassState {
+            if self.boxState {
+                self.boxState = false
+                self.boxSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_box", value: self.boxState)
+            }
+            if self.frameState {
+                self.frameState = false
+                self.frameSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_frame", value: self.frameState)
+            }
+        }
+        self.redraw()
+    }
+    
+    @objc private func toggleLiquidGlassWarning(_ sender: NSControl) {
+        self.liquidGlassWarningState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassWarning", value: self.liquidGlassWarningState)
+        self.redraw()
+    }
+    
+    @objc private func changeWarningThreshold(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        // Keep warning < critical so the slider pair always reads top-to-bottom.
+        let clamped = min(newValue, Int(self._colorZones.red * 100) - 1)
+        self._colorZones.orange = Double(clamped) / 100.0
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_colorZones_orange", value: clamped)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(clamped)%"
+        }
+        self.redraw()
+    }
+    
+    @objc private func changeCriticalThreshold(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        let clamped = max(newValue, Int(self._colorZones.orange * 100) + 1)
+        self._colorZones.red = Double(clamped) / 100.0
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_colorZones_red", value: clamped)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(clamped)%"
+        }
+        self.redraw()
+    }
+    
+    @objc private func changeLiquidGlassPillWidth(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        self.liquidGlassPillWidth = newValue
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillWidth", value: newValue)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(newValue)"
+        }
+        self.redraw()
+    }
+    
+    @objc private func changeLiquidGlassPillHeight(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        self.liquidGlassPillHeight = newValue
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillHeight", value: newValue)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(newValue)"
+        }
+        self.redraw()
+    }
+    
+    @objc private func toggleLiquidGlassOutline(_ sender: NSControl) {
+        self.liquidGlassOutlineState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutline", value: self.liquidGlassOutlineState)
+        self.redraw()
+    }
+    
+    @objc private func toggleLiquidGlassOutlineColor(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        self.liquidGlassOutlineColorKey = key
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutlineColor", value: key)
         self.redraw()
     }
 }

--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -40,9 +40,10 @@ public class BarChart: WidgetWrapper {
     public var liquidGlassPillHeight: Int = 9
     private var liquidGlassOutlineState: Bool = true
     // "same" is a sentinel meaning "use the same color as the fill".
-    private var liquidGlassOutlineColorKey: String = "same"
-    public var colorState: SColor = .systemAccent
+    private var liquidGlassOutlineColorKey: String = "utilization"
+    public var colorState: SColor = .utilization
     private var colors: [SColor] = SColor.allCases
+    private var splitSegmentColorsState: Bool = true
     
     private var _value: [[ColorValue]] = [[]]
     private var _pressureLevel: RAMPressure = .normal
@@ -225,13 +226,20 @@ public class BarChart: WidgetWrapper {
         
         x += offset
         for i in 0..<value.count {
+            let rowTotal = value[i].reduce(0.0) { $0 + $1.value }
+            let useUniformSplitColor = !self.splitSegmentColorsState && value[i].count > 1
+            let uniformColor = useUniformSplitColor
+                ? self.classicColorForValue(rowTotal, pressureLevel: pressureLevel, colorZones: colorZones)
+                : nil
             var y = offset
             for a in 0..<value[i].count {
                 let partitionValue = value[i][a]
                 let partitionHeight = maxPartitionHeight * CGFloat(partitionValue.value)
                 let partition = NSBezierPath(rect: NSRect(x: x, y: y, width: partitionWidth, height: partitionHeight))
                 
-                if partitionValue.color == nil {
+                if let uniformColor {
+                    uniformColor.set()
+                } else if partitionValue.color == nil {
                     switch self.colorState {
                     case .systemAccent: NSColor.controlAccentColor.set()
                     case .utilization: partitionValue.value.usageColor(zones: colorZones, reversed: self.title == "Battery").set()
@@ -268,43 +276,59 @@ public class BarChart: WidgetWrapper {
     
     // MARK: - Liquid Glass (macOS Tahoe) draw path
     
-    /// Resolves the color to use for an individual bar segment when the
-    /// pill style is enabled. If a per-value color is specified it is used
-    /// verbatim; otherwise the user's color preference is honored.
-    /// Liquid Glass defaults to white when no explicit accent has been chosen,
-    /// matching the monochrome glyphs in the Tahoe menu bar.
-    private func liquidGlassColor(_ partition: ColorValue, pressureLevel: RAMPressure, colorZones: colorZones) -> NSColor {
-        if let c = partition.color { return c }
+    /// Resolve the base "row color" for a Liquid Glass row, given the user's
+    /// color preference and the row total (used for utilization thresholds).
+    /// This is what fills a row when no per-segment override is in effect.
+    /// Note: `.systemAccent` always resolves to `liquidGlassInk` — that mode
+    /// is documented to override any per-segment coloring.
+    private func liquidGlassRowFillColor(rowTotal: Double, pressureLevel: RAMPressure, colorZones: colorZones) -> NSColor {
         switch self.colorState {
         case .systemAccent: return Constants.liquidGlassInk
-        case .utilization:  return partition.value.usageColor(zones: colorZones, reversed: self.title == "Battery")
+        case .utilization:
+            return Constants.liquidGlassWarningColor(
+                value: rowTotal,
+                warning: colorZones.orange,
+                critical: colorZones.red
+            )
         case .pressure:     return pressureLevel.pressureColor()
         case .monochrome:   return Constants.liquidGlassInk
         default:            return self.colorState.additional as? NSColor ?? Constants.liquidGlassInk
         }
     }
-    
-    /// Resolve the ink color for a single Liquid Glass row, applying the
-    /// per-widget warning / critical thresholds when the user has enabled
-    /// them and is using the default (system accent) color. The row's total
-    /// fill is what's evaluated against the thresholds, so multi-segment
-    /// stacks light up based on the combined utilization.
-    private func liquidGlassRowColor(rowTotal: Double) -> NSColor? {
-        guard self.liquidGlassWarningState, self.colorState == .systemAccent else { return nil }
-        return Constants.liquidGlassWarningColor(
-            value: rowTotal,
-            warning: self._colorZones.orange,
-            critical: self._colorZones.red
-        )
+
+    /// Classic (non-liquid) fill color resolver for an unsplit row value.
+    private func classicColorForValue(_ value: Double, pressureLevel: RAMPressure, colorZones: colorZones) -> NSColor {
+        switch self.colorState {
+        case .systemAccent:
+            return .controlAccentColor
+        case .utilization:
+            return value.usageColor(zones: colorZones, reversed: self.title == "Battery")
+        case .pressure:
+            return pressureLevel.pressureColor()
+        case .monochrome:
+            return self.boxState ? (isDarkMode ? .black : .white) : (isDarkMode ? .white : .black)
+        default:
+            return self.colorState.additional as? NSColor ?? .controlAccentColor
+        }
     }
     
-    /// Resolve the outline color for a Liquid Glass row. Returns the user's
-    /// chosen `liquidGlassOutlineColorKey` (if it maps to a real `SColor`),
-    /// otherwise falls back to the same color as the fill so the legacy
-    /// look is preserved by default.
-    private func resolvedOutlineColor(fallback: NSColor) -> NSColor {
-        guard self.liquidGlassOutlineColorKey != "same",
-              let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
+    /// Resolve the outline color for a Liquid Glass row. "same" reuses the
+    /// fill color, "utilization" uses the threshold-driven warning color
+    /// (system-accent / yellow / red), otherwise the user's picked SColor.
+    private func resolvedOutlineColor(fallback: NSColor, rowTotal: Double, colorZones: colorZones) -> NSColor {
+        if self.liquidGlassOutlineColorKey == "same" {
+            return fallback
+        }
+        if self.liquidGlassOutlineColorKey == "utilization" {
+            // Below warning -> liquidGlassInk (system accent in Liquid Glass);
+            // between -> warning hue; above critical -> error hue.
+            return Constants.liquidGlassWarningColor(
+                value: rowTotal,
+                warning: colorZones.orange,
+                critical: colorZones.red
+            )
+        }
+        guard let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
               let color = picked.additional as? NSColor
         else { return fallback }
         return color.withAlphaComponent(0.85)
@@ -363,17 +387,15 @@ public class BarChart: WidgetWrapper {
             let rowY = stackOriginY + CGFloat(count - 1 - i) * (rowHeight + interRowSpacing)
             
             let rowTotal = segments.reduce(0.0) { $0 + $1.value }
-            // When the warning thresholds are active, the row's fill flips
-            // to the warning / critical hue. The outline color picker takes
-            // priority for the outline itself so user-assigned color codes
-            // stay stable across alert states.
-            let warningColor = self.liquidGlassRowColor(rowTotal: rowTotal)
-            let baseColor = self.liquidGlassColor(
-                segments.last ?? ColorValue(0),
+            // The base row color: systemAccent -> liquidGlassInk (always),
+            // utilization -> threshold color (ink/yellow/red) of the row
+            // total, otherwise the user-picked SColor.
+            let rowColor = self.liquidGlassRowFillColor(
+                rowTotal: rowTotal,
                 pressureLevel: pressureLevel,
                 colorZones: colorZones
             )
-            let outlineColor = self.resolvedOutlineColor(fallback: warningColor ?? baseColor)
+            let outlineColor = self.resolvedOutlineColor(fallback: rowColor, rowTotal: rowTotal, colorZones: colorZones)
             
             let trackRect = NSRect(x: x + strokeWidth/2, y: rowY, width: pillWidth - strokeWidth, height: rowHeight)
             let track = NSBezierPath(roundedRect: trackRect, xRadius: radius, yRadius: radius)
@@ -403,14 +425,35 @@ public class BarChart: WidgetWrapper {
             let fillBaseWidth = useInsetFill ? innerRect.width : trackRect.width
             let fillBaseY = useInsetFill ? innerRect.origin.y : rowY
             let fillBaseHeight = useInsetFill ? innerRect.height : rowHeight
-            for seg in segments {
-                let segWidth = fillBaseWidth * CGFloat(min(max(seg.value, 0), 1))
+            let clampedSegments = segments.map { min(max($0.value, 0), 1) }
+            let separatorWidth: CGFloat = clampedSegments.count > 1 ? max(1.25, strokeWidth) : 0
+            let totalSeparatorWidth = separatorWidth * CGFloat(max(clampedSegments.count - 1, 0))
+            let drawableFillWidth = max(fillBaseWidth - totalSeparatorWidth, 0)
+
+            for (idx, seg) in segments.enumerated() {
+                let segWidth = drawableFillWidth * CGFloat(clampedSegments[idx])
                 guard segWidth > 0 else { continue }
                 let fillRect = NSRect(x: segX, y: fillBaseY, width: segWidth, height: fillBaseHeight)
-                let color = warningColor ?? self.liquidGlassColor(seg, pressureLevel: pressureLevel, colorZones: colorZones)
+                // Color rules for the inner bar segments:
+                //   - colorState == .systemAccent : ALWAYS liquidGlassInk
+                //     (overrides any per-segment color the module supplied).
+                //   - split colors ON + per-seg color present : use seg.color
+                //   - otherwise : the row color (which already encodes the
+                //     utilization threshold hue when colorState=.utilization).
+                let color: NSColor
+                if self.colorState == .systemAccent {
+                    color = Constants.liquidGlassInk
+                } else if self.splitSegmentColorsState, let segColor = seg.color {
+                    color = segColor
+                } else {
+                    color = rowColor
+                }
                 color.setFill()
                 NSBezierPath(rect: fillRect).fill()
                 segX += segWidth
+                if idx < segments.count - 1 {
+                    segX += separatorWidth
+                }
             }
             NSGraphicsContext.restoreGraphicsState()
             
@@ -433,10 +476,12 @@ public class BarChart: WidgetWrapper {
             }
             guard isDifferent else { return }
             self._value = newValue
-            // Tooltip: average of the first column (most modules feed a
-            // single column so this matches what the user sees).
-            if let first = newValue.first, !first.isEmpty {
-                let avg = first.reduce(0.0) { $0 + $1.value } / Double(first.count)
+            // Tooltip: total utilization — sum each column's segments, then
+            // average across columns. Matches what RoundedBarChart and Mini
+            // display so users get the same number across widget styles.
+            if !newValue.isEmpty {
+                let columnTotals = newValue.map { $0.reduce(0.0) { $0 + $1.value } }
+                let avg = columnTotals.reduce(0.0, +) / Double(columnTotals.count)
                 self.tooltipCallback?("\(Int(avg.rounded(toPlaces: 2) * 100))%")
             }
             self.redraw()
@@ -467,6 +512,14 @@ public class BarChart: WidgetWrapper {
             self.redraw()
         })
     }
+
+    public func setSplitColorized(_ state: Bool) {
+        DispatchQueue.main.async(execute: {
+            guard self.splitSegmentColorsState != state else { return }
+            self.splitSegmentColorsState = state
+            self.redraw()
+        })
+    }
     
     // MARK: - Settings
     
@@ -490,11 +543,15 @@ public class BarChart: WidgetWrapper {
         self.liquidGlassSettingsView = liquid
         
         // Build the outline color picker: only real hues are exposed, so
-        // semantic SColors like "Utilization", "Pressure", "System accent"
+        // semantic SColors like "Pressure", "System accent"
         // and "Monochrome" (which only make sense as a fill mode) are
-        // filtered out. A "Same as fill" sentinel is the default.
+        // filtered out. "Same as fill" and "Based on utilization" are
+        // explicit sentinel options.
         let outlineExcluded: Set<String> = ["system", "monochrome", "utilization", "pressure", "cluster", "clear"]
-        var outlineColors: [KeyValue_t] = [KeyValue_t(key: "same", value: "Same as fill")]
+        var outlineColors: [KeyValue_t] = [
+            KeyValue_t(key: "same", value: "Same as fill"),
+            KeyValue_t(key: "utilization", value: "Based on utilization")
+        ]
         for c in self.colors where !outlineExcluded.contains(c.key) && !c.key.contains("separator") {
             outlineColors.append(KeyValue_t(key: c.key, value: c.value))
         }

--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -30,13 +30,15 @@ public class BarChart: WidgetWrapper {
     // outline draws the stroke offset slightly from the fill (battery-style)
     // and outlineColor lets the user color-code the stroke independently of
     // the fill (e.g. orange CPU outline vs blue GPU outline).
-    public var liquidGlassPillWidth: Int = 28
-    // Per-row pill height. Default of 8pt sits between the historical
+    public var liquidGlassPillWidth: Int = 24
+    // Per-row pill height. Default of 9pt sits between the historical
     // multi-row (6pt) and single-row (10pt) caps; the slider lets the
     // user push it shorter for a slimmer indicator or taller (up to 14pt)
-    // for a beefier one.
-    public var liquidGlassPillHeight: Int = 8
-    private var liquidGlassOutlineState: Bool = false
+    // for a beefier one. Multi-row stacks (e.g. CPU per-core, network
+    // up/down) are bounded by `rawRowHeight` so this cap effectively
+    // only changes the single-row look.
+    public var liquidGlassPillHeight: Int = 9
+    private var liquidGlassOutlineState: Bool = true
     // "same" is a sentinel meaning "use the same color as the fill".
     private var liquidGlassOutlineColorKey: String = "same"
     public var colorState: SColor = .systemAccent
@@ -431,6 +433,12 @@ public class BarChart: WidgetWrapper {
             }
             guard isDifferent else { return }
             self._value = newValue
+            // Tooltip: average of the first column (most modules feed a
+            // single column so this matches what the user sees).
+            if let first = newValue.first, !first.isEmpty {
+                let avg = first.reduce(0.0) { $0 + $1.value } / Double(first.count)
+                self.tooltipCallback?("\(Int(avg.rounded(toPlaces: 2) * 100))%")
+            }
             self.redraw()
         })
     }

--- a/Kit/Widgets/Battery.swift
+++ b/Kit/Widgets/Battery.swift
@@ -407,6 +407,9 @@ public class BatteryWidget: WidgetWrapper {
         }
         
         if updated {
+            if let p = self._percentage {
+                self.tooltipCallback?("\(Int(p.rounded(toPlaces: 2) * 100))%")
+            }
             self.needsDisplay = true
             DispatchQueue.main.async(execute: {
                 self.display()
@@ -624,6 +627,9 @@ public class BatteryDetailsWidget: WidgetWrapper {
         }
         
         if updated {
+            if let p = self.percentage {
+                self.tooltipCallback?("\(Int(p.rounded(toPlaces: 2) * 100))%")
+            }
             self.needsDisplay = true
             DispatchQueue.main.async(execute: {
                 self.display()

--- a/Kit/Widgets/Dot.swift
+++ b/Kit/Widgets/Dot.swift
@@ -53,6 +53,14 @@ public class DotWidget: WidgetWrapper {
     public func setValue(_ value: NSColor) {
         guard self.value != value else { return }
         self.value = value
+        // The dot widget is purely visual; surface a short RGB hex so
+        // the tooltip says something more useful than the widget type.
+        if let rgb = value.usingColorSpace(.deviceRGB) {
+            let r = Int(rgb.redComponent * 255)
+            let g = Int(rgb.greenComponent * 255)
+            let b = Int(rgb.blueComponent * 255)
+            self.tooltipCallback?(String(format: "#%02X%02X%02X", r, g, b))
+        }
         DispatchQueue.main.async(execute: {
             self.display()
         })

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -26,11 +26,12 @@ public class LineChart: WidgetWrapper {
     // Liquid Glass warning hues. Persisted as two int percentages.
     private var _colorZones: colorZones = (0.6, 0.8)
     // Liquid Glass cosmetic options. See BarChart for the same trio.
-    public var liquidGlassPillWidth: Int = 28
-    // Pill height. Default of 8pt matches the original hard-coded value;
-    // the slider runs 4-14pt for a slimmer or beefier indicator.
-    public var liquidGlassPillHeight: Int = 8
-    private var liquidGlassOutlineState: Bool = false
+    public var liquidGlassPillWidth: Int = 24
+    // Pill height. Default of 9pt matches BarChart so a single line/bar
+    // pill looks identical across modules; the slider runs 4-14pt for
+    // a slimmer or beefier indicator.
+    public var liquidGlassPillHeight: Int = 9
+    private var liquidGlassOutlineState: Bool = true
     private var liquidGlassOutlineColorKey: String = "same"
     private var colorState: SColor = .systemAccent
     private var historyCount: Int = 60
@@ -359,6 +360,7 @@ public class LineChart: WidgetWrapper {
     public func setValue(_ newValue: Double) {
         DispatchQueue.main.async(execute: {
             self._value = newValue
+            self.tooltipCallback?("\(Int(newValue.rounded(toPlaces: 2) * 100))%")
             self.chart.addValue(newValue)
             self.display()
         })

--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -17,6 +17,21 @@ public class LineChart: WidgetWrapper {
     private var frameState: Bool = false
     private var valueState: Bool = false
     private var valueColorState: Bool = false
+    // Liquid Glass / macOS Tahoe pill style. Defaults on for macOS 26+.
+    public var liquidGlassState: Bool = Constants.isTahoe
+    // Liquid Glass warning thresholds (see BarChart for the same logic).
+    private var liquidGlassWarningState: Bool = true
+    // Reuses the project's existing `colorZones` typealias so the same
+    // breakpoints feed both Utilization color mode (when offered) and the
+    // Liquid Glass warning hues. Persisted as two int percentages.
+    private var _colorZones: colorZones = (0.6, 0.8)
+    // Liquid Glass cosmetic options. See BarChart for the same trio.
+    public var liquidGlassPillWidth: Int = 28
+    // Pill height. Default of 8pt matches the original hard-coded value;
+    // the slider runs 4-14pt for a slimmer or beefier indicator.
+    public var liquidGlassPillHeight: Int = 8
+    private var liquidGlassOutlineState: Bool = false
+    private var liquidGlassOutlineColorKey: String = "same"
     private var colorState: SColor = .systemAccent
     private var historyCount: Int = 60
     private var scaleState: Scale = .none
@@ -56,6 +71,7 @@ public class LineChart: WidgetWrapper {
     
     private var boxSettingsView: NSSwitch? = nil
     private var frameSettingsView: NSSwitch? = nil
+    private var liquidGlassSettingsView: NSSwitch? = nil
     
     public var NSLabelCharts: [NSAttributedString] = []
     
@@ -99,6 +115,15 @@ public class LineChart: WidgetWrapper {
             self.valueState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_value", defaultValue: self.valueState)
             self.labelState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_label", defaultValue: self.labelState)
             self.valueColorState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_valueColor", defaultValue: self.valueColorState)
+            self.liquidGlassState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", defaultValue: self.liquidGlassState)
+            self.liquidGlassWarningState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlassWarning", defaultValue: self.liquidGlassWarningState)
+            let storedOrange = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_colorZones_orange", defaultValue: Int(self._colorZones.orange * 100))
+            let storedRed = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_colorZones_red", defaultValue: Int(self._colorZones.red * 100))
+            self._colorZones = (Double(storedOrange) / 100.0, Double(storedRed) / 100.0)
+            self.liquidGlassPillWidth = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillWidth", defaultValue: self.liquidGlassPillWidth)
+            self.liquidGlassPillHeight = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillHeight", defaultValue: self.liquidGlassPillHeight)
+            self.liquidGlassOutlineState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutline", defaultValue: self.liquidGlassOutlineState)
+            self.liquidGlassOutlineColorKey = Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutlineColor", defaultValue: self.liquidGlassOutlineColorKey)
             self.colorState = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_color", defaultValue: self.colorState.key))
             self.historyCount = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_historyCount", defaultValue: self.historyCount)
             self.scaleState = Scale.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_scale", defaultValue: self.scaleState.key))
@@ -158,7 +183,9 @@ public class LineChart: WidgetWrapper {
         
         var color: NSColor = .controlAccentColor
         switch self.colorState {
-        case .systemAccent: color = .controlAccentColor
+        case .systemAccent:
+            // Liquid Glass defaults to white to match Tahoe's monochrome glyphs.
+            color = self.liquidGlassState ? Constants.liquidGlassInk : .controlAccentColor
         case .utilization: color = value.usageColor()
         case .pressure: color = pressureLevel.pressureColor()
         case .monochrome:
@@ -168,6 +195,26 @@ public class LineChart: WidgetWrapper {
                 color = (isDarkMode ? NSColor.white : NSColor.black)
             }
         default: color = self.colorState.additional as? NSColor ?? .controlAccentColor
+        }
+        
+        // Liquid Glass: short-circuit the line chart and draw a single
+        // horizontal pill whose fill grows left-to-right with the current
+        // value. The classic line-chart code below is skipped entirely.
+        if self.liquidGlassState {
+            // Apply per-widget warning thresholds when the user is on the
+            // default color, so the pill turns yellow / red as the value
+            // saturates. Any explicit accent overrides the warning hue.
+            var pillColor = color
+            if self.liquidGlassWarningState, self.colorState == .systemAccent {
+                pillColor = Constants.liquidGlassWarningColor(
+                    value: value,
+                    warning: self._colorZones.orange,
+                    critical: self._colorZones.red
+                )
+            }
+            self.drawLiquidGlassPill(value: value, color: pillColor, x: &x, width: &width, lineWidth: lineWidth)
+            self.setWidth(width)
+            return
         }
         
         if self.labelState {
@@ -247,6 +294,68 @@ public class LineChart: WidgetWrapper {
         self.setWidth(width)
     }
     
+    /// Tahoe-style pill: a single horizontal capsule sized like the menu bar
+    /// glyphs. The capsule is outlined and the fill grows from left to right
+    /// in proportion to the current value, both in the same color.
+    private func drawLiquidGlassPill(value: Double, color: NSColor, x: inout CGFloat, width: inout CGFloat, lineWidth: CGFloat) {
+        let strokeWidth: CGFloat = 1.25
+        let pillWidth: CGFloat = CGFloat(self.liquidGlassPillWidth)
+        let pillHeight: CGFloat = CGFloat(self.liquidGlassPillHeight)
+        
+        let pillX = x + strokeWidth/2
+        let pillY = (self.frame.size.height - pillHeight) / 2
+        let radius = pillHeight / 2
+        let trackRect = NSRect(x: pillX, y: pillY, width: pillWidth - strokeWidth, height: pillHeight)
+        let track = NSBezierPath(roundedRect: trackRect, xRadius: radius, yRadius: radius)
+        
+        // Outline mode: inset the fill so a small gap separates it from the
+        // stroke, and round the inner fill so its ends mirror the outer pill
+        // (battery-style). Off: legacy clip-to-outer behavior.
+        let useInsetFill = self.liquidGlassOutlineState
+        let fillInset: CGFloat = useInsetFill ? max(strokeWidth + 0.75, 1.5) : 0
+        let innerRect = trackRect.insetBy(dx: fillInset, dy: fillInset)
+        let innerRadius = useInsetFill ? max(radius - fillInset, 0) : radius
+        let fillBaseWidth = useInsetFill ? innerRect.width : trackRect.width
+        let pct = CGFloat(min(max(value, 0), 1))
+        let fillWidth = fillBaseWidth * pct
+        
+        if fillWidth > 0 {
+            NSGraphicsContext.saveGraphicsState()
+            if useInsetFill {
+                // Build a sub-pill the exact width of the fill so both ends
+                // are rounded (not just the leading edge).
+                let innerFillRect = NSRect(x: innerRect.origin.x, y: innerRect.origin.y, width: fillWidth, height: innerRect.height)
+                let innerFillRadius = min(innerRadius, innerRect.height / 2)
+                let innerFill = NSBezierPath(roundedRect: innerFillRect, xRadius: innerFillRadius, yRadius: innerFillRadius)
+                color.setFill()
+                innerFill.fill()
+            } else {
+                track.addClip()
+                color.setFill()
+                NSBezierPath(rect: NSRect(x: trackRect.origin.x, y: pillY, width: fillWidth, height: pillHeight)).fill()
+            }
+            NSGraphicsContext.restoreGraphicsState()
+        }
+        
+        // Outline color override: lets the user color-code stroke vs fill.
+        let outlineColor = self.resolvedOutlineColor(fallback: color)
+        outlineColor.setStroke()
+        track.lineWidth = strokeWidth
+        track.stroke()
+        
+        width = x + pillWidth + Constants.Widget.margin.x
+    }
+    
+    /// Resolve the outline color override; returns the chosen `SColor` value
+    /// when the user has picked one, otherwise falls back to the fill color.
+    private func resolvedOutlineColor(fallback: NSColor) -> NSColor {
+        guard self.liquidGlassOutlineColorKey != "same",
+              let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
+              let color = picked.additional as? NSColor
+        else { return fallback }
+        return color.withAlphaComponent(0.85)
+    }
+    
     public func setValue(_ newValue: Double) {
         DispatchQueue.main.async(execute: {
             self._value = newValue
@@ -278,8 +387,26 @@ public class LineChart: WidgetWrapper {
             state: self.frameState
         )
         self.frameSettingsView = frame
+        let liquid = switchView(
+            action: #selector(self.toggleLiquidGlass),
+            state: self.liquidGlassState
+        )
+        self.liquidGlassSettingsView = liquid
         
+        // Outline color picker: only real hues (semantic SColors like
+        // Utilization / Pressure / System accent / Monochrome are filtered).
+        let outlineExcluded: Set<String> = ["system", "monochrome", "utilization", "pressure", "cluster", "clear"]
+        var outlineColors: [KeyValue_t] = [KeyValue_t(key: "same", value: "Same as fill")]
+        for c in self.colors where !outlineExcluded.contains(c.key) && !c.key.contains("separator") {
+            outlineColors.append(KeyValue_t(key: c.key, value: c.value))
+        }
+        
+        // Section 1: appearance — every control that affects how the chart
+        // looks. Box/Frame is classic-mode only and the Bar width / Outline
+        // / Outline color trio is Liquid Glass only; grouped here so the
+        // user has a single place to tune visual style.
         view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Liquid Glass (Tahoe)"), component: liquid),
             PreferencesRow(localizedString("Label"), component: switchView(
                 action: #selector(self.toggleLabel),
                 state: self.labelState
@@ -288,8 +415,6 @@ public class LineChart: WidgetWrapper {
                 action: #selector(self.toggleValue),
                 state: self.valueState
             )),
-            PreferencesRow(localizedString("Box"), component: box),
-            PreferencesRow(localizedString("Frame"), component: frame),
             PreferencesRow(localizedString("Color"), component: selectView(
                 action: #selector(self.toggleColor),
                 items: self.colors,
@@ -299,6 +424,31 @@ public class LineChart: WidgetWrapper {
                 action: #selector(self.toggleValueColor),
                 state: self.valueColorState
             )),
+            PreferencesRow(localizedString("Bar width"), component: sliderView(
+                action: #selector(self.changeLiquidGlassPillWidth),
+                value: self.liquidGlassPillWidth,
+                initialValue: "\(self.liquidGlassPillWidth)",
+                min: 16,
+                max: 60
+            )),
+            PreferencesRow(localizedString("Bar height"), component: sliderView(
+                action: #selector(self.changeLiquidGlassPillHeight),
+                value: self.liquidGlassPillHeight,
+                initialValue: "\(self.liquidGlassPillHeight)",
+                min: 4,
+                max: 14
+            )),
+            PreferencesRow(localizedString("Outline"), component: switchView(
+                action: #selector(self.toggleLiquidGlassOutline),
+                state: self.liquidGlassOutlineState
+            )),
+            PreferencesRow(localizedString("Outline color"), component: selectView(
+                action: #selector(self.toggleLiquidGlassOutlineColor),
+                items: outlineColors,
+                selected: self.liquidGlassOutlineColorKey
+            )),
+            PreferencesRow(localizedString("Box"), component: box),
+            PreferencesRow(localizedString("Frame"), component: frame),
             PreferencesRow(localizedString("Number of reads in the chart"), component: selectView(
                 action: #selector(self.toggleHistoryCount),
                 items: self.historyNumbers,
@@ -308,6 +458,24 @@ public class LineChart: WidgetWrapper {
                 action: #selector(self.toggleScale),
                 items: Scale.allCases.filter({ $0 != .fixed }),
                 selected: self.scaleState.key
+            ))
+        ]))
+        
+        // Section 2: warning thresholds (mirrors the BarChart UI).
+        view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Warning colors"), component: switchView(
+                action: #selector(self.toggleLiquidGlassWarning),
+                state: self.liquidGlassWarningState
+            )),
+            PreferencesRow(localizedString("Warning threshold"), component: sliderView(
+                action: #selector(self.changeWarningThreshold),
+                value: Int(self._colorZones.orange * 100),
+                initialValue: "\(Int(self._colorZones.orange * 100))%"
+            )),
+            PreferencesRow(localizedString("Critical threshold"), component: sliderView(
+                action: #selector(self.changeCriticalThreshold),
+                value: Int(self._colorZones.red * 100),
+                initialValue: "\(Int(self._colorZones.red * 100))%"
             ))
         ]))
         
@@ -367,6 +535,26 @@ public class LineChart: WidgetWrapper {
         self.display()
     }
     
+    @objc private func toggleLiquidGlass(_ sender: NSControl) {
+        self.liquidGlassState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", value: self.liquidGlassState)
+        // The classic Box/Frame chrome would composite with the capsule; turn
+        // them off when Liquid Glass is enabled to avoid double-stroking.
+        if self.liquidGlassState {
+            if self.boxState {
+                self.boxState = false
+                self.boxSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_box", value: self.boxState)
+            }
+            if self.frameState {
+                self.frameState = false
+                self.frameSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_frame", value: self.frameState)
+            }
+        }
+        self.display()
+    }
+    
     @objc private func toggleHistoryCount(_ sender: NSMenuItem) {
         guard let key = sender.representedObject as? String, let value = Int(key) else { return }
         self.historyCount = value
@@ -381,6 +569,71 @@ public class LineChart: WidgetWrapper {
         self.scaleState = value
         self.chart.setScale(value)
         Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_scale", value: key)
+        self.display()
+    }
+    
+    @objc private func toggleLiquidGlassWarning(_ sender: NSControl) {
+        self.liquidGlassWarningState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassWarning", value: self.liquidGlassWarningState)
+        self.display()
+    }
+    
+    @objc private func changeWarningThreshold(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        let clamped = min(newValue, Int(self._colorZones.red * 100) - 1)
+        self._colorZones.orange = Double(clamped) / 100.0
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_colorZones_orange", value: clamped)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(clamped)%"
+        }
+        self.display()
+    }
+    
+    @objc private func changeCriticalThreshold(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        let clamped = max(newValue, Int(self._colorZones.orange * 100) + 1)
+        self._colorZones.red = Double(clamped) / 100.0
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_colorZones_red", value: clamped)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(clamped)%"
+        }
+        self.display()
+    }
+    
+    @objc private func changeLiquidGlassPillWidth(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        self.liquidGlassPillWidth = newValue
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillWidth", value: newValue)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(newValue)"
+        }
+        self.display()
+    }
+    
+    @objc private func changeLiquidGlassPillHeight(_ sender: NSSlider) {
+        let newValue = Int(sender.intValue)
+        self.liquidGlassPillHeight = newValue
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassPillHeight", value: newValue)
+        if let stack = sender.superview as? NSStackView,
+           let label = stack.arrangedSubviews.compactMap({ $0 as? NSTextField }).first {
+            label.stringValue = "\(newValue)"
+        }
+        self.display()
+    }
+    
+    @objc private func toggleLiquidGlassOutline(_ sender: NSControl) {
+        self.liquidGlassOutlineState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutline", value: self.liquidGlassOutlineState)
+        self.display()
+    }
+    
+    @objc private func toggleLiquidGlassOutlineColor(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        self.liquidGlassOutlineColorKey = key
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlassOutlineColor", value: key)
         self.display()
     }
 }

--- a/Kit/Widgets/Memory.swift
+++ b/Kit/Widgets/Memory.swift
@@ -131,6 +131,7 @@ public class MemoryWidget: WidgetWrapper {
     public func setValue(_ value: (String, String), usedPercentage: Double) {
         self.value = value
         self.percentage = usedPercentage
+        self.tooltipCallback?("\(Int(usedPercentage.rounded(toPlaces: 2) * 100))%")
         
         DispatchQueue.main.async(execute: {
             self.display()

--- a/Kit/Widgets/Mini.swift
+++ b/Kit/Widgets/Mini.swift
@@ -176,6 +176,13 @@ public class Mini: WidgetWrapper {
     }
     
     public func setColorZones(_ newColorZones: colorZones) {
+        // Skip the module-supplied default if the user has saved a custom
+        // value via the settings sliders (presence in Store == customized).
+        let userKeyOrange = "\(self.title)_\(self.type.rawValue)_colorZones_orange"
+        let userKeyRed = "\(self.title)_\(self.type.rawValue)_colorZones_red"
+        if Store.shared.exist(key: userKeyOrange) || Store.shared.exist(key: userKeyRed) {
+            return
+        }
         guard self._colorZones != newColorZones else { return }
         self._colorZones = newColorZones
         DispatchQueue.main.async(execute: {

--- a/Kit/Widgets/Mini.swift
+++ b/Kit/Widgets/Mini.swift
@@ -150,6 +150,7 @@ public class Mini: WidgetWrapper {
     public func setValue(_ newValue: Double) {
         guard self._value != newValue else { return }
         self._value = newValue
+        self.tooltipCallback?("\(Int(newValue.rounded(toPlaces: 2) * 100))\(self._suffix)")
         DispatchQueue.main.async(execute: {
             self.display()
         })

--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -15,6 +15,8 @@ public class NetworkChart: WidgetWrapper {
     private var boxState: Bool = false
     private var frameState: Bool = false
     private var labelState: Bool = false
+    // Liquid Glass / macOS Tahoe pill style. Defaults on for macOS 26+.
+    private var liquidGlassState: Bool = Constants.isTahoe
     private var historyCount: Int = 60
     private var downloadColor: SColor = .secondBlue
     private var uploadColor: SColor = .secondRed
@@ -50,6 +52,7 @@ public class NetworkChart: WidgetWrapper {
     
     private var boxSettingsView: NSSwitch? = nil
     private var frameSettingsView: NSSwitch? = nil
+    private var liquidGlassSettingsView: NSSwitch? = nil
     
     public var NSLabelCharts: [NSAttributedString] = []
     
@@ -77,6 +80,7 @@ public class NetworkChart: WidgetWrapper {
             self.boxState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_box", defaultValue: self.boxState)
             self.frameState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_frame", defaultValue: self.frameState)
             self.labelState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_label", defaultValue: self.labelState)
+            self.liquidGlassState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", defaultValue: self.liquidGlassState)
             self.historyCount = Store.shared.int(key: "\(self.title)_\(self.type.rawValue)_historyCount", defaultValue: self.historyCount)
             self.downloadColor = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_downloadColor", defaultValue: self.downloadColor.key))
             self.uploadColor = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_uploadColor", defaultValue: self.uploadColor.key))
@@ -119,6 +123,7 @@ public class NetworkChart: WidgetWrapper {
         var labelState: Bool = false
         var boxState: Bool = false
         var frameState: Bool = false
+        var liquidGlassState: Bool = false
         var scaleState: Scale = .linear
         var reverseOrderState: Bool = false
         var originWidth: CGFloat = 0
@@ -130,6 +135,7 @@ public class NetworkChart: WidgetWrapper {
             labelState = self.labelState
             boxState = self.boxState
             frameState = self.frameState
+            liquidGlassState = self.liquidGlassState
             scaleState = self.scaleState
             reverseOrderState = self.reverseOrderState
             labelString = self.NSLabelCharts
@@ -157,6 +163,23 @@ public class NetworkChart: WidgetWrapper {
             
             width += letterWidth + Constants.Widget.spacing
             x = letterWidth + Constants.Widget.spacing
+        }
+        
+        // Liquid Glass: short-circuit the line chart and draw two stacked
+        // horizontal pills — top = download, bottom = upload (or reversed).
+        // Fill grows left-to-right based on current activity vs. the running
+        // peak in the buffer.
+        if liquidGlassState {
+            self.drawLiquidGlassPills(
+                points: points,
+                downloadColor: downloadColor,
+                uploadColor: uploadColor,
+                reverseOrder: reverseOrderState,
+                x: &x,
+                width: &width
+            )
+            self.setWidth(width)
+            return
         }
         
         let box = NSBezierPath(roundedRect: NSRect(
@@ -262,6 +285,74 @@ public class NetworkChart: WidgetWrapper {
         self.setWidth(width)
     }
     
+    /// Tahoe-style: two stacked horizontal pills (top = download by default,
+    /// bottom = upload). Fill grows left-to-right based on the latest sample
+    /// normalized against the peak in the visible history buffer. Defaults to
+    /// white when no explicit accent has been chosen.
+    private func drawLiquidGlassPills(
+        points: [(Double, Double)],
+        downloadColor: SColor,
+        uploadColor: SColor,
+        reverseOrder: Bool,
+        x: inout CGFloat,
+        width: inout CGFloat
+    ) {
+        let strokeWidth: CGFloat = 1.25
+        let pillWidth: CGFloat = 22
+        let pillHeight: CGFloat = 5
+        let interRowSpacing: CGFloat = 2.0
+        
+        // Default Liquid Glass color is the system menu bar ink (white in
+        // dark menu bar, dark grey in light menu bar). Honor an explicit
+        // accent if the user has changed it from the default.
+        let topColor: NSColor = {
+            let base = reverseOrder ? uploadColor : downloadColor
+            return base == .secondBlue || base == .secondRed
+                ? Constants.liquidGlassInk
+                : (base.additional as? NSColor ?? Constants.liquidGlassInk)
+        }()
+        let bottomColor: NSColor = {
+            let base = reverseOrder ? downloadColor : uploadColor
+            return base == .secondBlue || base == .secondRed
+                ? Constants.liquidGlassInk
+                : (base.additional as? NSColor ?? Constants.liquidGlassInk)
+        }()
+        
+        let topMax = max((points.map { reverseOrder ? $0.1 : $0.0 }.max() ?? 1), 1)
+        let bottomMax = max((points.map { reverseOrder ? $0.0 : $0.1 }.max() ?? 1), 1)
+        let latest = points.last ?? (0, 0)
+        let topValue = (reverseOrder ? latest.1 : latest.0) / topMax
+        let bottomValue = (reverseOrder ? latest.0 : latest.1) / bottomMax
+        
+        let stackHeight = (pillHeight * 2) + interRowSpacing
+        let stackOriginY = (self.frame.size.height - stackHeight) / 2
+        let radius = pillHeight / 2
+        
+        let pillX = x + strokeWidth/2
+        let topY = stackOriginY + pillHeight + interRowSpacing
+        let bottomY = stackOriginY
+        
+        for (yPos, value, color) in [(topY, topValue, topColor), (bottomY, bottomValue, bottomColor)] {
+            let trackRect = NSRect(x: pillX, y: yPos, width: pillWidth - strokeWidth, height: pillHeight)
+            let track = NSBezierPath(roundedRect: trackRect, xRadius: radius, yRadius: radius)
+            
+            let fillWidth = trackRect.width * CGFloat(min(max(value, 0), 1))
+            if fillWidth > 0 {
+                NSGraphicsContext.saveGraphicsState()
+                track.addClip()
+                color.setFill()
+                NSBezierPath(rect: NSRect(x: trackRect.origin.x, y: yPos, width: fillWidth, height: pillHeight)).fill()
+                NSGraphicsContext.restoreGraphicsState()
+            }
+            
+            color.setStroke()
+            track.lineWidth = strokeWidth
+            track.stroke()
+        }
+        
+        width = x + pillWidth + Constants.Widget.margin.x
+    }
+    
     public func setValue(upload: Double, download: Double) {
         DispatchQueue.main.async(execute: {
             self.points.remove(at: 0)
@@ -288,8 +379,14 @@ public class NetworkChart: WidgetWrapper {
             state: self.frameState
         )
         self.frameSettingsView = frame
+        let liquid = switchView(
+            action: #selector(self.toggleLiquidGlass),
+            state: self.liquidGlassState
+        )
+        self.liquidGlassSettingsView = liquid
         
         view.addArrangedSubview(PreferencesSection([
+            PreferencesRow(localizedString("Liquid Glass (Tahoe)"), component: liquid),
             PreferencesRow(localizedString("Label"), component: switchView(
                 action: #selector(self.toggleLabel),
                 state: self.labelState
@@ -400,6 +497,24 @@ public class NetworkChart: WidgetWrapper {
     @objc private func toggleReverseOrder(_ sender: NSControl) {
         self.reverseOrderState = controlState(sender)
         Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_reverseOrder", value: self.reverseOrderState)
+        self.display()
+    }
+    
+    @objc private func toggleLiquidGlass(_ sender: NSControl) {
+        self.liquidGlassState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_liquidGlass", value: self.liquidGlassState)
+        if self.liquidGlassState {
+            if self.boxState {
+                self.boxState = false
+                self.boxSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_box", value: self.boxState)
+            }
+            if self.frameState {
+                self.frameState = false
+                self.frameSettingsView?.state = .off
+                Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_frame", value: self.frameState)
+            }
+        }
         self.display()
     }
 }

--- a/Kit/Widgets/NetworkChart.swift
+++ b/Kit/Widgets/NetworkChart.swift
@@ -358,6 +358,11 @@ public class NetworkChart: WidgetWrapper {
             self.points.remove(at: 0)
             self.points.append((upload, download))
             
+            let base: DataSizeBase = DataSizeBase(rawValue: Store.shared.string(key: "\(self.title)_base", defaultValue: "byte")) ?? .byte
+            let down = Units(bytes: Int64(download)).getReadableSpeed(base: base)
+            let up = Units(bytes: Int64(upload)).getReadableSpeed(base: base)
+            self.tooltipCallback?("\u{2193} \(down)  \u{2191} \(up)")
+            
             if self.window?.isVisible ?? false {
                 self.display()
             }

--- a/Kit/Widgets/PieChart.swift
+++ b/Kit/Widgets/PieChart.swift
@@ -100,6 +100,10 @@ public class PieChart: WidgetWrapper {
             }
         }
         
+        // Tooltip: total of all segment values as a percentage.
+        let total = list.reduce(0.0) { $0 + $1.value }
+        self.tooltipCallback?("\(Int(total.rounded(toPlaces: 2) * 100))%")
+        
         DispatchQueue.main.async(execute: {
             self.chart.setSegments(segments)
         })

--- a/Kit/Widgets/RoundedBarChart.swift
+++ b/Kit/Widgets/RoundedBarChart.swift
@@ -11,7 +11,7 @@
 
 import Cocoa
 
-public class LineChart: WidgetWrapper {
+public class RoundedBarChart: WidgetWrapper {
     private var labelState: Bool = false
     private var boxState: Bool = true
     private var frameState: Bool = false
@@ -32,8 +32,8 @@ public class LineChart: WidgetWrapper {
     // a slimmer or beefier indicator.
     public var liquidGlassPillHeight: Int = 9
     private var liquidGlassOutlineState: Bool = true
-    private var liquidGlassOutlineColorKey: String = "same"
-    private var colorState: SColor = .systemAccent
+    private var liquidGlassOutlineColorKey: String = "utilization"
+    private var colorState: SColor = .utilization
     private var historyCount: Int = 60
     private var scaleState: Scale = .none
     
@@ -45,6 +45,8 @@ public class LineChart: WidgetWrapper {
     ), num: 60)
     private var colors: [SColor] = SColor.allCases.filter({ $0 != SColor.cluster })
     private var _value: Double = 0
+    private var _splitSegments: [ColorValue] = []
+    private var splitSegmentColorsState: Bool = true
     private var _pressureLevel: RAMPressure = .normal
     
     private var historyNumbers: [KeyValue_p] = [
@@ -170,9 +172,11 @@ public class LineChart: WidgetWrapper {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
         
         var value: Double = 0
+        var splitSegments: [ColorValue] = []
         var pressureLevel: RAMPressure = .normal
         self.queue.sync {
             value = self._value
+            splitSegments = self._splitSegments
             pressureLevel = self._pressureLevel
         }
         
@@ -183,37 +187,37 @@ public class LineChart: WidgetWrapper {
         var boxSize: CGSize = CGSize(width: self.width - (Constants.Widget.margin.x*2), height: self.frame.size.height)
         
         var color: NSColor = .controlAccentColor
-        switch self.colorState {
-        case .systemAccent:
-            // Liquid Glass defaults to white to match Tahoe's monochrome glyphs.
-            color = self.liquidGlassState ? Constants.liquidGlassInk : .controlAccentColor
-        case .utilization: color = value.usageColor()
-        case .pressure: color = pressureLevel.pressureColor()
-        case .monochrome:
-            if self.boxState {
-                color = (isDarkMode ? NSColor.black : NSColor.white)
-            } else {
-                color = (isDarkMode ? NSColor.white : NSColor.black)
+        // Liquid Glass uses a unified color resolution shared with BarChart
+        // (square). The classic line-chart path keeps its own switch below
+        // so non-Liquid-Glass behavior is unchanged.
+        if self.liquidGlassState {
+            let total = splitSegments.isEmpty ? value : splitSegments.reduce(0.0) { $0 + $1.value }
+            color = self.liquidGlassRowFillColor(rowTotal: total, pressureLevel: pressureLevel)
+        } else {
+            switch self.colorState {
+            case .systemAccent:
+                color = .controlAccentColor
+            case .utilization: color = value.usageColor()
+            case .pressure: color = pressureLevel.pressureColor()
+            case .monochrome:
+                if self.boxState {
+                    color = (isDarkMode ? NSColor.black : NSColor.white)
+                } else {
+                    color = (isDarkMode ? NSColor.white : NSColor.black)
+                }
+            default: color = self.colorState.additional as? NSColor ?? .controlAccentColor
             }
-        default: color = self.colorState.additional as? NSColor ?? .controlAccentColor
         }
         
         // Liquid Glass: short-circuit the line chart and draw a single
         // horizontal pill whose fill grows left-to-right with the current
         // value. The classic line-chart code below is skipped entirely.
         if self.liquidGlassState {
-            // Apply per-widget warning thresholds when the user is on the
-            // default color, so the pill turns yellow / red as the value
-            // saturates. Any explicit accent overrides the warning hue.
-            var pillColor = color
-            if self.liquidGlassWarningState, self.colorState == .systemAccent {
-                pillColor = Constants.liquidGlassWarningColor(
-                    value: value,
-                    warning: self._colorZones.orange,
-                    critical: self._colorZones.red
-                )
+            if !splitSegments.isEmpty {
+                self.drawLiquidGlassSplitPill(segments: splitSegments, fallbackColor: color, x: &x, width: &width, lineWidth: lineWidth)
+            } else {
+                self.drawLiquidGlassPill(value: value, color: color, x: &x, width: &width, lineWidth: lineWidth)
             }
-            self.drawLiquidGlassPill(value: value, color: pillColor, x: &x, width: &width, lineWidth: lineWidth)
             self.setWidth(width)
             return
         }
@@ -339,19 +343,149 @@ public class LineChart: WidgetWrapper {
         }
         
         // Outline color override: lets the user color-code stroke vs fill.
-        let outlineColor = self.resolvedOutlineColor(fallback: color)
+        let outlineColor = self.resolvedOutlineColor(fallback: color, rowTotal: value)
         outlineColor.setStroke()
         track.lineWidth = strokeWidth
         track.stroke()
         
         width = x + pillWidth + Constants.Widget.margin.x
     }
+
+    /// Split-mode Tahoe pill: renders multiple colored segments separated by
+    /// explicit vertical gaps so RAM App/Wired/Compressed parts stay legible
+    /// in the rounded-bar style.
+    private func drawLiquidGlassSplitPill(segments: [ColorValue], fallbackColor: NSColor, x: inout CGFloat, width: inout CGFloat, lineWidth: CGFloat) {
+        let strokeWidth: CGFloat = 1.25
+        let pillWidth: CGFloat = CGFloat(self.liquidGlassPillWidth)
+        let pillHeight: CGFloat = CGFloat(self.liquidGlassPillHeight)
+
+        let pillX = x + strokeWidth/2
+        let pillY = (self.frame.size.height - pillHeight) / 2
+        let radius = pillHeight / 2
+        let trackRect = NSRect(x: pillX, y: pillY, width: pillWidth - strokeWidth, height: pillHeight)
+        let track = NSBezierPath(roundedRect: trackRect, xRadius: radius, yRadius: radius)
+
+        let useInsetFill = self.liquidGlassOutlineState
+        let fillInset: CGFloat = useInsetFill ? max(strokeWidth + 0.75, 1.5) : 0
+        let innerRect = trackRect.insetBy(dx: fillInset, dy: fillInset)
+        let fillBaseWidth = useInsetFill ? innerRect.width : trackRect.width
+        let fillBaseY = useInsetFill ? innerRect.origin.y : trackRect.origin.y
+        let fillBaseHeight = useInsetFill ? innerRect.height : trackRect.height
+
+        let clampedSegments = segments.map { min(max($0.value, 0), 1) }
+        let separatorWidth: CGFloat = clampedSegments.count > 1 ? max(1.25, strokeWidth) : 0
+        let totalSeparatorWidth = separatorWidth * CGFloat(max(clampedSegments.count - 1, 0))
+        let drawableFillWidth = max(fillBaseWidth - totalSeparatorWidth, 0)
+
+        NSGraphicsContext.saveGraphicsState()
+        if useInsetFill {
+            NSBezierPath(roundedRect: innerRect, xRadius: max(radius - fillInset, 0), yRadius: max(radius - fillInset, 0)).addClip()
+        } else {
+            track.addClip()
+        }
+
+        var segX = useInsetFill ? innerRect.origin.x : trackRect.origin.x
+        let nonZeroSegmentIndices = clampedSegments.enumerated()
+            .filter { $0.element > 0 }
+            .map { $0.offset }
+        let lastVisibleSegmentIndex = nonZeroSegmentIndices.last
+
+        for (idx, seg) in segments.enumerated() {
+            let segWidth = drawableFillWidth * CGFloat(clampedSegments[idx])
+            guard segWidth > 0 else { continue }
+
+            let fillRect = NSRect(x: segX, y: fillBaseY, width: segWidth, height: fillBaseHeight)
+            // Same color rules as BarChart:
+            //   - colorState == .systemAccent : ALWAYS liquidGlassInk
+            //     (overrides any per-segment color the module supplied).
+            //   - split colors ON + per-seg color present : use seg.color
+            //   - otherwise : the row's fallback color (already encodes the
+            //     utilization threshold hue when colorState=.utilization).
+            let segColor: NSColor
+            if self.colorState == .systemAccent {
+                segColor = Constants.liquidGlassInk
+            } else if self.splitSegmentColorsState, let c = seg.color {
+                segColor = c
+            } else {
+                segColor = fallbackColor
+            }
+            segColor.setFill()
+
+            if idx == lastVisibleSegmentIndex {
+                // Only the far-right edge should be rounded; the split edge
+                // on the left stays flat so segment boundaries remain crisp.
+                let tailRadius = min(fillRect.height / 2, fillRect.width / 2)
+                if tailRadius > 0 {
+                    let minX = fillRect.minX
+                    let maxX = fillRect.maxX
+                    let minY = fillRect.minY
+                    let maxY = fillRect.maxY
+
+                    let path = NSBezierPath()
+                    path.move(to: NSPoint(x: minX, y: minY))
+                    path.line(to: NSPoint(x: maxX - tailRadius, y: minY))
+                    path.appendArc(withCenter: NSPoint(x: maxX - tailRadius, y: minY + tailRadius), radius: tailRadius, startAngle: 270, endAngle: 0)
+                    path.line(to: NSPoint(x: maxX, y: maxY - tailRadius))
+                    path.appendArc(withCenter: NSPoint(x: maxX - tailRadius, y: maxY - tailRadius), radius: tailRadius, startAngle: 0, endAngle: 90)
+                    path.line(to: NSPoint(x: minX, y: maxY))
+                    path.close()
+                    path.fill()
+                } else {
+                    NSBezierPath(rect: fillRect).fill()
+                }
+            } else {
+                NSBezierPath(rect: fillRect).fill()
+            }
+
+            segX += segWidth
+            if idx < segments.count - 1 {
+                segX += separatorWidth
+            }
+        }
+        NSGraphicsContext.restoreGraphicsState()
+
+        let outlineColor = self.resolvedOutlineColor(fallback: fallbackColor, rowTotal: segments.reduce(0.0) { $0 + $1.value })
+        outlineColor.setStroke()
+        track.lineWidth = strokeWidth
+        track.stroke()
+
+        width = x + pillWidth + Constants.Widget.margin.x
+    }
     
-    /// Resolve the outline color override; returns the chosen `SColor` value
-    /// when the user has picked one, otherwise falls back to the fill color.
-    private func resolvedOutlineColor(fallback: NSColor) -> NSColor {
-        guard self.liquidGlassOutlineColorKey != "same",
-              let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
+    /// Resolve the base "row color" for the Liquid Glass pill, given the
+    /// user's color preference and the row total (used for utilization
+    /// thresholds). Mirrors `BarChart.liquidGlassRowFillColor` so square
+    /// and rounded widgets behave identically.
+    private func liquidGlassRowFillColor(rowTotal: Double, pressureLevel: RAMPressure) -> NSColor {
+        switch self.colorState {
+        case .systemAccent: return Constants.liquidGlassInk
+        case .utilization:
+            return Constants.liquidGlassWarningColor(
+                value: rowTotal,
+                warning: self._colorZones.orange,
+                critical: self._colorZones.red
+            )
+        case .pressure:     return pressureLevel.pressureColor()
+        case .monochrome:   return Constants.liquidGlassInk
+        default:            return self.colorState.additional as? NSColor ?? Constants.liquidGlassInk
+        }
+    }
+    
+    /// Resolve the outline color override; "same" reuses the fill,
+    /// "utilization" uses the threshold-driven warning color (system
+    /// accent / yellow / red), otherwise the user's picked SColor.
+    private func resolvedOutlineColor(fallback: NSColor, rowTotal: Double) -> NSColor {
+        if self.liquidGlassOutlineColorKey == "same" {
+            return fallback
+        }
+        if self.liquidGlassOutlineColorKey == "utilization" {
+            return Constants.liquidGlassWarningColor(
+                value: rowTotal,
+                warning: self._colorZones.orange,
+                critical: self._colorZones.red
+            )
+        }
+        guard let picked = self.colors.first(where: { $0.key == self.liquidGlassOutlineColorKey }),
               let color = picked.additional as? NSColor
         else { return fallback }
         return color.withAlphaComponent(0.85)
@@ -360,8 +494,27 @@ public class LineChart: WidgetWrapper {
     public func setValue(_ newValue: Double) {
         DispatchQueue.main.async(execute: {
             self._value = newValue
+            self._splitSegments = []
             self.tooltipCallback?("\(Int(newValue.rounded(toPlaces: 2) * 100))%")
             self.chart.addValue(newValue)
+            self.display()
+        })
+    }
+
+    public func setSegments(_ newSegments: [ColorValue]) {
+        DispatchQueue.main.async(execute: {
+            self._splitSegments = newSegments
+            self._value = newSegments.reduce(0) { $0 + $1.value }
+            self.tooltipCallback?("\(Int(self._value.rounded(toPlaces: 2) * 100))%")
+            self.chart.addValue(self._value)
+            self.display()
+        })
+    }
+
+    public func setSplitColorized(_ state: Bool) {
+        DispatchQueue.main.async(execute: {
+            guard self.splitSegmentColorsState != state else { return }
+            self.splitSegmentColorsState = state
             self.display()
         })
     }
@@ -396,9 +549,13 @@ public class LineChart: WidgetWrapper {
         self.liquidGlassSettingsView = liquid
         
         // Outline color picker: only real hues (semantic SColors like
-        // Utilization / Pressure / System accent / Monochrome are filtered).
+        // Pressure / System accent / Monochrome are filtered).
+        // "Same as fill" and "Based on utilization" are explicit sentinel options.
         let outlineExcluded: Set<String> = ["system", "monochrome", "utilization", "pressure", "cluster", "clear"]
-        var outlineColors: [KeyValue_t] = [KeyValue_t(key: "same", value: "Same as fill")]
+        var outlineColors: [KeyValue_t] = [
+            KeyValue_t(key: "same", value: "Same as fill"),
+            KeyValue_t(key: "utilization", value: "Based on utilization")
+        ]
         for c in self.colors where !outlineExcluded.contains(c.key) && !c.key.contains("separator") {
             outlineColors.append(KeyValue_t(key: c.key, value: c.value))
         }

--- a/Kit/Widgets/Speed.swift
+++ b/Kit/Widgets/Speed.swift
@@ -667,6 +667,9 @@ public class SpeedWidget: WidgetWrapper {
         }
         
         if updated {
+            let down = Units(bytes: self.inputValue).getReadableSpeed(base: self.base)
+            let up = Units(bytes: self.outputValue).getReadableSpeed(base: self.base)
+            self.tooltipCallback?("\u{2193} \(down)  \u{2191} \(up)")
             DispatchQueue.main.async(execute: {
                 self.display()
             })

--- a/Kit/Widgets/Stack.swift
+++ b/Kit/Widgets/Stack.swift
@@ -249,6 +249,14 @@ public class StackWidget: WidgetWrapper {
             if tableNeedsToBeUpdated {
                 self.orderTableView.update()
             }
+            // Tooltip joins each visible value with its label so the
+            // hover reads e.g. "CPU 12% • GPU 4%" instead of the
+            // generic widget type name.
+            let tip = self.values.map { v -> String in
+                if let l = v.label, !l.isEmpty { return "\(l) \(v.value)" }
+                return v.value
+            }.joined(separator: " \u{2022} ")
+            if !tip.isEmpty { self.tooltipCallback?(tip) }
             self.display()
         })
     }

--- a/Kit/Widgets/Tachometer.swift
+++ b/Kit/Widgets/Tachometer.swift
@@ -82,6 +82,9 @@ public class Tachometer: WidgetWrapper {
             }
         }
         
+        let total = list.reduce(0.0) { $0 + $1.value }
+        self.tooltipCallback?("\(Int(total.rounded(toPlaces: 2) * 100))%")
+        
         DispatchQueue.main.async(execute: {
             self.chart.setSegments(segments)
         })

--- a/Kit/Widgets/Text.swift
+++ b/Kit/Widgets/Text.swift
@@ -70,6 +70,7 @@ public class TextWidget: WidgetWrapper {
     public func setValue(_ newValue: String) {
         guard self.value != newValue else { return }
         self.value = newValue
+        self.tooltipCallback?(newValue)
         DispatchQueue.main.async(execute: {
             self.display()
         })

--- a/Kit/constants.swift
+++ b/Kit/constants.swift
@@ -14,9 +14,13 @@ import Cocoa
 public struct Popup_c_s {
     public let width: CGFloat = 264
     public let height: CGFloat = 300
-    public let margins: CGFloat = 8
+    /// Outer inset between the popup window edge (the glass surface)
+    /// and its content. Applied symmetrically to header (top + sides)
+    /// and body (sides + bottom + gap above body) so the dialog has
+    /// a uniform frame matching system menus / popovers.
+    public let margins: CGFloat = 16
     public let spacing: CGFloat = 2
-    public let headerHeight: CGFloat = 42
+    public let headerHeight: CGFloat = 28
     public let separatorHeight: CGFloat = 30
     public let portalHeight: CGFloat = 120
 }

--- a/Kit/constants.swift
+++ b/Kit/constants.swift
@@ -48,6 +48,72 @@ public struct Constants {
     public static let Widget: Widget_c_s = Widget_c_s()
     
     public static let defaultProcessIcon = NSWorkspace.shared.icon(forFile: "/bin/bash")
+    
+    /// `true` on macOS Tahoe (macOS 26) and later. Used by menu bar status
+    /// items (referred to internally as "widgets") to opt into the Liquid
+    /// Glass pill style by default while preserving the classic look on
+    /// older systems.
+    public static let isTahoe: Bool = ProcessInfo().isOperatingSystemAtLeast(
+        OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
+    )
+    
+    /// Default monochrome ink for Liquid Glass widgets. In Tahoe the light
+    /// menu bar uses a desaturated near-black (~`#3C3C43`, matching the
+    /// system's `secondaryLabelColor` ink) rather than pure black, and pure
+    /// white in the dark menu bar. Use this anywhere a widget would otherwise
+    /// hardcode `.white` / `.black` for its outline / fill.
+    public static var liquidGlassInk: NSColor {
+        // Resolve against the currently-drawing appearance (set on the
+        // graphics stack by AppKit during `draw(_:)`). This lets the preview
+        // window override appearance per-widget via `view.appearance`, and
+        // also picks up live system menu bar light/dark changes.
+        let appearance = NSAppearance.current ?? NSApp.effectiveAppearance
+        let isDark: Bool = {
+            switch appearance.name {
+            case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:
+                return true
+            default:
+                return false
+            }
+        }()
+        return isDark
+            ? NSColor.white.withAlphaComponent(0.85)
+            : NSColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.85)
+    }
+    
+    /// Resolve a Liquid Glass warning color for a normalized 0…1 value. When
+    /// the value crosses the warning threshold the ink turns yellow; past the
+    /// critical threshold it turns red. Below warning, the regular menu-bar
+    /// ink is returned. Alpha matches the rest of the menu bar (~0.85).
+    /// In the light menu bar the system colors are too bright and wash out
+    /// against white chrome, so a darker amber/scarlet pair is substituted.
+    public static func liquidGlassWarningColor(value: Double, warning: Double, critical: Double) -> NSColor {
+        let appearance = NSAppearance.current ?? NSApp.effectiveAppearance
+        let isDark: Bool = {
+            switch appearance.name {
+            case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:
+                return true
+            default:
+                return false
+            }
+        }()
+        if value >= critical {
+            // Dark menu bar: stock systemRed reads well at 0.85 alpha.
+            // Light menu bar: shift to a deeper, less saturated red so it
+            // doesn't bloom against the bright background.
+            return isDark
+                ? NSColor.systemRed.withAlphaComponent(0.85)
+                : NSColor(red: 0.70, green: 0.10, blue: 0.10, alpha: 0.90)
+        }
+        if value >= warning {
+            // Light menu bar: yellow is the worst offender on white. Use a
+            // darker amber/orange so the warning stays legible.
+            return isDark
+                ? NSColor.systemYellow.withAlphaComponent(0.85)
+                : NSColor(red: 0.72, green: 0.45, blue: 0.05, alpha: 0.90)
+        }
+        return liquidGlassInk
+    }
 }
 
 public enum ModuleType: Int {

--- a/Kit/liquidGlassUI.swift
+++ b/Kit/liquidGlassUI.swift
@@ -1,0 +1,269 @@
+//
+//  liquidGlassUI.swift
+//  Kit
+//
+//  App-wide Liquid Glass appearance for module popups (and any future
+//  surfaces that opt in). On macOS 26 (Tahoe) we use the real
+//  `NSGlassEffectView` API — the same primitive Apple's Wi-Fi / Battery
+//  / Control Center popovers are built on. On older systems we fall
+//  back to an `NSVisualEffectView` translucent panel.
+//
+
+import Cocoa
+
+public extension Notification.Name {
+    /// Posted whenever the global Liquid Glass UI preference (toggle or
+    /// tint) changes. Open windows should rebuild their material in place.
+    static let liquidGlassUIChanged = Notification.Name("liquidGlassUIChanged")
+}
+
+public struct LiquidGlassUI {
+    public static let storeKey: String = "LiquidGlassUI"
+    public static let tintStoreKey: String = "LiquidGlassUI_tint"
+    public static let styleStoreKey: String = "LiquidGlassUI_style"
+
+    /// Glass material thickness. Apple's `NSGlassEffectView` only ships
+    /// two real styles in the macOS 26 SDK: `regular` (thicker, frosted
+    /// — matches Wi-Fi / Battery popovers and menu bar menus) and
+    /// `clear` (thinner, more transparent — matches floating HUDs and
+    /// overlays on top of media).
+    public enum Style: String, CaseIterable {
+        case regular, clear
+
+        public var localizedName: String {
+            switch self {
+            case .regular: return localizedString("Regular")
+            case .clear:   return localizedString("Clear")
+            }
+        }
+
+        @available(macOS 26.0, *)
+        public var nsStyle: NSGlassEffectView.Style {
+            switch self {
+            case .regular: return .regular
+            case .clear:   return .clear
+            }
+        }
+    }
+
+    public static var style: Style {
+        get { Style(rawValue: Store.shared.string(key: styleStoreKey, defaultValue: Style.regular.rawValue)) ?? .regular }
+        set {
+            Store.shared.set(key: styleStoreKey, value: newValue.rawValue)
+            NotificationCenter.default.post(name: .liquidGlassUIChanged, object: nil)
+        }
+    }
+
+    /// Master toggle. Defaults to ON on macOS 26+ and OFF otherwise so
+    /// users on older systems never get the new chrome unless they ask.
+    public static var isEnabled: Bool {
+        get { Store.shared.bool(key: storeKey, defaultValue: Constants.isTahoe) }
+        set {
+            Store.shared.set(key: storeKey, value: newValue)
+            NotificationCenter.default.post(name: .liquidGlassUIChanged, object: nil)
+        }
+    }
+
+    /// Tint applied to the glass material. `clear` is the default (pure
+    /// system glass), `accent` follows the user's system accent color,
+    /// `gray` picks a neutral monochrome wash similar to Control Center
+    /// modules.
+    public enum Tint: String, CaseIterable {
+        case clear, dark, accent, gray
+
+        public var localizedName: String {
+            switch self {
+            case .clear:  return localizedString("Clear")
+            case .dark:   return localizedString("Dark")
+            case .accent: return localizedString("Accent")
+            case .gray:   return localizedString("Monochrome")
+            }
+        }
+
+        /// Color fed to `NSGlassEffectView.tintColor` (Tahoe). Alpha is
+        /// what determines how visible the wash is on top of the system
+        /// material — go too low and the tint disappears, too high and
+        /// the glass character is lost.
+        public var glassTint: NSColor? {
+            switch self {
+            case .clear:
+                return nil
+            case .dark:
+                // Matches the heavy dark frost of system Wi-Fi / Battery
+                // popovers when the menu bar is dark. Combined with the
+                // forced .darkAqua appearance below.
+                return NSColor.black.withAlphaComponent(0.55)
+            case .accent:
+                return NSColor.controlAccentColor.withAlphaComponent(0.45)
+            case .gray:
+                return NSColor.gray.withAlphaComponent(0.35)
+            }
+        }
+
+        /// Force a specific NSAppearance on the glass surface. Returning
+        /// `nil` lets the surface follow the system. The Dark tint forces
+        /// dark aqua so labels / text inside the popup recolor correctly.
+        public var forcedAppearance: NSAppearance? {
+            switch self {
+            case .dark:
+                return NSAppearance(named: .darkAqua)
+            default:
+                return nil
+            }
+        }
+    }
+
+    public static var tint: Tint {
+        get { Tint(rawValue: Store.shared.string(key: tintStoreKey, defaultValue: Tint.clear.rawValue)) ?? .clear }
+        set {
+            Store.shared.set(key: tintStoreKey, value: newValue.rawValue)
+            NotificationCenter.default.post(name: .liquidGlassUIChanged, object: nil)
+        }
+    }
+
+    /// Corner radius used for popup-style surfaces. Tahoe menu bar menus
+    /// (File / Edit / View dropdowns) use a small ~8pt radius — noticeably
+    /// tighter than popovers (~20pt). We match the menu look here.
+    public static var cornerRadius: CGFloat { Constants.isTahoe ? 8 : 6 }
+
+    /// Background color for the per-section "card" backgrounds inside
+    /// module popups. When Liquid Glass is on we want the underlying
+    /// glass to show through, so we return a near-clear wash; otherwise
+    /// the legacy gray cards are returned. The legacy colors are kept
+    /// here verbatim so the original look is preserved when the toggle
+    /// is off.
+    public static func popupCardColor(isDarkMode: Bool) -> NSColor {
+        if isEnabled {
+            // Match the look of menu items sitting on glass: faint hover
+            // wash, slightly stronger in dark mode for contrast.
+            return isDarkMode
+                ? NSColor.white.withAlphaComponent(0.06)
+                : NSColor.black.withAlphaComponent(0.04)
+        }
+        return isDarkMode
+            ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25)
+            : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)
+    }
+}
+
+/// A composite background view that renders a Liquid Glass surface.
+/// On macOS 26+ it embeds an `NSGlassEffectView`; on older systems it
+/// falls back to `NSVisualEffectView` with a layer tint overlay. Use
+/// it as a sibling background — header / body should be added on top
+/// of it as siblings, not as subviews of this view.
+public final class LiquidGlassBackgroundView: NSView {
+    private var glass: NSView?
+    private var fallback: NSVisualEffectView?
+    private var fallbackTintHost: NSView?
+    /// Faux specular rim drawn on top of the glass to make the edge
+    /// pop a little more. The real `NSGlassEffectView` rim is subtle;
+    /// this hairline 1px stroke approximates the brighter rim seen on
+    /// some system surfaces. It does not refract — it is purely cosmetic.
+    private var rim: CALayer?
+
+    public override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.wantsLayer = true
+        self.layer?.masksToBounds = true
+
+        if #available(macOS 26.0, *) {
+            let g = NSGlassEffectView(frame: self.bounds)
+            g.autoresizingMask = [.width, .height]
+            // .regular = thicker frosted glass, matches the system
+            // Wi-Fi / Battery / Control Center popovers. .clear is
+            // for translucent overlays on top of busy content.
+            g.style = .regular
+            self.glass = g
+            self.addSubview(g)
+        } else {
+            let fx = NSVisualEffectView(frame: self.bounds)
+            fx.autoresizingMask = [.width, .height]
+            fx.blendingMode = .behindWindow
+            fx.state = .active
+            // .menu matches the look of menu bar dropdowns (File / Edit / View)
+            // — a darker, more frosted material than .popover.
+            fx.material = .menu
+            fx.wantsLayer = true
+            self.fallback = fx
+            self.addSubview(fx)
+
+            let tint = NSView(frame: self.bounds)
+            tint.autoresizingMask = [.width, .height]
+            tint.wantsLayer = true
+            self.fallbackTintHost = tint
+            self.addSubview(tint)
+        }
+
+        let r = CALayer()
+        r.frame = self.bounds
+        r.borderWidth = 1
+        r.borderColor = NSColor.white.withAlphaComponent(0.18).cgColor
+        r.backgroundColor = NSColor.clear.cgColor
+        r.allowsEdgeAntialiasing = true
+        self.rim = r
+        self.layer?.addSublayer(r)
+
+        self.apply()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public override func layout() {
+        super.layout()
+        if let r = self.rim {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            r.frame = self.bounds
+            CATransaction.commit()
+        }
+    }
+
+    /// Re-read the global preference and reconfigure material, tint and
+    /// corner radius. Safe to call repeatedly.
+    public func apply() {
+        let on = LiquidGlassUI.isEnabled
+        let radius: CGFloat = on ? LiquidGlassUI.cornerRadius : 6
+
+        if let layer = self.layer {
+            layer.cornerRadius = radius
+            if #available(macOS 11.0, *) { layer.cornerCurve = .continuous }
+        }
+
+        if #available(macOS 26.0, *), let g = self.glass as? NSGlassEffectView {
+            g.isHidden = !on
+            g.cornerRadius = radius
+            g.style = LiquidGlassUI.style.nsStyle
+            // Real Liquid Glass tinting — affects the material itself so
+            // it is visible even where opaque content sits on top.
+            g.tintColor = on ? LiquidGlassUI.tint.glassTint : nil
+        }
+        if let fx = self.fallback {
+            fx.isHidden = !on
+            if let layer = fx.layer {
+                layer.cornerRadius = radius
+                if #available(macOS 11.0, *) { layer.cornerCurve = .continuous }
+            }
+        }
+        if let host = self.fallbackTintHost {
+            host.isHidden = !on
+            host.layer?.cornerRadius = radius
+            if let tint = LiquidGlassUI.tint.glassTint, on {
+                host.layer?.backgroundColor = tint.withAlphaComponent(tint.alphaComponent * 0.5).cgColor
+            } else {
+                host.layer?.backgroundColor = NSColor.clear.cgColor
+            }
+        }
+        if let r = self.rim {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            r.isHidden = !on
+            r.cornerRadius = radius
+            if #available(macOS 11.0, *) { r.cornerCurve = .continuous }
+            // Slightly brighter rim for the dark tint where the underlying
+            // material is darkest; subtler elsewhere.
+            let alpha: CGFloat = LiquidGlassUI.tint == .dark ? 0.28 : 0.18
+            r.borderColor = NSColor.white.withAlphaComponent(alpha).cgColor
+            CATransaction.commit()
+        }
+    }
+}

--- a/Kit/module/module.swift
+++ b/Kit/module/module.swift
@@ -321,7 +321,7 @@ open class Module {
             }
             
             popup.setFrameOrigin(NSPoint(x: x, y: y))
-            popup.setIsVisible(true)
+            popup.makeKeyAndOrderFront(nil)
         } else {
             popup.locked = false
             popup.openedBy = nil

--- a/Kit/module/popup.swift
+++ b/Kit/module/popup.swift
@@ -82,6 +82,7 @@ public class PopupWindow: NSWindow, NSWindowDelegate {
         self.collectionBehavior = .moveToActiveSpace
         self.backgroundColor = .clear
         self.hasShadow = true
+        self.hidesOnDeactivate = true
         self.setIsVisible(false)
         self.delegate = self
     }

--- a/Kit/module/popup.swift
+++ b/Kit/module/popup.swift
@@ -110,7 +110,7 @@ internal class PopupViewController: NSViewController {
             x: 0,
             y: 0,
             width: Constants.Popup.width + (Constants.Popup.margins * 2),
-            height: Constants.Popup.height+Constants.Popup.headerHeight
+            height: Constants.Popup.height + Constants.Popup.headerHeight + (Constants.Popup.margins * 2)
         ), module: module)
         super.init(nibName: nil, bundle: nil)
     }
@@ -153,6 +153,7 @@ internal class PopupView: NSView {
     
     private var foreground: NSVisualEffectView
     private var background: NSView
+    private let glass: LiquidGlassBackgroundView
     
     private let header: HeaderView
     private let body: NSScrollView
@@ -164,17 +165,22 @@ internal class PopupView: NSView {
     private var containerHeight: CGFloat?
     
     init(frame: NSRect, module: ModuleType) {
+        // Header is inset by `margins/2` on all four sides (sides, top,
+        // and gap to the body) so it hugs the dialog edge. The body
+        // keeps `margins` on its sides and `margins/2` at the bottom
+        // to mirror the top inset above the header. Total popup height
+        // grows by `margins*1.5` (top + gap + bottom).
         self.header = HeaderView(frame: NSRect(
-            x: 0,
-            y: frame.height - Constants.Popup.headerHeight,
-            width: frame.width,
+            x: Constants.Popup.margins*0.75,
+            y: frame.height - Constants.Popup.headerHeight - (Constants.Popup.margins*0.75),
+            width: frame.width - Constants.Popup.margins*1.5,
             height: Constants.Popup.headerHeight
         ), module: module)
         self.body = NSScrollView(frame: NSRect(
             x: Constants.Popup.margins,
-            y: Constants.Popup.margins,
+            y: Constants.Popup.margins*0.75,
             width: frame.width - Constants.Popup.margins*2,
-            height: frame.height - self.header.frame.height - Constants.Popup.margins*2
+            height: frame.height - self.header.frame.height - (Constants.Popup.margins*2)
         ))
         self.windowHeight = NSScreen.main?.visibleFrame.height
         self.containerHeight = self.body.documentView?.frame.height
@@ -191,6 +197,9 @@ internal class PopupView: NSView {
         self.background.wantsLayer = true
         self.foreground.addSubview(self.background)
         
+        self.glass = LiquidGlassBackgroundView(frame: frame)
+        self.glass.autoresizingMask = [.width, .height]
+        
         super.init(frame: frame)
         
         self.body.drawsBackground = false
@@ -202,8 +211,19 @@ internal class PopupView: NSView {
         self.body.horizontalScrollElasticity = .none
         
         self.addSubview(self.foreground, positioned: .below, relativeTo: .none)
+        self.addSubview(self.glass, positioned: .below, relativeTo: .none)
         self.addSubview(self.header)
         self.addSubview(self.body)
+        
+        self.applyLiquidGlass()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(self.applyLiquidGlass),
+            name: .liquidGlassUIChanged, object: nil
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .liquidGlassUIChanged, object: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -211,7 +231,40 @@ internal class PopupView: NSView {
     }
     
     override func updateLayer() {
-        self.background.layer?.backgroundColor = self.isDarkMode ? .clear : NSColor.white.cgColor
+        if LiquidGlassUI.isEnabled {
+            self.background.layer?.backgroundColor = .clear
+        } else {
+            self.background.layer?.backgroundColor = self.isDarkMode ? .clear : NSColor.white.cgColor
+        }
+    }
+    
+    /// Switches the popup between the legacy titlebar-material foreground
+    /// and the new Liquid Glass surface. Toggles visibility of the two
+    /// background layers and calls `glass.apply()` to pick up tint/radius
+    /// changes without rebuilding the view tree.
+    @objc private func applyLiquidGlass() {
+        let on = LiquidGlassUI.isEnabled
+        self.glass.isHidden = !on
+        self.foreground.isHidden = on
+        self.glass.frame = self.bounds
+        self.glass.apply()
+        if let layer = self.layer {
+            layer.cornerRadius = on ? LiquidGlassUI.cornerRadius : 6
+            if #available(macOS 11.0, *) { layer.cornerCurve = .continuous }
+            layer.masksToBounds = true
+        }
+        // Forced appearance (e.g. Dark tint) must live on the popup root
+        // so the header / body / scroll view inherit it and pick up the
+        // matching label & control colors.
+        if on {
+            self.appearance = LiquidGlassUI.tint.forcedAppearance
+            self.window?.appearance = LiquidGlassUI.tint.forcedAppearance
+        } else {
+            self.appearance = nil
+            self.window?.appearance = nil
+        }
+        self.needsDisplay = true
+        self.updateLayer()
     }
     
     fileprivate func setView(_ view: Popup_p?) {
@@ -240,7 +293,8 @@ internal class PopupView: NSView {
             width: size.width - (Constants.Popup.margins*2) + (isScrollVisible ? 20 : 0),
             height: size.height - Constants.Popup.headerHeight - (Constants.Popup.margins*2)
         ))
-        self.header.setFrameOrigin(NSPoint(x: 0, y: size.height - Constants.Popup.headerHeight))
+        self.header.setFrameSize(NSSize(width: size.width - Constants.Popup.margins*1.5, height: Constants.Popup.headerHeight))
+        self.header.setFrameOrigin(NSPoint(x: Constants.Popup.margins*0.75, y: size.height - Constants.Popup.headerHeight - (Constants.Popup.margins*0.75)))
         
         if let view = view {
             self.body.documentView = view
@@ -304,9 +358,10 @@ internal class PopupView: NSView {
             width: windowSize.width - (Constants.Popup.margins*2) + (isScrollVisible ? 20 : 0),
             height: windowSize.height - Constants.Popup.headerHeight - (Constants.Popup.margins*2)
         ))
+        self.header.setFrameSize(NSSize(width: windowSize.width - Constants.Popup.margins*1.5, height: Constants.Popup.headerHeight))
         self.header.setFrameOrigin(NSPoint(
-            x: self.header.frame.origin.x,
-            y: self.body.frame.height + (Constants.Popup.margins*2)
+            x: Constants.Popup.margins*0.75,
+            y: self.body.frame.height + (Constants.Popup.margins*1.25)
         ))
         
         if let documentView = self.body.documentView {
@@ -340,7 +395,7 @@ internal class HeaderView: NSStackView {
         
         let activity = NSButtonWithPadding()
         activity.frame = CGRect(x: 0, y: 0, width: 24, height: self.frame.height)
-        activity.horizontalPadding = activity.frame.height - 24
+        activity.horizontalPadding = 0
         activity.bezelStyle = .regularSquare
         activity.translatesAutoresizingMaskIntoConstraints = false
         activity.imageScaling = .scaleNone
@@ -374,7 +429,7 @@ internal class HeaderView: NSStackView {
         
         let settings = NSButtonWithPadding()
         settings.frame = CGRect(x: 0, y: 0, width: 24, height: self.frame.height)
-        settings.horizontalPadding = activity.frame.height - 24
+        settings.horizontalPadding = 0
         settings.bezelStyle = .regularSquare
         settings.translatesAutoresizingMaskIntoConstraints = false
         settings.imageScaling = .scaleNone

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -90,12 +90,23 @@ public enum widget_t: String {
                     width = view.bounds.width + 3
                 }
             case is BarChart:
-                if module == "GPU" || module == "RAM" || module == "Disk" || module == "Battery" {
+                // Liquid Glass mode renders a pill of `liquidGlassPillWidth`
+                // (28pt by default, user-configurable). The classic mode
+                // hard-coded widths below leave too little room for the
+                // pill, so the chooser image looks cut off. When Liquid
+                // Glass is on, size the preview to the pill's footprint.
+                if let bc = view as? BarChart, bc.liquidGlassState {
+                    width = CGFloat(bc.liquidGlassPillWidth) + (Constants.Widget.margin.x*2)
+                } else if module == "GPU" || module == "RAM" || module == "Disk" || module == "Battery" {
                     width = 11 + (Constants.Widget.margin.x*2)
                 } else if module == "Sensors" {
                     width = 22 + (Constants.Widget.margin.x*2)
                 } else if module == "CPU" {
                     width = 30 + (Constants.Widget.margin.x*2)
+                }
+            case is LineChart:
+                if let lc = view as? LineChart, lc.liquidGlassState {
+                    width = CGFloat(lc.liquidGlassPillWidth) + (Constants.Widget.margin.x*2)
                 }
             case is StackWidget:
                 if module == "Sensors" {

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -162,6 +162,11 @@ extension widget_t: CaseIterable {}
 public protocol widget_p: NSView {
     var widthHandler: (() -> Void)? { get set }
     var onClick: (() -> Void)? { get set }
+    /// Called by the widget whenever its displayed value changes so the
+    /// owning `Widget` wrapper can refresh the menu bar tooltip with a
+    /// human-readable representation (e.g. "62%", "1.2 MB/s"). Pass
+    /// `nil` to clear the value and fall back to the widget type name.
+    var tooltipCallback: ((String?) -> Void)? { get set }
     
     func settings() -> NSView
 }
@@ -171,6 +176,7 @@ open class WidgetWrapper: NSView, widget_p {
     public var title: String
     public var widthHandler: (() -> Void)? = nil
     public var onClick: (() -> Void)? = nil
+    public var tooltipCallback: ((String?) -> Void)? = nil
     public var shadowSize: CGSize
     internal var queue: DispatchQueue
     
@@ -346,6 +352,19 @@ public class SWidget {
                 self.menuBarItem?.button?.addSubview(self.item)
                 self.menuBarItem?.button?.image = NSImage()
                 self.menuBarItem?.button?.toolTip = "\(localizedString(self.module)): \(self.type.name())"
+                
+                // Wire the widget -> menubar tooltip channel. The widget
+                // will push a current-value string ("62%", "1.2 MB/s",
+                // ...) whenever it updates so the hover tooltip reflects
+                // the live reading instead of the widget type name.
+                self.item.tooltipCallback = { [weak self] value in
+                    guard let s = self else { return }
+                    let head = localizedString(s.module)
+                    let body = (value?.isEmpty == false) ? value! : s.type.name()
+                    DispatchQueue.main.async {
+                        s.menuBarItem?.button?.toolTip = "\(head): \(body)"
+                    }
+                }
                 
                 if let item = self.menuBarItem, !item.isVisible {
                     self.menuBarItem?.isVisible = true

--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -40,8 +40,8 @@ public enum widget_t: String {
             preview = Mini(title: module, config: widgetConfig, preview: true)
             item = Mini(title: module, config: widgetConfig, preview: false)
         case .lineChart:
-            preview = LineChart(title: module, config: widgetConfig, preview: true)
-            item = LineChart(title: module, config: widgetConfig, preview: false)
+            preview = RoundedBarChart(title: module, config: widgetConfig, preview: true)
+            item = RoundedBarChart(title: module, config: widgetConfig, preview: false)
         case .barChart:
             preview = BarChart(title: module, config: widgetConfig, preview: true)
             item = BarChart(title: module, config: widgetConfig, preview: false)
@@ -104,8 +104,8 @@ public enum widget_t: String {
                 } else if module == "CPU" {
                     width = 30 + (Constants.Widget.margin.x*2)
                 }
-            case is LineChart:
-                if let lc = view as? LineChart, lc.liquidGlassState {
+            case is RoundedBarChart:
+                if let lc = view as? RoundedBarChart, lc.liquidGlassState {
                     width = CGFloat(lc.liquidGlassPillWidth) + (Constants.Widget.margin.x*2)
                 }
             case is StackWidget:
@@ -140,8 +140,8 @@ public enum widget_t: String {
     public func name() -> String {
         switch self {
         case .mini: return localizedString("Mini widget")
-        case .lineChart: return localizedString("Line chart widget")
-        case .barChart: return localizedString("Bar chart widget")
+        case .lineChart: return localizedString("Bar (rounded)")
+        case .barChart: return localizedString("Bar (square)")
         case .pieChart: return localizedString("Pie chart widget")
         case .networkChart: return localizedString("Network chart widget")
         case .speed: return localizedString("Speed widget")

--- a/Modules/Battery/config.plist
+++ b/Modules/Battery/config.plist
@@ -50,7 +50,7 @@
 			<key>Preview</key>
 			<dict>
 				<key>Value</key>
-				<string>0.9</string>
+				<string>0.58</string>
 				<key>Color</key>
 				<true/>
 			</dict>

--- a/Modules/Bluetooth/popup.swift
+++ b/Modules/Bluetooth/popup.swift
@@ -101,7 +101,7 @@ internal class BLEView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     public func update(_ batteryLevel: [KeyValue_t]) {

--- a/Modules/CPU/config.plist
+++ b/Modules/CPU/config.plist
@@ -40,7 +40,7 @@
 			<key>Default</key>
 			<false/>
 			<key>Color</key>
-			<string>systemAccent</string>
+			<string>utilization</string>
 			<key>Unsupported colors</key>
 			<array>
 				<string>pressure</string>

--- a/Modules/CPU/config.plist
+++ b/Modules/CPU/config.plist
@@ -55,7 +55,7 @@
 			<key>Preview</key>
 			<dict>
 				<key>Value</key>
-				<string>0.36,0.28,0.32,0.26</string>
+				<string>0.58</string>
 				<key>Color</key>
 				<true/>
 			</dict>

--- a/Modules/CPU/main.swift
+++ b/Modules/CPU/main.swift
@@ -204,7 +204,7 @@ public class CPU: Module {
         self.menuBar.widgets.filter{ $0.isActive }.forEach { [self] (w: SWidget) in
             switch w.item {
             case let widget as Mini: widget.setValue(value.totalUsage)
-            case let widget as LineChart: widget.setValue(value.totalUsage)
+            case let widget as RoundedBarChart: widget.setValue(value.totalUsage)
             case let widget as BarChart:
                 var val: [[ColorValue]] = [[ColorValue(value.totalUsage)]]
                 let cores = SystemKit.shared.device.info.cpu?.cores ?? []

--- a/Modules/Clock/popup.swift
+++ b/Modules/Clock/popup.swift
@@ -222,7 +222,7 @@ private class CalendarView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     private func setup() {
@@ -568,7 +568,7 @@ internal class ClockView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     private func setTZ() {

--- a/Modules/Disk/config.plist
+++ b/Modules/Disk/config.plist
@@ -50,7 +50,7 @@
 			<key>Box</key>
 			<true/>
 			<key>Color</key>
-			<string>systemAccent</string>
+			<string>utilization</string>
 			<key>Preview</key>
 			<dict>
 				<key>Label</key>

--- a/Modules/Disk/config.plist
+++ b/Modules/Disk/config.plist
@@ -58,7 +58,7 @@
 				<key>Box</key>
 				<true/>
 				<key>Value</key>
-				<string>0.36</string>
+				<string>0.58</string>
 			</dict>
 			<key>Unsupported colors</key>
 			<array>

--- a/Modules/Disk/popup.swift
+++ b/Modules/Disk/popup.swift
@@ -345,7 +345,7 @@ internal class DiskView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     public func update(free: Int64, smart: smart_t?) {

--- a/Modules/GPU/config.plist
+++ b/Modules/GPU/config.plist
@@ -38,7 +38,7 @@
 			<key>Default</key>
 			<false/>
 			<key>Color</key>
-			<string>systemAccent</string>
+			<string>utilization</string>
 			<key>Unsupported colors</key>
 			<array>
 				<string>pressure</string>

--- a/Modules/GPU/main.swift
+++ b/Modules/GPU/main.swift
@@ -189,7 +189,7 @@ public class GPU: Module {
             case let widget as Mini:
                 widget.setValue(utilization)
                 widget.setTitle(self.showType ? "\(selectedGPU.type)GPU" : nil)
-            case let widget as LineChart: widget.setValue(utilization)
+            case let widget as RoundedBarChart: widget.setValue(utilization)
             case let widget as BarChart: widget.setValue([[ColorValue(utilization)]])
             case let widget as Tachometer:
                 widget.setValue([

--- a/Modules/GPU/popup.swift
+++ b/Modules/GPU/popup.swift
@@ -127,7 +127,7 @@ private class GPUView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     private func title() -> NSView {

--- a/Modules/RAM/config.plist
+++ b/Modules/RAM/config.plist
@@ -57,7 +57,7 @@
 				<key>Color</key>
 				<true/>
 				<key>Value</key>
-				<string>0.48</string>
+				<string>0.58</string>
 			</dict>
 			<key>Order</key>
 			<integer>3</integer>

--- a/Modules/RAM/config.plist
+++ b/Modules/RAM/config.plist
@@ -34,7 +34,7 @@
 			<key>Default</key>
 			<false/>
 			<key>Color</key>
-			<string>systemAccent</string>
+			<string>utilization</string>
 			<key>Order</key>
 			<integer>2</integer>
 		</dict>
@@ -47,7 +47,7 @@
 			<key>Box</key>
 			<true/>
 			<key>Color</key>
-			<string>systemAccent</string>
+			<string>utilization</string>
 			<key>Preview</key>
 			<dict>
 				<key>Label</key>

--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -66,6 +66,9 @@ public class RAM: Module {
     private var splitValueState: Bool {
         return Store.shared.bool(key: "\(self.config.name)_splitValue", defaultValue: false)
     }
+    private var splitValueColorsState: Bool {
+        return Store.shared.bool(key: "\(self.config.name)_splitValueColors", defaultValue: true)
+    }
     private var appColor: NSColor {
         let color = SColor.secondBlue
         let key = Store.shared.string(key: "\(self.config.name)_appColor", defaultValue: color.key)
@@ -160,20 +163,52 @@ public class RAM: Module {
             case let widget as Mini:
                 widget.setValue(value.usage)
                 widget.setPressure(value.pressure.value)
-            case let widget as LineChart:
-                widget.setValue(value.usage)
+            case let widget as RoundedBarChart:
                 widget.setPressure(value.pressure.value)
-            case let widget as BarChart:
                 if self.splitValueState {
-                    widget.setValue([[
-                        ColorValue(value.app/total, color: self.appColor),
-                        ColorValue(value.wired/total, color: self.wiredColor),
-                        ColorValue(value.compressed/total, color: self.compressedColor)
-                    ]])
+                    widget.setSplitColorized(self.splitValueColorsState)
+                    let splitSegments: [ColorValue]
+                    if self.splitValueColorsState {
+                        splitSegments = [
+                            ColorValue(value.app/total, color: self.appColor),
+                            ColorValue(value.wired/total, color: self.wiredColor),
+                            ColorValue(value.compressed/total, color: self.compressedColor)
+                        ]
+                    } else {
+                        splitSegments = [
+                            ColorValue(value.app/total),
+                            ColorValue(value.wired/total),
+                            ColorValue(value.compressed/total)
+                        ]
+                    }
+                    widget.setSegments(splitSegments)
                 } else {
+                    widget.setSplitColorized(true)
+                    widget.setValue(value.usage)
+                }
+            case let widget as BarChart:
+                widget.setPressure(value.pressure.value)
+                widget.setColorZones((0.8, 0.95))
+                if self.splitValueState {
+                    widget.setSplitColorized(self.splitValueColorsState)
+                    let splitSegments: [ColorValue]
+                    if self.splitValueColorsState {
+                        splitSegments = [
+                            ColorValue(value.app/total, color: self.appColor),
+                            ColorValue(value.wired/total, color: self.wiredColor),
+                            ColorValue(value.compressed/total, color: self.compressedColor)
+                        ]
+                    } else {
+                        splitSegments = [
+                            ColorValue(value.app/total),
+                            ColorValue(value.wired/total),
+                            ColorValue(value.compressed/total)
+                        ]
+                    }
+                    widget.setValue([splitSegments])
+                } else {
+                    widget.setSplitColorized(true)
                     widget.setValue([[ColorValue(value.usage)]])
-                    widget.setColorZones((0.8, 0.95))
-                    widget.setPressure(value.pressure.value)
                 }
             case let widget as PieChart:
                 widget.setValue([

--- a/Modules/RAM/settings.swift
+++ b/Modules/RAM/settings.swift
@@ -47,6 +47,7 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     private var updateTopIntervalValue: Int = 1
     private var numberOfProcesses: Int = 8
     private var splitValueState: Bool = false
+    private var splitValueColorsState: Bool = true
     private var notificationLevel: String = "Disabled"
     private var textValue: String = "$mem.used/$mem.total ($pressure.value)"
     private var combinedProcessesState: Bool = false
@@ -66,6 +67,7 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
         self.updateTopIntervalValue = Store.shared.int(key: "\(self.title)_updateTopInterval", defaultValue: self.updateTopIntervalValue)
         self.numberOfProcesses = Store.shared.int(key: "\(self.title)_processes", defaultValue: self.numberOfProcesses)
         self.splitValueState = Store.shared.bool(key: "\(self.title)_splitValue", defaultValue: self.splitValueState)
+        self.splitValueColorsState = Store.shared.bool(key: "\(self.title)_splitValueColors", defaultValue: self.splitValueColorsState)
         self.notificationLevel = Store.shared.string(key: "\(self.title)_notificationLevel", defaultValue: self.notificationLevel)
         self.textValue = Store.shared.string(key: "\(self.title)_textWidgetValue", defaultValue: self.textValue)
         self.combinedProcessesState = Store.shared.bool(key: "\(self.title)_combinedProcesses", defaultValue: self.combinedProcessesState)
@@ -109,13 +111,24 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
             ))
         ]))
         
-        if !widgets.filter({ $0 == .barChart }).isEmpty {
-            self.addArrangedSubview(PreferencesSection([
+        if widgets.contains(where: { $0 == .barChart || $0 == .lineChart }) {
+            var splitRows: [PreferencesRow] = [
                 PreferencesRow(localizedString("Split the value (App/Wired/Compressed)"), component: switchView(
                     action: #selector(toggleSplitValue),
                     state: self.splitValueState
                 ))
-            ]))
+            ]
+
+            if self.splitValueState {
+                splitRows.append(
+                    PreferencesRow(localizedString("Split segment colors"), component: switchView(
+                        action: #selector(toggleSplitValueColors),
+                        state: self.splitValueColorsState
+                    ))
+                )
+            }
+
+            self.addArrangedSubview(PreferencesSection(splitRows))
         }
         
         if widgets.contains(where: { $0 == .text }) {
@@ -167,6 +180,11 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     @objc private func toggleSplitValue(_ sender: NSControl) {
         self.splitValueState = controlState(sender)
         Store.shared.set(key: "\(self.title)_splitValue", value: self.splitValueState)
+        self.callback()
+    }
+    @objc private func toggleSplitValueColors(_ sender: NSControl) {
+        self.splitValueColorsState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_splitValueColors", value: self.splitValueColorsState)
         self.callback()
     }
     @objc private func toggleCombinedProcesses(_ sender: NSControl) {

--- a/Modules/Sensors/config.plist
+++ b/Modules/Sensors/config.plist
@@ -58,7 +58,7 @@
 			<key>Preview</key>
 			<dict>
 				<key>Value</key>
-				<string>0.36,0.3</string>
+				<string>0.58</string>
 				<key>Color</key>
 				<true/>
 			</dict>

--- a/Modules/Sensors/popup.swift
+++ b/Modules/Sensors/popup.swift
@@ -574,7 +574,7 @@ internal class FanView: NSStackView {
     }
     
     override func updateLayer() {
-        self.layer?.backgroundColor = (isDarkMode ? NSColor(red: 17/255, green: 17/255, blue: 17/255, alpha: 0.25) : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)).cgColor
+        self.layer?.backgroundColor = LiquidGlassUI.popupCardColor(isDarkMode: isDarkMode).cgColor
     }
     
     private func nameAndSpeed() {

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		9AF9EE0A24648751005D2270 /* Disk.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF9EE0224648751005D2270 /* Disk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9AF9EE0F2464875F005D2270 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF9EE0E2464875F005D2270 /* main.swift */; };
 		9AF9EE1124648ADC005D2270 /* readers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF9EE1024648ADC005D2270 /* readers.swift */; };
+		A1B2C3D40000000000000001 /* WidgetPreviewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* WidgetPreviewWindow.swift */; };
 		AA00000000000000000000A1 /* libIOReport.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C1E45552D11D66200525864 /* libIOReport.tbd */; };
 /* End PBXBuildFile section */
 
@@ -721,6 +722,7 @@
 		9AF9EE1024648ADC005D2270 /* readers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = readers.swift; sourceTree = "<group>"; };
 		9AF9EE12246492E8005D2270 /* config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = config.plist; sourceTree = "<group>"; };
 		9AF9EE192464A7B3005D2270 /* config.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = config.plist; sourceTree = "<group>"; };
+		A1B2C3D40000000000000002 /* WidgetPreviewWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetPreviewWindow.swift; sourceTree = "<group>"; };
 		B8F0D4F1259D19B100AAFAAF /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		BB9E59E725BB5F5E004AED95 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C904AECF255939DB004A9EBC /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1136,6 +1138,7 @@
 				9A81C74B24499C7000825D92 /* AppSettings.swift */,
 				9A9EA9442476D34500E3B883 /* Update.swift */,
 				9A83526E2889A03100791BAC /* Setup.swift */,
+				A1B2C3D40000000000000002 /* WidgetPreviewWindow.swift */,
 				5C2016422D36D0EF0049C788 /* Support.swift */,
 				5C21D80A296C7B81005BA16D /* CombinedView.swift */,
 			);
@@ -1738,7 +1741,7 @@
 					New,
 				);
 				LastSwiftUpdateCheck = 1540;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 2640;
 				ORGANIZATIONNAME = "Serhiy Mytrovtsiy";
 				TargetAttributes = {
 					5C22299C29CCB3C400F00E69 = {
@@ -2089,6 +2092,7 @@
 				9A81C74D24499C7000825D92 /* AppSettings.swift in Sources */,
 				5C21D80B296C7B81005BA16D /* CombinedView.swift in Sources */,
 				9A83526F2889A03100791BAC /* Setup.swift in Sources */,
+				A1B2C3D40000000000000001 /* WidgetPreviewWindow.swift in Sources */,
 				9AD33AC624BCD3EE007E8820 /* helpers.swift in Sources */,
 				5C2016432D36D0EF0049C788 /* Support.swift in Sources */,
 			);
@@ -2457,8 +2461,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2468,6 +2471,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Serhiy Mytrovtsiy. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2478,6 +2482,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Clock;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2495,8 +2500,7 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -2506,6 +2510,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Serhiy Mytrovtsiy. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2516,6 +2521,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Clock;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2535,11 +2541,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = "Widgets/Supporting Files/Widgets.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -2558,7 +2563,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -2574,11 +2579,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = "Widgets/Supporting Files/Widgets.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -2597,7 +2601,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2609,11 +2613,10 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/SMC/Helper/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
@@ -2641,11 +2644,10 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/SMC/Helper/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
@@ -2683,6 +2685,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Bluetooth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2691,6 +2694,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Bluetooth;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2717,6 +2721,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Bluetooth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2725,6 +2730,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Bluetooth;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2798,6 +2804,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				USE_HEADERMAP = YES;
@@ -2860,6 +2867,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = YES;
@@ -2869,16 +2877,14 @@
 		9A141106229E721200D29793 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Stats/Supporting Files/Stats.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2898,7 +2904,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -2906,16 +2912,14 @@
 		9A141107229E721200D29793 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Stats/Supporting Files/Stats.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2935,7 +2939,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				REGISTER_APP_GROUPS = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -2955,6 +2959,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = "Kit/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2965,6 +2970,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Kit/lldb";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-w";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Kit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -2992,6 +2998,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = "Kit/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3002,6 +3009,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Kit/lldb";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-w";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Kit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -3019,13 +3027,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = LaunchAtLogin/LaunchAtLogin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = LaunchAtLogin/Info.plist;
@@ -3048,13 +3055,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = LaunchAtLogin/LaunchAtLogin.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = LaunchAtLogin/Info.plist;
@@ -3086,6 +3092,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Net/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3094,6 +3101,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Net;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3120,6 +3128,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Net/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3128,6 +3137,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Net;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3153,6 +3163,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/RAM/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3161,6 +3172,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.RAM;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3187,6 +3199,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/RAM/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3195,6 +3208,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.RAM;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3220,6 +3234,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/GPU/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3229,6 +3244,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.GPU;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3256,6 +3272,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/GPU/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3265,6 +3282,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.GPU;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3291,6 +3309,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
@@ -3303,6 +3322,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.CPU;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -3332,6 +3352,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
@@ -3344,6 +3365,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.CPU;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -3420,6 +3442,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Battery/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3428,6 +3451,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Battery;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3454,6 +3478,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Battery/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3462,6 +3487,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Battery;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3477,12 +3503,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/SMC/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
@@ -3501,12 +3526,11 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = RP2S87B72W;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/SMC/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
@@ -3535,6 +3559,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Sensors/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3543,6 +3568,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Sensors;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3570,6 +3596,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Sensors/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3578,6 +3605,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Sensors;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3605,6 +3633,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Disk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3613,6 +3642,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Disk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3641,6 +3671,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = NO;
 				INFOPLIST_FILE = Modules/Disk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3649,6 +3680,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.5;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = eu.exelban.Stats.Disk;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		9A28480E2666AB3000EC1F6D /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2848072666AB3000EC1F6D /* Updater.swift */; };
 		9A28481E2666AB3600EC1F6D /* extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28481A2666AB3500EC1F6D /* extensions.swift */; };
 		9A28481F2666AB3600EC1F6D /* constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28481B2666AB3500EC1F6D /* constants.swift */; };
+		BBC0FFEE000000000000A001 /* liquidGlassUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC0FFEE000000000000A002 /* liquidGlassUI.swift */; };
 		9A2848202666AB3600EC1F6D /* types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28481C2666AB3500EC1F6D /* types.swift */; };
 		9A2848212666AB3600EC1F6D /* helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A28481D2666AB3600EC1F6D /* helpers.swift */; };
 		9A2848892666AC0100EC1F6D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A2848882666AC0100EC1F6D /* Assets.xcassets */; };
@@ -626,6 +627,7 @@
 		9A2848072666AB3000EC1F6D /* Updater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		9A28481A2666AB3500EC1F6D /* extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = extensions.swift; sourceTree = "<group>"; };
 		9A28481B2666AB3500EC1F6D /* constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = constants.swift; sourceTree = "<group>"; };
+		BBC0FFEE000000000000A002 /* liquidGlassUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = liquidGlassUI.swift; sourceTree = "<group>"; };
 		9A28481C2666AB3500EC1F6D /* types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = types.swift; sourceTree = "<group>"; };
 		9A28481D2666AB3600EC1F6D /* helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = helpers.swift; sourceTree = "<group>"; };
 		9A2848882666AC0100EC1F6D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1031,6 +1033,7 @@
 				9A28481B2666AB3500EC1F6D /* constants.swift */,
 				9A28481A2666AB3500EC1F6D /* extensions.swift */,
 				9A28481D2666AB3600EC1F6D /* helpers.swift */,
+				BBC0FFEE000000000000A002 /* liquidGlassUI.swift */,
 				9A28481C2666AB3500EC1F6D /* types.swift */,
 				5C621D812B4770D6004ED7AF /* process.swift */,
 			);
@@ -2113,6 +2116,7 @@
 				9A28481E2666AB3600EC1F6D /* extensions.swift in Sources */,
 				9A2848092666AB3000EC1F6D /* Store.swift in Sources */,
 				9A28481F2666AB3600EC1F6D /* constants.swift in Sources */,
+				BBC0FFEE000000000000A001 /* liquidGlassUI.swift in Sources */,
 				9A28480A2666AB3000EC1F6D /* SystemKit.swift in Sources */,
 				9A28477D2666AA5000EC1F6D /* widget.swift in Sources */,
 				9A2848212666AB3600EC1F6D /* helpers.swift in Sources */,

--- a/Stats.xcodeproj/project.pbxproj
+++ b/Stats.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 		9A11AB67266FDB69000C1C05 /* Kit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A2846F72666A9CC00EC1F6D /* Kit.framework */; };
 		9A2846FE2666A9CC00EC1F6D /* Kit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A2846F72666A9CC00EC1F6D /* Kit.framework */; };
 		9A2846FF2666A9CC00EC1F6D /* Kit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9A2846F72666A9CC00EC1F6D /* Kit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9A28475F2666AA2700EC1F6D /* LineChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2847552666AA2700EC1F6D /* LineChart.swift */; };
+		9A28475F2666AA2700EC1F6D /* RoundedBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2847552666AA2700EC1F6D /* RoundedBarChart.swift */; };
 		9A2847602666AA2700EC1F6D /* NetworkChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2847562666AA2700EC1F6D /* NetworkChart.swift */; };
 		9A2847612666AA2700EC1F6D /* PieChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2847572666AA2700EC1F6D /* PieChart.swift */; };
 		9A2847622666AA2700EC1F6D /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2847582666AA2700EC1F6D /* Label.swift */; };
@@ -605,7 +605,7 @@
 		9A141101229E721200D29793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A27D4A925389EFD001BB651 /* Stats.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Stats.entitlements; sourceTree = "<group>"; };
 		9A2846F72666A9CC00EC1F6D /* Kit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Kit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A2847552666AA2700EC1F6D /* LineChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChart.swift; sourceTree = "<group>"; };
+		9A2847552666AA2700EC1F6D /* RoundedBarChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoundedBarChart.swift; sourceTree = "<group>"; };
 		9A2847562666AA2700EC1F6D /* NetworkChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkChart.swift; sourceTree = "<group>"; };
 		9A2847572666AA2700EC1F6D /* PieChart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieChart.swift; sourceTree = "<group>"; };
 		9A2847582666AA2700EC1F6D /* Label.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
@@ -1046,7 +1046,7 @@
 				9A2847592666AA2700EC1F6D /* Mini.swift */,
 				9A2847582666AA2700EC1F6D /* Label.swift */,
 				9A28475D2666AA2700EC1F6D /* BarChart.swift */,
-				9A2847552666AA2700EC1F6D /* LineChart.swift */,
+				9A2847552666AA2700EC1F6D /* RoundedBarChart.swift */,
 				9A2847572666AA2700EC1F6D /* PieChart.swift */,
 				9A2847562666AA2700EC1F6D /* NetworkChart.swift */,
 				9A28475A2666AA2700EC1F6D /* Battery.swift */,
@@ -2122,7 +2122,7 @@
 				9A2848212666AB3600EC1F6D /* helpers.swift in Sources */,
 				5CAA50722C8E417700B13E13 /* Text.swift in Sources */,
 				9A28477A2666AA5000EC1F6D /* window.swift in Sources */,
-				9A28475F2666AA2700EC1F6D /* LineChart.swift in Sources */,
+				9A28475F2666AA2700EC1F6D /* RoundedBarChart.swift in Sources */,
 				9A302614286A2A3B00B41D57 /* Repeater.swift in Sources */,
 				5C4E8BA12B6EEE8E00F148B6 /* lldb.m in Sources */,
 				9A28480E2666AB3000EC1F6D /* Updater.swift in Sources */,

--- a/Stats.xcodeproj/xcshareddata/xcschemes/Stats.xcscheme
+++ b/Stats.xcodeproj/xcshareddata/xcschemes/Stats.xcscheme
@@ -89,6 +89,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--preview"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--reset"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -64,6 +64,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         let startingPoint = Date()
         
+        // Shorten the menu-bar tooltip hover delay so the widget value
+        // (pushed via `tooltipCallback`) appears almost immediately on
+        // hover instead of after the system default ~1s.
+        UserDefaults.standard.set(0.15, forKey: "NSInitialToolTipDelay")
+        
         self.parseArguments()
         if self.previewMode {
             NSApp.setActivationPolicy(.regular)

--- a/Stats/AppDelegate.swift
+++ b/Stats/AppDelegate.swift
@@ -45,6 +45,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     internal var clickInNotification: Bool = false
     internal var menuBarItem: NSStatusItem? = nil
     internal var combinedView: CombinedView = CombinedView()
+    internal var previewMode: Bool = false
+    internal var previewWindow: WidgetPreviewWindow? = nil
     
     internal var pauseState: Bool {
         Store.shared.bool(key: "pause", defaultValue: false)
@@ -63,6 +65,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         let startingPoint = Date()
         
         self.parseArguments()
+        if self.previewMode {
+            NSApp.setActivationPolicy(.regular)
+            let win = WidgetPreviewWindow()
+            self.previewWindow = win
+            win.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
         self.parseVersion()
         SMCHelper.shared.checkForUpdate()
         self.setup {

--- a/Stats/Views/AppSettings.swift
+++ b/Stats/Views/AppSettings.swift
@@ -57,6 +57,9 @@ class ApplicationSettings: NSStackView {
     private var combinedModulesView: PreferencesSection?
     private var fanHelperView: PreferencesSection?
     private var remoteView: PreferencesSection?
+    private var liquidGlassSection: PreferencesSection?
+    private var liquidGlassTintSelector: NSPopUpButton?
+    private var liquidGlassStyleSelector: NSPopUpButton?
     
     private let updateWindow: UpdateWindow = UpdateWindow()
     private let moduleSelector: ModuleSelectorView = ModuleSelectorView()
@@ -116,6 +119,30 @@ class ApplicationSettings: NSStackView {
                 state: self.systemWidgetsUpdatesState
             ))
         ]))
+        
+        if Constants.isTahoe {
+            self.liquidGlassStyleSelector = selectView(
+                action: #selector(self.toggleLiquidGlassStyle),
+                items: LiquidGlassUI.Style.allCases.map { KeyValue_t(key: $0.rawValue, value: $0.localizedName) },
+                selected: LiquidGlassUI.style.rawValue
+            )
+            self.liquidGlassTintSelector = selectView(
+                action: #selector(self.toggleLiquidGlassTint),
+                items: LiquidGlassUI.Tint.allCases.map { KeyValue_t(key: $0.rawValue, value: $0.localizedName) },
+                selected: LiquidGlassUI.tint.rawValue
+            )
+            self.liquidGlassSection = PreferencesSection(title: localizedString("Appearance"), [
+                PreferencesRow(localizedString("Liquid Glass UI"), component: switchView(
+                    action: #selector(self.toggleLiquidGlassUI),
+                    state: LiquidGlassUI.isEnabled
+                )),
+                PreferencesRow(localizedString("Glass style"), component: self.liquidGlassStyleSelector!),
+                PreferencesRow(localizedString("Glass tint"), component: self.liquidGlassTintSelector!)
+            ])
+            scrollView.stackView.addArrangedSubview(self.liquidGlassSection!)
+            self.liquidGlassSection?.setRowVisibility(1, newState: LiquidGlassUI.isEnabled)
+            self.liquidGlassSection?.setRowVisibility(2, newState: LiquidGlassUI.isEnabled)
+        }
         
         self.combinedModulesView = PreferencesSection([
             PreferencesRow(localizedString("Combined modules"), component: switchView(
@@ -501,6 +528,24 @@ class ApplicationSettings: NSStackView {
     
     @objc private func toggleSystemWidgetsUpdatesState(_ sender: NSButton) {
         self.systemWidgetsUpdatesState = sender.state == NSControl.StateValue.on
+    }
+    
+    @objc private func toggleLiquidGlassUI(_ sender: NSButton) {
+        LiquidGlassUI.isEnabled = sender.state == .on
+        self.liquidGlassSection?.setRowVisibility(1, newState: LiquidGlassUI.isEnabled)
+        self.liquidGlassSection?.setRowVisibility(2, newState: LiquidGlassUI.isEnabled)
+    }
+    
+    @objc private func toggleLiquidGlassStyle(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String,
+              let style = LiquidGlassUI.Style(rawValue: key) else { return }
+        LiquidGlassUI.style = style
+    }
+    
+    @objc private func toggleLiquidGlassTint(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String,
+              let tint = LiquidGlassUI.Tint(rawValue: key) else { return }
+        LiquidGlassUI.tint = tint
     }
 }
 

--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -162,7 +162,7 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
             }
             
             popup.setFrameOrigin(NSPoint(x: x, y: y))
-            popup.setIsVisible(true)
+            popup.makeKeyAndOrderFront(nil)
         } else {
             popup.setIsVisible(false)
         }

--- a/Stats/Views/WidgetPreviewWindow.swift
+++ b/Stats/Views/WidgetPreviewWindow.swift
@@ -1,0 +1,168 @@
+//
+//  WidgetPreviewWindow.swift
+//  Stats
+//
+//  Development-only preview window for menu bar widgets. Launched via the
+//  `--preview` CLI flag so widget appearance can be iterated on without
+//  installing the app to the menu bar.
+//
+
+import Cocoa
+import Kit
+
+internal class WidgetPreviewWindow: NSWindow {
+    private var liquidGlass: Bool = Constants.isTahoe
+    private var darkBackground: Bool = true
+    
+    private let stack: NSStackView = {
+        let s = NSStackView()
+        s.orientation = .vertical
+        s.alignment = .leading
+        s.spacing = 16
+        s.edgeInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        s.translatesAutoresizingMaskIntoConstraints = false
+        return s
+    }()
+    
+    private let menubarRow: NSStackView = {
+        let s = NSStackView()
+        s.orientation = .horizontal
+        s.alignment = .top
+        s.spacing = 18
+        s.edgeInsets = NSEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+        s.wantsLayer = true
+        s.layer?.cornerRadius = 8
+        return s
+    }()
+    
+    init() {
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 360),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        self.title = "Stats — Widget Preview"
+        self.center()
+        self.isReleasedWhenClosed = false
+        
+        let content = NSView()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(self.stack)
+        NSLayoutConstraint.activate([
+            self.stack.topAnchor.constraint(equalTo: content.topAnchor),
+            self.stack.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            self.stack.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            self.stack.bottomAnchor.constraint(equalTo: content.bottomAnchor)
+        ])
+        self.contentView = content
+        
+        self.buildControls()
+        self.stack.addArrangedSubview(self.menubarRow)
+        self.refresh()
+    }
+    
+    private func buildControls() {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 12
+        
+        let glass = NSButton(checkboxWithTitle: "Liquid Glass", target: self, action: #selector(toggleGlass(_:)))
+        glass.state = self.liquidGlass ? .on : .off
+        
+        let dark = NSButton(checkboxWithTitle: "Dark menu bar", target: self, action: #selector(toggleDark(_:)))
+        dark.state = self.darkBackground ? .on : .off
+        
+        row.addArrangedSubview(glass)
+        row.addArrangedSubview(dark)
+        self.stack.addArrangedSubview(row)
+    }
+    
+    @objc private func toggleGlass(_ sender: NSButton) {
+        self.liquidGlass = sender.state == .on
+        self.persist()
+        self.refresh()
+    }
+    
+    @objc private func toggleDark(_ sender: NSButton) {
+        self.darkBackground = sender.state == .on
+        self.refresh()
+    }
+    
+    private func persist() {
+        // Pre-seed Store entries so the freshly constructed widgets pick up
+        // the current Liquid Glass state on init.
+        let titles = ["CPU", "GPU", "RAM", "Disk", "Network", "Battery"]
+        let widgets = ["bar_chart", "line_chart", "network_chart", "battery"]
+        for t in titles {
+            for w in widgets {
+                Store.shared.set(key: "\(t)_\(w)_liquidGlass", value: self.liquidGlass)
+            }
+        }
+    }
+    
+    private func refresh() {
+        // Tear down the simulated menu bar row and rebuild from scratch so the
+        // new toggle state takes effect on the next draw cycle.
+        self.menubarRow.subviews.forEach { $0.removeFromSuperview() }
+        self.menubarRow.layer?.backgroundColor = (self.darkBackground
+            ? NSColor.black.withAlphaComponent(0.35)
+            : NSColor.white.withAlphaComponent(0.35)).cgColor
+        
+        // Force the widgets inside the simulated menu bar to resolve as the
+        // toggled appearance so `NSAppearance.current` (and any color helper
+        // that reads it) returns the right ink color even when the host
+        // window itself isn't using that appearance.
+        let widgetAppearance = NSAppearance(named: self.darkBackground ? .darkAqua : .aqua)
+        self.menubarRow.appearance = widgetAppearance
+        
+        // Helper that wraps each widget in a vertical stack with a name label
+        // so it's obvious which widget is which in the preview.
+        func labeled(_ name: String, _ widget: NSView) -> NSView {
+            let column = NSStackView()
+            column.orientation = .vertical
+            column.alignment = .centerX
+            column.spacing = 4
+            
+            let row = NSStackView()
+            row.orientation = .horizontal
+            row.alignment = .centerY
+            row.addArrangedSubview(widget)
+            column.addArrangedSubview(row)
+            
+            let label = NSTextField(labelWithString: name)
+            label.font = .systemFont(ofSize: 10, weight: .medium)
+            label.textColor = self.darkBackground ? .white : .black
+            column.addArrangedSubview(label)
+            return column
+        }
+        
+        // BarChart — CPU shows two stacked bars (e.g. system + user usage).
+        let bar = BarChart(title: "CPU", config: nil, preview: false)
+        bar.setValue([[ColorValue(0.32, color: nil)], [ColorValue(0.71, color: nil)]])
+        self.menubarRow.addArrangedSubview(labeled("BarChart (CPU)", bar))
+        
+        // BarChart — GPU shows a single bar to demonstrate the taller
+        // single-row pill that gets to claim more vertical space.
+        let gpu = BarChart(title: "GPU", config: nil, preview: false)
+        gpu.setValue([[ColorValue(0.55, color: nil)]])
+        self.menubarRow.addArrangedSubview(labeled("BarChart (GPU)", gpu))
+        
+        // LineChart — RAM.
+        let line = LineChart(title: "RAM", config: nil, preview: false)
+        for v in stride(from: 0.1, through: 0.9, by: 0.07) { line.setValue(v) }
+        self.menubarRow.addArrangedSubview(labeled("LineChart (RAM)", line))
+        
+        // NetworkChart — Network.
+        let net = NetworkChart(title: "Network", config: nil, preview: false)
+        for i in 0..<30 {
+            net.setValue(upload: Double((i % 7) * 1000), download: Double((i % 11) * 1500))
+        }
+        self.menubarRow.addArrangedSubview(labeled("NetworkChart (Net)", net))
+        
+        // Battery.
+        let bat = BatteryWidget(title: "Battery", preview: false)
+        bat.setValue(percentage: 0.62, ACStatus: false, isCharging: false, optimizedCharging: false, time: 0)
+        self.menubarRow.addArrangedSubview(labeled("Battery", bat))
+    }
+}

--- a/Stats/Views/WidgetPreviewWindow.swift
+++ b/Stats/Views/WidgetPreviewWindow.swift
@@ -148,10 +148,10 @@ internal class WidgetPreviewWindow: NSWindow {
         gpu.setValue([[ColorValue(0.55, color: nil)]])
         self.menubarRow.addArrangedSubview(labeled("BarChart (GPU)", gpu))
         
-        // LineChart — RAM.
-        let line = LineChart(title: "RAM", config: nil, preview: false)
+        // RoundedBarChart — RAM.
+            let line = RoundedBarChart(title: "RAM", config: nil, preview: false)
         for v in stride(from: 0.1, through: 0.9, by: 0.07) { line.setValue(v) }
-        self.menubarRow.addArrangedSubview(labeled("LineChart (RAM)", line))
+            self.menubarRow.addArrangedSubview(labeled("RoundedBarChart (RAM)", line))
         
         // NetworkChart — Network.
         let net = NetworkChart(title: "Network", config: nil, preview: false)

--- a/Stats/helpers.swift
+++ b/Stats/helpers.swift
@@ -17,6 +17,12 @@ extension AppDelegate {
     internal func parseArguments() {
         let args = CommandLine.arguments
         
+        if args.contains("--preview") {
+            // Dev-only: open the WidgetPreviewWindow and skip normal startup.
+            self.previewMode = true
+            return
+        }
+        
         if args.contains("--reset") {
             debug("Receive --reset argument. Resetting store (UserDefaults)...")
             Store.shared.reset()


### PR DESCRIPTION
Adds a "Liquid Glass" appearance for Stats so the menu bar widgets and their dropdowns match the new macOS 26 (Tahoe) look. Specifically, tried to create widgets that look like the system widgets like the battery widget.

<img width="418" height="105" alt="Screenshot 2026-05-13 at 10 58 34 PM" src="https://github.com/user-attachments/assets/c3e78e9a-251f-4fbf-83a1-77452446a98b" />

(In the above example, the left most widget shows ram usage)

## Widgets
- New `Constants.isTahoe` + Liquid Glass draw path for `BarChart`, `Mini`, `NetworkChart`, and the new `RoundedBarChart` (replaces the old `LineChart`, kept under the `lineChart` widget id for back-compat).
- Per-widget settings: pill width/height, outline on/off, outline color (incl. "Same as fill" / "Based on utilization"), warning + critical thresholds to allow users to choose at what utilization percentages the widget adopts warning colors like yellow-orange and red.
- `BarChart`: split-segment color toggle, segment separator gaps, multi-column tooltip averaging.

## Dropdowns / popups

<img width="430" height="210" alt="Screenshot 2026-05-13 at 10 59 10 PM" src="https://github.com/user-attachments/assets/9dd6b3cf-e6a1-4a4a-acda-08e7531ddc76" />
<img width="440" height="275" alt="Screenshot 2026-05-13 at 10 59 29 PM" src="https://github.com/user-attachments/assets/6ee1b2c2-cbe6-457f-9887-e0981aa0efe9" />

(the two images above are to show how close I got to matching the new dark glass appearance: the background and transparency is the same, just the borders differ slightly...couldnt figure out how to change this)

- New `Kit/liquidGlassUI.swift` with glass-styled pickers; adopted by every widget settings sheet and every module popup.
- App-level toggle in `AppSettings`.
- Popups now use `makeKeyAndOrderFront` + `hidesOnDeactivate` so they close on focus loss, matching native menu items.

## Defaults
- Default `Color` for CPU / GPU / RAM / Disk / Battery / Sensors flipped from `systemAccent` to `utilization`, so the warning hues are visible out of the box.

## Other
- `WidgetPreviewWindow` debug view (behind a scheme arg) for iterating on the new look.
- Fast appearing tooltip shows ram usage when new ram widgets are moused / hovered over.
