### PR TITLE
fix: guard menu-bar widget paths against unhosted state

### DIFF
--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -162,6 +162,12 @@ open class WidgetWrapper: NSView, widget_p {
     public var onClick: (() -> Void)? = nil
     public var shadowSize: CGSize
     internal var queue: DispatchQueue
+
+    private var hasUsableHost: Bool {
+        guard self.superview != nil else { return false }
+        guard let window = self.window else { return false }
+        return window.windowNumber != -1
+    }
     
     public init(_ type: widget_t, title: String, frame: NSRect) {
         self.type = type
@@ -186,6 +192,7 @@ open class WidgetWrapper: NSView, widget_p {
         self.shadowSize.width = newWidth
         
         DispatchQueue.main.async {
+            guard self.hasUsableHost else { return }
             self.setFrameSize(NSSize(width: newWidth, height: self.frame.size.height))
             self.widthHandler?()
         }
@@ -215,7 +222,8 @@ open class WidgetWrapper: NSView, widget_p {
     
     public func redraw() {
         DispatchQueue.main.async { [weak self] in
-            self?.display()
+            guard let self, self.hasUsableHost else { return }
+            self.display()
         }
     }
     
@@ -279,10 +287,12 @@ public class SWidget {
         self.originX = item.frame.origin.x
         
         self.item.widthHandler = { [weak self] in
-            self?.sizeCallback?()
-            if let s = self, let item = s.menuBarItem, let width: CGFloat = self?.item.frame.width, item.length != width {
-                item.length = width
-            }
+            guard let s = self else { return }
+            s.sizeCallback?()
+            guard let item = s.menuBarItem,
+                  item.button?.window != nil,
+                  item.length != s.item.frame.width else { return }
+            item.length = s.item.frame.width
         }
         self.item.identifier = NSUserInterfaceItemIdentifier(self.type.rawValue)
     }
@@ -332,17 +342,21 @@ public class SWidget {
                 if self.item.frame.origin.x != self.originX {
                     self.item.setFrameOrigin(NSPoint(x: self.originX, y: self.item.frame.origin.y))
                 }
-                self.menuBarItem?.button?.addSubview(self.item)
-                self.menuBarItem?.button?.image = NSImage()
-                self.menuBarItem?.button?.toolTip = "\(localizedString(self.module)): \(self.type.name())"
+                guard let button = self.menuBarItem?.button else { return }
+                if self.item.superview !== button {
+                    self.item.removeFromSuperview()
+                    button.addSubview(self.item)
+                }
+                button.image = NSImage()
+                button.toolTip = "\(localizedString(self.module)): \(self.type.name())"
                 
                 if let item = self.menuBarItem, !item.isVisible {
                     self.menuBarItem?.isVisible = true
                 }
                 
-                self.menuBarItem?.button?.target = self
-                self.menuBarItem?.button?.action = #selector(self.togglePopup)
-                self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
+                button.target = self
+                button.action = #selector(self.togglePopup)
+                button.sendAction(on: [.leftMouseDown, .rightMouseDown])
             })
         } else if let item = self.menuBarItem {
             NSStatusBar.system.removeStatusItem(item)
@@ -492,11 +506,12 @@ public class MenuBar {
     
     private func recalculateWidth() {
         guard self.oneView, self.active else { return }
-        
+        guard let item = self.menuBarItem, item.button?.window != nil else { return }
+
         let w = self.activeWidgets.map({ $0.item.frame.width }).reduce(0, +) +
             (CGFloat(self.activeWidgets.count - 1) * Constants.Widget.spacing) +
             Constants.Widget.spacing * 2
-        self.menuBarItem?.length = w
+        item.length = w
         self.view.setFrameOrigin(NSPoint(x: 0, y: 0))
         self.view.setFrameSize(NSSize(width: w, height: Constants.Widget.height))
         
@@ -558,7 +573,10 @@ public class MenuBarView: NSView {
     }
     
     public func addWidget(_ view: NSView) {
-        self.addSubview(view)
+        if view.superview !== self {
+            view.removeFromSuperview()
+            self.addSubview(view)
+        }
     }
     
     public func removeWidget(type: widget_t) {

--- a/Modules/Net/preview.swift
+++ b/Modules/Net/preview.swift
@@ -139,7 +139,7 @@ internal class Preview: PreviewWrapper {
         view.spacing = Constants.Settings.margin*2
         view.heightAnchor.constraint(equalToConstant: 140).isActive = true
         
-        let chart = NetworkChartView(num: 600)
+        let chart = NetworkChartView(frame: NSRect(x: 0, y: 0, width: 0, height: 140), num: 600)
         self.chart = chart
         chart.setColors(in: self.downloadColor, out: self.uploadColor)
         chart.setLegend(x: true, y: false)

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -30,7 +30,9 @@ extension CWPHYMode: @retroactive CustomStringConvertible {
         case .mode11g:  return "802.11g"
         case .mode11n:  return "802.11n"
         case .mode11ax: return "802.11ax"
+        #if compiler(<6.2)
         case .mode11be: return "802.11be"
+        #endif
         case .modeNone: return "none"
         @unknown default: return "unknown"
         }


### PR DESCRIPTION
Several widget redraw and resize paths could fire while a widget was not yet attached to its hosting NSStatusItem button, or while the button itself had no associated NSWindow (windowNumber == -1).

When that happened, calls into setFrameSize/display/NSStatusItem.length would still reach AppKit, which forwarded them to WindowServer and caused log spamming to occur. The same paths were also unconditionally re-adding the widget view to its host on every status-item setup, causing needless view-hierarchy churn on toggle.

This change introduces a small hasUsableHost helper on WidgetWrapper that requires both a non-nil superview and a window with a valid windowNumber, and uses it to early-return from:

- WidgetWrapper.setWidth (before setFrameSize/widthHandler)

- WidgetWrapper.redraw (before display)

For the per-widget status item, SWidget.widthHandler and MenuBar.recalculateWidth now require the menu-bar button to have a window before assigning NSStatusItem.length, which is what actually triggers the WindowServer round-trip and log spam.

SWidget.setMenuBarItem and MenuBarView.addWidget are also made idempotent: they only call addSubview when the view isn't already parented to the intended host, removing repeated reparent work on toggle and one-view changes.

Two unrelated fixes are included in the same change because they surfaced while reproducing the menu-bar issue on macOS Tahoe:

  - Modules/Net/preview.swift: the network preview chart was being initialised without an explicit frame, leaving it sized 0x0 until the first layout pass. Provide an explicit (0, 0, 0, 140) frame so the preview renders correctly on first display.

  - Modules/Net/readers.swift: guard the CWPHYMode.mode11be case in the CustomStringConvertible extension behind `#if compiler(<6.2)`. The symbol is not exposed by the CoreWLAN headers shipped with the Tahoe SDK (Xcode 26/Swift 6.2), so unconditionally referencing it breaks the build on that toolchain. Older toolchains (Sonoma, Sequoia) continue to render Wi-Fi 7 networks as "802.11be".

Related: #2829, #3212