### PR TITLE
fix: prevent nettop orphan processes via watchdog + waitUntilExit

### DIFF
--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -125,6 +125,12 @@ private func runNettopSample(timeout: TimeInterval, log: NextLog) -> String? {
     task.standardOutput = outputPipe
     task.standardError = errorPipe
 
+    defer {
+        inputPipe.fileHandleForWriting.closeFile()
+        outputPipe.fileHandleForReading.closeFile()
+        errorPipe.fileHandleForReading.closeFile()
+    }
+
     do {
         try task.run()
     } catch let err {
@@ -143,10 +149,6 @@ private func runNettopSample(timeout: TimeInterval, log: NextLog) -> String? {
     _ = errorPipe.fileHandleForReading.readDataToEndOfFile()
     task.waitUntilExit()
     watchdog.cancel()
-
-    inputPipe.fileHandleForWriting.closeFile()
-    outputPipe.fileHandleForReading.closeFile()
-    errorPipe.fileHandleForReading.closeFile()
 
     return String(data: outputData, encoding: .utf8)
 }

--- a/Modules/Net/readers.swift
+++ b/Modules/Net/readers.swift
@@ -104,6 +104,53 @@ extension CWChannel {
     }
 }
 
+// Runs a single `nettop` sample with a hard timeout so a hanging child cannot become a
+// long-lived orphan. macOS sometimes leaves `nettop -L 1` stuck (sandbox/sleep-wake/IPC),
+// and Swift's `Process` deinit does not kill the child — without a watchdog the timer
+// keeps spawning new instances and they pile up at high CPU. See exelban/stats#3224.
+private func runNettopSample(timeout: TimeInterval, log: NextLog) -> String? {
+    let task = Process()
+    task.launchPath = "/usr/bin/nettop"
+    task.arguments = ["-P", "-L", "1", "-n", "-k", "time,interface,state,rx_dupe,rx_ooo,re-tx,rtt_avg,rcvsize,tx_win,tc_class,tc_mgt,cc_algo,P,C,R,W,arch"]
+    task.environment = [
+        "NSUnbufferedIO": "YES",
+        "LC_ALL": "en_US.UTF-8"
+    ]
+
+    let inputPipe = Pipe()
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+
+    task.standardInput = inputPipe
+    task.standardOutput = outputPipe
+    task.standardError = errorPipe
+
+    do {
+        try task.run()
+    } catch let err {
+        error("nettop launch failed: \(err)", log: log)
+        return nil
+    }
+
+    let watchdog = DispatchWorkItem { [weak task] in
+        guard let task, task.isRunning else { return }
+        error("nettop did not exit within \(timeout)s, terminating to prevent orphan", log: log)
+        task.terminate()
+    }
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: watchdog)
+
+    let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+    _ = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    task.waitUntilExit()
+    watchdog.cancel()
+
+    inputPipe.fileHandleForWriting.closeFile()
+    outputPipe.fileHandleForReading.closeFile()
+    errorPipe.fileHandleForReading.closeFile()
+
+    return String(data: outputData, encoding: .utf8)
+}
+
 internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
     private var reachability: Reachability = Reachability(start: true)
     private let variablesQueue = DispatchQueue(label: "eu.exelban.NetworkUsageReader")
@@ -300,40 +347,9 @@ internal class UsageReader: Reader<Network_Usage>, CWEventDelegate {
     }
     
     private func readProcessBandwidth() -> Bandwidth {
-        let task = Process()
-        task.launchPath = "/usr/bin/nettop"
-        task.arguments = ["-P", "-L", "1", "-n", "-k", "time,interface,state,rx_dupe,rx_ooo,re-tx,rtt_avg,rcvsize,tx_win,tc_class,tc_mgt,cc_algo,P,C,R,W,arch"]
-        task.environment = [
-            "NSUnbufferedIO": "YES",
-            "LC_ALL": "en_US.UTF-8"
-        ]
-        
-        let inputPipe = Pipe()
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        
-        defer {
-            inputPipe.fileHandleForWriting.closeFile()
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
-        }
-        
-        task.standardInput = inputPipe
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-        
-        do {
-            try task.run()
-        } catch let err {
-            error("read bandwidth from processes: \(err)", log: self.log)
+        guard let output = runNettopSample(timeout: 5, log: self.log), !output.isEmpty else {
             return Bandwidth()
         }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8)
-        _ = String(data: errorData, encoding: .utf8)
-        guard let output, !output.isEmpty else { return Bandwidth() }
 
         var totalUpload: Int64 = 0
         var totalDownload: Int64 = 0
@@ -638,41 +654,10 @@ public class ProcessReader: Reader<[Network_Process]> {
         if self.numberOfProcesses == 0 {
             return
         }
-        
-        let task = Process()
-        task.launchPath = "/usr/bin/nettop"
-        task.arguments = ["-P", "-L", "1", "-n", "-k", "time,interface,state,rx_dupe,rx_ooo,re-tx,rtt_avg,rcvsize,tx_win,tc_class,tc_mgt,cc_algo,P,C,R,W,arch"]
-        task.environment = [
-            "NSUnbufferedIO": "YES",
-            "LC_ALL": "en_US.UTF-8"
-        ]
-        
-        let inputPipe = Pipe()
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        
-        defer {
-            inputPipe.fileHandleForWriting.closeFile()
-            outputPipe.fileHandleForReading.closeFile()
-            errorPipe.fileHandleForReading.closeFile()
-        }
-        
-        task.standardInput = inputPipe
-        task.standardOutput = outputPipe
-        task.standardError = errorPipe
-        
-        do {
-            try task.run()
-        } catch let error {
-            print(error)
+
+        guard let output = runNettopSample(timeout: 5, log: self.log), !output.isEmpty else {
             return
         }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8)
-        _ = String(data: errorData, encoding: .utf8)
-        guard let output, !output.isEmpty else { return }
         
         var list: [Network_Process] = []
         var firstLine = false


### PR DESCRIPTION
## Summary

Fixes #3224 (and the long-standing #606, #536, #744): `nettop` orphan processes that survive indefinitely after Stats spawns them, each burning ~35% CPU.

## Root cause

`UsageReader.readProcessBandwidth()` and `ProcessReader.read()` in `Modules/Net/readers.swift` launched `/usr/bin/nettop` via `Process` but **never called `waitUntilExit()` or `terminate()`**. When `nettop` failed to exit cleanly (known on Apple Silicon, under sandbox, after sleep/wake, IPC stalls), the Swift `Process` object deinit-ed without killing the child. The orphan was reparented to `launchd` and kept running. The 1-second timer then spawned more, and they accumulated.

Example from my machine before the fix:

```
$ ps aux | grep nettop
matteogazzetta   54449  37.9 ... /usr/bin/nettop -P -L 1 -n -k time...
matteogazzetta   56519  37.4 ... /usr/bin/nettop -P -L 1 -n -k time...
matteogazzetta   46923  37.4 ... /usr/bin/nettop -P -L 1 -n -k time...
matteogazzetta   31881  36.8 ... /usr/bin/nettop -P -L 1 -n -k time...   (8 days old)
matteogazzetta   66169  36.6 ... /usr/bin/nettop -P -L 1 -n -k time...   (9 days old)
matteogazzetta   56300  35.5 ... /usr/bin/nettop -P -L 1 -n -k time...
matteogazzetta   68103  34.2 ... /usr/bin/nettop -P -L 1 -n -k time...   (9 days old)
matteogazzetta   56672   6.8 ... /usr/bin/nettop -P -L 1 -n -k time...
```

Eight orphans, ~3 cores combined.

## Fix

Both call sites now go through a shared file-private helper `runNettopSample(timeout:log:)` that:

- Launches `nettop` exactly as before.
- Schedules a 5-second watchdog `DispatchWorkItem` on a background queue. If the task is still running when it fires, the watchdog calls `task.terminate()`. `SIGTERM` closes `nettop`'s stdout, which unblocks `readDataToEndOfFile()` via EOF.
- Calls `task.waitUntilExit()` after draining the output and error pipes, so the function never returns until the child is reaped.
- Cancels the watchdog on clean exit.

This guarantees no orphan can survive past a single read, regardless of why `nettop` hangs. The 5s timeout is well above any normal `nettop -L 1` runtime (sub-second on healthy systems) and below the 1s timer cadence × any reasonable user tolerance.

## Test plan

- [ ] Build Stats from this branch in Xcode.
- [ ] Enable Network module with `Reader type = process based`. Open the popup. Leave running.
- [ ] `ps aux | grep nettop` — exactly 0 or 1 instance at any time.
- [ ] Sleep / wake the Mac several times. Recheck — still 0 or 1 instance.
- [ ] Force-quit Stats. Recheck — no surviving `nettop`.
- [ ] Confirm the popup still shows top processes with up/down rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
