### PR TITLE
Refresh GPU identity metadata

### DIFF
--- a/Modules/GPU/main.swift
+++ b/Modules/GPU/main.swift
@@ -24,11 +24,11 @@ public enum GPU_types: GPU_type {
 
 public struct GPU_Info: Codable {
     public let id: String
-    public let type: GPU_type
+    public var type: GPU_type
     
-    public let IOClass: String
+    public var IOClass: String
     public var vendor: String? = nil
-    public let model: String
+    public var model: String
     public var cores: Int? = nil
     
     public var state: Bool = true

--- a/Modules/GPU/reader.swift
+++ b/Modules/GPU/reader.swift
@@ -166,7 +166,7 @@ internal class InfoReader: Reader<GPUs> {
                     }
                 }
             } else if ioClass.contains("agx") { // apple
-                predictModel = stats["model"] as? String ?? "Apple Graphics"
+                predictModel = accelerator["model"] as? String ?? stats["model"] as? String ?? "Apple Graphics"
                 if let display = self.displays.first(where: { $0.vendor == "sppci_vendor_Apple" }) {
                     if let name = display.name {
                         predictModel = name
@@ -175,6 +175,7 @@ internal class InfoReader: Reader<GPUs> {
                         cores = num
                     }
                 }
+                model = predictModel
                 type = .integrated
             } else {
                 predictModel = "Unknown"
@@ -201,6 +202,11 @@ internal class InfoReader: Reader<GPUs> {
             guard let idx = self.gpus.list.firstIndex(where: { $0.id == id }) else {
                 return
             }
+            self.gpus.list[idx].type = type.rawValue
+            self.gpus.list[idx].IOClass = IOClass
+            self.gpus.list[idx].vendor = vendor
+            self.gpus.list[idx].model = model
+            self.gpus.list[idx].cores = cores
             
             if let agcInfo = accelerator["AGCInfo"] as? [String: Int], let state = agcInfo["poweredOffByAGC"] {
                 self.gpus.list[idx].state = state == 0


### PR DESCRIPTION
## Summary
- prefer the current AGX accelerator/system_profiler model for Apple GPUs
- refresh GPU identity metadata on each read instead of keeping the first sampled model/core count forever

## Why
After migrating from an M2 Max Mac to an M5 Max Mac, Stats could keep showing the initial Apple M2 Max GPU identity even though current system_profiler and IORegistry data reported Apple M5 Max / AGXAcceleratorG17X / 40 GPU cores. The existing reader only updated live utilization fields after creating a GPU entry, so model, IOClass, type, vendor, and core count could not self-correct.

## Validation
- Confirmed affected machine reports Apple M5 Max, Mac17,7, AGXAcceleratorG17X, and 40 GPU cores via system_profiler and IORegistry.
- Ran `xcodebuild -runFirstLaunch` to repair local Xcode setup.
- Ran `xcodebuild -project Stats.xcodeproj -scheme Stats -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO build` successfully.