### PR TITLE
Toggle combined details with Option key

### DIFF
--- a/Kit/module/widget.swift
+++ b/Kit/module/widget.swift
@@ -151,6 +151,7 @@ extension widget_t: CaseIterable {}
 public protocol widget_p: NSView {
     var widthHandler: (() -> Void)? { get set }
     var onClick: (() -> Void)? { get set }
+    var onOptionClick: (() -> Void)? { get set }
     
     func settings() -> NSView
 }
@@ -160,6 +161,7 @@ open class WidgetWrapper: NSView, widget_p {
     public var title: String
     public var widthHandler: (() -> Void)? = nil
     public var onClick: (() -> Void)? = nil
+    public var onOptionClick: (() -> Void)? = nil
     public var shadowSize: CGSize
     internal var queue: DispatchQueue
     
@@ -222,6 +224,10 @@ open class WidgetWrapper: NSView, widget_p {
     open func settings() -> NSView { return NSView() }
     
     open override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.option), let f = self.onOptionClick {
+            f()
+            return
+        }
         if let f = self.onClick {
             f()
             return

--- a/Stats/Views/CombinedView.swift
+++ b/Stats/Views/CombinedView.swift
@@ -77,26 +77,11 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
         self.menuBarItem?.button?.image = NSImage()
         self.menuBarItem?.button?.toolTip = localizedString("Combined modules")
         
-        if !self.combinedModulesPopup {
-            self.activeModules.forEach { (m: Module) in
-                m.menuBar.widgets.forEach { w in
-                    w.item.onClick = {
-                        if let window = w.item.window {
-                            NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
-                                "module": m.name,
-                                "widget": w.type,
-                                "origin": window.frame.origin,
-                                "center": window.frame.width/2
-                            ])
-                        }
-                    }
-                }
-            }
-        } else {
-            self.menuBarItem?.button?.target = self
-            self.menuBarItem?.button?.action = #selector(self.togglePopup)
-            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
-        }
+        self.menuBarItem?.button?.target = self
+        self.menuBarItem?.button?.action = #selector(self.togglePopup)
+        self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
+        
+        self.setModuleDetailsClickHandlers()
         
         DispatchQueue.main.async(execute: {
             self.recalculate()
@@ -107,6 +92,7 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
         self.activeModules.forEach { (m: Module) in
             m.menuBar.widgets.forEach { w in
                 w.item.onClick = nil
+                w.item.onOptionClick = nil
             }
         }
         if let item = self.menuBarItem {
@@ -142,7 +128,18 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
     // call when popup appear/disappear
     private func visibilityCallback(_ state: Bool) {}
     
-    @objc private func togglePopup(_ sender: NSButton) {
+    @objc private func togglePopup() {
+        if let event = NSApp.currentEvent, event.modifierFlags.contains(.option) {
+            guard !self.combinedModulesPopup, event.type == .leftMouseDown else {
+                return
+            }
+        } else if !self.combinedModulesPopup {
+            return
+        }
+        self.showPopup()
+    }
+    
+    private func showPopup() {
         guard let popup = self.popup, let item = self.menuBarItem, let window = item.button?.window else { return }
         let openedWindows = NSApplication.shared.windows.filter{ $0 is NSPanel }
         openedWindows.forEach{ $0.setIsVisible(false) }
@@ -183,33 +180,7 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
     }
     
     @objc private func listenCombinedModulesPopup() {
-        if !self.combinedModulesPopup {
-            self.activeModules.forEach { (m: Module) in
-                m.menuBar.widgets.forEach { w in
-                    w.item.onClick = {
-                        if let window = w.item.window {
-                            NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
-                                "module": m.name,
-                                "widget": w.type,
-                                "origin": window.frame.origin,
-                                "center": window.frame.width/2
-                            ])
-                        }
-                    }
-                }
-            }
-            self.menuBarItem?.button?.action = nil
-        } else {
-            self.activeModules.forEach { (m: Module) in
-                m.menuBar.widgets.forEach { w in
-                    w.item.onClick = nil
-                }
-            }
-            
-            self.menuBarItem?.button?.target = self
-            self.menuBarItem?.button?.action = #selector(self.togglePopup)
-            self.menuBarItem?.button?.sendAction(on: [.leftMouseDown, .rightMouseDown])
-        }
+        self.setModuleDetailsClickHandlers()
     }
     
     @objc private func listenForModule(_ notification: Notification) {
@@ -218,16 +189,28 @@ internal class CombinedView: NSObject, NSGestureRecognizerDelegate {
               state,
               let module = self.activeModules.first(where: { $0.name == name }) else { return }
         
+        self.setModuleDetailsClickHandlers(module: module)
+    }
+    
+    private func setModuleDetailsClickHandlers() {
+        self.activeModules.forEach { self.setModuleDetailsClickHandlers(module: $0) }
+    }
+    
+    private func setModuleDetailsClickHandlers(module: Module) {
         module.menuBar.widgets.forEach { w in
-            w.item.onClick = {
-                if let window = w.item.window {
-                    NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
-                        "module": module.name,
-                        "widget": w.type,
-                        "origin": window.frame.origin,
-                        "center": window.frame.width/2
-                    ])
-                }
+            let moduleDetails: () -> Void = { [weak w] in
+                guard let w = w, let window = w.item.window else { return }
+                NotificationCenter.default.post(name: .togglePopup, object: nil, userInfo: [
+                    "module": module.name,
+                    "widget": w.type,
+                    "origin": window.frame.origin,
+                    "center": window.frame.width/2
+                ])
+            }
+            
+            w.item.onClick = self.combinedModulesPopup ? nil : moduleDetails
+            w.item.onOptionClick = self.combinedModulesPopup ? moduleDetails : { [weak self] in
+                self?.showPopup()
             }
         }
     }


### PR DESCRIPTION
Allows toggling between "combined details" view using Option (⌥) key as proposed in #3223.
I decided to use Option key instead of Shift/Right click as it keeps it consistent with other native Mac OS widgets (Wi-Fi).

Note that this feature works by inverting the behaviour selected in "combined details" depending on key combination.

Fixes #3223 
