### PR TITLE
Fix updater app copy preserving framework symlinks

### DIFF
--- a/Kit/scripts/updater.sh
+++ b/Kit/scripts/updater.sh
@@ -30,9 +30,13 @@ launch_app() {
     fi
 }
 
-if [[ "$STEP" == "2" ]]; then
+install_app() {
     rm -rf "$APP_DST"
-    cp -rf "$APP_SRC" "$APP_DST"
+    /usr/bin/ditto "$APP_SRC" "$APP_DST"
+}
+
+if [[ "$STEP" == "2" ]]; then
+    install_app
 
     launch_app "$APP_DST/Contents/MacOS/Stats" --dmg "$DMG_PATH"
 
@@ -44,8 +48,7 @@ elif [[ "$STEP" == "3" ]]; then
 
     echo "Done"
 else
-    rm -rf "$APP_DST"
-    cp -rf "$APP_SRC" "$APP_DST"
+    install_app
 
     launch_app "$APP_DST/Contents/MacOS/Stats" --dmg-path "$DMG_PATH" --mount-path "$MOUNT_PATH"
 


### PR DESCRIPTION
Fixes #3218.

## Summary
- replace the updater's `cp -rf` app copy with `/usr/bin/ditto`
- share the app install step between both updater launch paths
- preserve framework bundle symlinks from the mounted DMG so Gatekeeper keeps accepting the installed app

## Verification
- `bash -n Kit/scripts/updater.sh`
- Ran `Kit/scripts/updater.sh` against a fake `Stats.app` containing framework-style symlinks and confirmed `Test.framework/Test`, `Test.framework/Resources`, and `Test.framework/Versions/Current` remain symlinks after install.
- Reproduced the released v2.12.14 DMG behavior locally: `cp -rf` copy is rejected by `spctl` with `bundle format is ambiguous`, while a `ditto` copy is accepted as `Notarized Developer ID`.