### PR TITLE
Allow selecting different calendars in clock widget

### DIFF
--- a/Modules/Clock/main.swift
+++ b/Modules/Clock/main.swift
@@ -19,8 +19,35 @@ public struct Clock_t: Codable {
     public var name: String
     public var format: String
     public var tz: String
+    public var calendar: String
     
     public var value: Date? = nil
+    
+    private enum CodingKeys: String, CodingKey {
+        case id, enabled, name, format, tz, calendar, value
+    }
+    
+    public init(id: String = UUID().uuidString, enabled: Bool = true, name: String, format: String, tz: String, calendar: String = "gregorian", value: Date? = nil) {
+        self.id = id
+        self.enabled = enabled
+        self.name = name
+        self.format = format
+        self.tz = tz
+        self.calendar = calendar
+        self.value = value
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        self.name = try container.decode(String.self, forKey: .name)
+        self.format = try container.decode(String.self, forKey: .format)
+        self.tz = try container.decode(String.self, forKey: .tz)
+        self.calendar = try container.decodeIfPresent(String.self, forKey: .calendar) ?? Clock.defaultCalendar
+        self.value = try container.decodeIfPresent(Date.self, forKey: .value)
+    }
     
     var popupIndex: Int {
         get { Store.shared.int(key: "clock_\(self.id)_popupIndex", defaultValue: -1) }
@@ -33,6 +60,9 @@ public struct Clock_t: Codable {
     
     public func formatted() -> String {
         let formatter = DateFormatter()
+        var calendar = Clock.calendar(from: self.calendar)
+        calendar.timeZone = TimeZone(from: self.tz)
+        formatter.calendar = calendar
         formatter.dateFormat = self.format
         formatter.timeZone = TimeZone(from: self.tz)
         return formatter.string(from: self.value ?? Date())
@@ -108,9 +138,59 @@ public class Clock: Module {
 }
 
 extension Clock {
+    static let defaultCalendar = "gregorian"
     static let localID: String = UUID().uuidString
     static var local: Clock_t {
         Clock_t(id: Clock.localID, name: localizedString("Local time"), format: "yyyy-MM-dd HH:mm:ss", tz: "local")
+    }
+    static func calendar(from key: String) -> Calendar {
+        if let calendar = NSCalendar(calendarIdentifier: NSCalendar.Identifier(key)) {
+            return calendar as Calendar
+        }
+        return Calendar(identifier: .gregorian)
+    }
+    static var calendarIdentifiers: [String] {
+        var identifiers = [
+            "gregorian",
+            "buddhist",
+            "chinese",
+            "coptic",
+            "ethiopic",
+            "ethioaa",
+            "hebrew",
+            "iso8601",
+            "indian",
+            "islamic",
+            "islamic-civil",
+            "japanese",
+            "persian",
+            "roc",
+            "islamic-tbla",
+            "islamic-umalqura"
+        ]
+        
+        if #available(macOS 26.0, *) {
+            identifiers.append(contentsOf: [
+                "bangla",
+                "gujarati",
+                "kannada",
+                "malayalam",
+                "marathi",
+                "odia",
+                "tamil",
+                "telugu",
+                "vikram",
+                "dangi",
+                "vietnamese"
+            ])
+        }
+        
+        return identifiers.filter { NSCalendar(calendarIdentifier: NSCalendar.Identifier($0)) != nil }
+    }
+    static var calendars: [KeyValue_t] {
+        self.calendarIdentifiers.map {
+            KeyValue_t(key: $0, value: (NSLocale.current as NSLocale).localizedString(forCalendarIdentifier: $0) ?? $0)
+        }
     }
     static var zones: [KeyValue_t] {
         [

--- a/Modules/Clock/settings.swift
+++ b/Modules/Clock/settings.swift
@@ -15,6 +15,7 @@ import Kit
 let nameColumnID = NSUserInterfaceItemIdentifier(rawValue: "name")
 let formatColumnID = NSUserInterfaceItemIdentifier(rawValue: "format")
 let tzColumnID = NSUserInterfaceItemIdentifier(rawValue: "tz")
+let calendarColumnID = NSUserInterfaceItemIdentifier(rawValue: "calendar")
 let statusColumnID = NSUserInterfaceItemIdentifier(rawValue: "status")
 
 internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate {
@@ -99,6 +100,10 @@ internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableVi
         tzColumn.headerCell.title = localizedString("Time zone")
         tzColumn.headerCell.alignment = .center
         tzColumn.width = 132
+        let calendarColumn = NSTableColumn(identifier: calendarColumnID)
+        calendarColumn.headerCell.title = localizedString("Calendar")
+        calendarColumn.headerCell.alignment = .center
+        calendarColumn.width = 132
         let statusColumn = NSTableColumn(identifier: statusColumnID)
         statusColumn.headerCell.title = ""
         statusColumn.width = 16
@@ -106,6 +111,7 @@ internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableVi
         self.tableView.addTableColumn(nameColumn)
         self.tableView.addTableColumn(formatColumn)
         self.tableView.addTableColumn(tzColumn)
+        self.tableView.addTableColumn(calendarColumn)
         self.tableView.addTableColumn(statusColumn)
         
         let separator = NSBox()
@@ -214,6 +220,16 @@ internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableVi
         case tzColumnID:
             let select: NSPopUpButton = selectView(action: #selector(self.toggleTZ), items: Clock.zones, selected: item.tz)
             select.identifier = NSUserInterfaceItemIdentifier("\(row)")
+            select.itemArray.forEach { $0.identifier = NSUserInterfaceItemIdentifier("\(row)") }
+            select.sizeToFit()
+            select.preferredEdge = .maxX
+            select.translatesAutoresizingMaskIntoConstraints = false
+            select.widthAnchor.constraint(lessThanOrEqualToConstant: 132).isActive = true
+            cell.addSubview(select)
+        case calendarColumnID:
+            let select: NSPopUpButton = selectView(action: #selector(self.toggleCalendar), items: Clock.calendars, selected: item.calendar)
+            select.identifier = NSUserInterfaceItemIdentifier("\(row)")
+            select.itemArray.forEach { $0.identifier = NSUserInterfaceItemIdentifier("\(row)") }
             select.sizeToFit()
             select.preferredEdge = .maxX
             select.translatesAutoresizingMaskIntoConstraints = false
@@ -260,9 +276,35 @@ internal class Settings: NSStackView, Settings_v, NSTableViewDelegate, NSTableVi
         }
     }
     
-    @objc private func toggleTZ(_ sender: NSMenuItem) {
-        guard let key = sender.representedObject as? String, let id = sender.identifier, let i = Int(id.rawValue) else { return }
+    private func selectValue(_ sender: Any) -> (key: String, index: Int)? {
+        if let select = sender as? NSPopUpButton,
+           let key = select.selectedItem?.representedObject as? String,
+           let id = select.identifier,
+           let index = Int(id.rawValue) {
+            return (key, index)
+        }
+        
+        if let item = sender as? NSMenuItem,
+           let key = item.representedObject as? String,
+           let id = item.identifier,
+           let index = Int(id.rawValue) {
+            return (key, index)
+        }
+        
+        return nil
+    }
+    
+    @objc private func toggleTZ(_ sender: Any) {
+        guard let value = self.selectValue(sender) else { return }
+        let key = value.key
+        let i = value.index
         self.list[i].tz = key
+    }
+    @objc private func toggleCalendar(_ sender: Any) {
+        guard let value = self.selectValue(sender) else { return }
+        let key = value.key
+        let i = value.index
+        self.list[i].calendar = key
     }
     @objc private func toggleClock(_ sender: NSButton) {
         guard let id = sender.identifier, let i = Int(id.rawValue) else { return }


### PR DESCRIPTION
This PR aims to fix #2590 by allowing to customize calendar to be used in clock widget. 

Available options vary between OS versions though.

<img width="1037" height="912" alt="image" src="https://github.com/user-attachments/assets/667155b8-741f-41ab-8274-061946cbe79b" />
