### PR TITLE
fix(de): correct Gemma 4b mistranslations in Localizable.strings

### DIFF
--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -178,7 +178,7 @@
 "Number of threads" = "%0 Threads";
 "Number of e-cores" = "%0 Effizienzkerne";
 "Number of p-cores" = "%0 Leistungskerne";
-"Number of s-cores" = "%0 Super-Prozessoren"; // translategemma:4b
+"Number of s-cores" = "%0 S-Kerne";
 "Disks" = "Festplatten";
 "Display" = "Bildschirm";
 
@@ -191,7 +191,7 @@
 // Widgets
 "Color" = "Farbe";
 "Label" = "Beschriftung";
-"Box" = "Karton"; // translategemma:4b
+"Box" = "Box";
 "Frame" = "Rahmen";
 "Value" = "Wert";
 "Colorize" = "Einfärben";
@@ -212,7 +212,7 @@
 "Stack widget" = "Stapel";
 "Memory widget" = "Speicher";
 "Static width" = "Feste Breite";
-"Tachometer widget" = "Drehzahlmesser"; // translategemma:4b
+"Tachometer widget" = "Tachometer";
 "State widget" = "Status-Widget";
 "Text widget" = "Text-Widget";
 "Battery details widget" = "Batteriedetails-Widget";
@@ -291,10 +291,10 @@
 "Efficiency cores load" = "Effizienzkerne-Last";
 "Performance cores load" = "Leistungskerne-Last";
 "All cores" = "Alle Kerne";
-"Load per core" = "Laden pro Kern"; // translategemma:4b
-"Efficiency core" = "Kern der Effizienz"; // translategemma:4b
-"Performance core" = "Leistungszentrum"; // translategemma:4b
-"Super core" = "Hervorragende Kernfunktion"; // translategemma:4b
+"Load per core" = "Last pro Kern";
+"Efficiency core" = "Effizienzkern";
+"Performance core" = "Leistungskern";
+"Super core" = "Superkern";
 
 // GPU
 "GPU to show" = "Anzuzeigende GPU";
@@ -419,8 +419,8 @@
 "Network activity" = "Netzwerkaktivität";
 "Last reset" = "Letzte Zurücksetzung vor %0";
 "Latency" = "Latenz";
-"Upload speed" = "Hochladen"; // translategemma:4b
-"Download speed" = "Herunterladen"; // translategemma:4b
+"Upload speed" = "Uploadgeschwindigkeit";
+"Download speed" = "Downloadgeschwindigkeit";
 "Address" = "Adresse";
 "WiFi network" = "WLAN-Netzwerk";
 "Local IP changed" = "Lokale IP hat sich geändert";


### PR DESCRIPTION
Fix 9 incorrect German translations introduced by automated Gemma 4b translation in `Stats/Supporting Files/de.lproj/Localizable.strings`.

### Changes

| Key | Before | After | Reason |
|-----|--------|-------|--------|
| `Number of s-cores` | `%0 Super-Prozessoren` | `%0 S-Kerne` | Pattern consistency with e-cores/p-cores |
| `Box` | `Karton` | `Box` | Established UI loanword |
| `Tachometer widget` | `Drehzahlmesser` | `Tachometer` | Avoids automotive jargon |
| `Load per core` | `Laden pro Kern` | `Last pro Kern` | Matches existing "Last" usage in file |
| `Efficiency core` | `Kern der Effizienz` | `Effizienzkern` | Matches existing "Effizienzkerne" |
| `Performance core` | `Leistungszentrum` | `Leistungskern` | Matches existing "Leistungskerne" |
| `Super core` | `Hervorragende Kernfunktion` | `Superkern` | Semantic error |
| `Upload speed` | `Hochladen` | `Uploadgeschwindigkeit` | "speed" was missing entirely |
| `Download speed` | `Herunterladen` | `Downloadgeschwindigkeit` | "speed" was missing entirely |