### PR TITLE
feat: split-bar I/O mode for Disk and Network widgets

### DIFF
--- a/Kit/Widgets/BarChart.swift
+++ b/Kit/Widgets/BarChart.swift
@@ -15,13 +15,21 @@ public class BarChart: WidgetWrapper {
     private var labelState: Bool = false
     private var boxState: Bool = true
     private var frameState: Bool = false
+    private var splitState: Bool = false
     public var colorState: SColor = .systemAccent
     private var colors: [SColor] = SColor.allCases
-    
+
     private var _value: [[ColorValue]] = [[]]
     private var _pressureLevel: RAMPressure = .normal
     private var _colorZones: colorZones = (0.6, 0.8)
-    
+
+    // Rolling session peaks — used as the 100% reference in split I/O mode so
+    // the bar self-calibrates without user configuration.
+    private var peakInput: Int64 = 1
+    private var peakOutput: Int64 = 1
+
+    public var isSplitMode: Bool { self.splitState }
+
     private var boxSettingsView: NSSwitch? = nil
     private var frameSettingsView: NSSwitch? = nil
     
@@ -74,6 +82,7 @@ public class BarChart: WidgetWrapper {
             self.boxState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_box", defaultValue: self.boxState)
             self.frameState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_frame", defaultValue: self.frameState)
             self.labelState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_label", defaultValue: self.labelState)
+            self.splitState = Store.shared.bool(key: "\(self.title)_\(self.type.rawValue)_split", defaultValue: self.splitState)
             self.colorState = SColor.fromString(Store.shared.string(key: "\(self.title)_\(self.type.rawValue)_color", defaultValue: self.colorState.key))
         }
         
@@ -181,12 +190,39 @@ public class BarChart: WidgetWrapper {
         
         x += offset
         for i in 0..<value.count {
+            if self.splitState && value[i].count == 2 {
+                // Split I/O mode: read fills bottom-up, write stacks on top of read.
+                // Each ratio is scaled against half the bar height so both at 100%
+                // exactly fill the bar.
+                let halfHeight = maxPartitionHeight / 2
+                let lowerRatio = max(0, min(1, CGFloat(value[i][0].value)))
+                let upperRatio = max(0, min(1, CGFloat(value[i][1].value)))
+
+                let lowerColor = value[i][0].color ?? NSColor.systemBlue
+                let upperColor = value[i][1].color ?? NSColor.systemRed
+
+                let lowerFill = lowerRatio * halfHeight
+                if lowerFill > 0 {
+                    lowerColor.set()
+                    NSBezierPath(rect: NSRect(x: x, y: offset, width: partitionWidth, height: lowerFill)).fill()
+                }
+
+                let upperFill = upperRatio * halfHeight
+                if upperFill > 0 {
+                    upperColor.set()
+                    NSBezierPath(rect: NSRect(x: x, y: offset + lowerFill, width: partitionWidth, height: upperFill)).fill()
+                }
+
+                x += partitionWidth + partitionMargin
+                continue
+            }
+
             var y = offset
             for a in 0..<value[i].count {
                 let partitionValue = value[i][a]
                 let partitionHeight = maxPartitionHeight * CGFloat(partitionValue.value)
                 let partition = NSBezierPath(rect: NSRect(x: x, y: y, width: partitionWidth, height: partitionHeight))
-                
+
                 if partitionValue.color == nil {
                     switch self.colorState {
                     case .systemAccent: NSColor.controlAccentColor.set()
@@ -203,13 +239,13 @@ public class BarChart: WidgetWrapper {
                 } else {
                     partitionValue.color?.set()
                 }
-                
+
                 partition.fill()
                 partition.close()
-                
+
                 y += partitionHeight
             }
-            
+
             x += partitionWidth + partitionMargin
         }
         
@@ -222,6 +258,21 @@ public class BarChart: WidgetWrapper {
         self.setWidth(width)
     }
     
+    // Feed raw throughput in bytes/sec; the widget tracks per-session peaks and
+    // renders the two halves proportionally. Caller order is (input/read, output/write).
+    public func setSplitValue(input: Int64, output: Int64) {
+        let i = abs(input)
+        let o = abs(output)
+        if i > self.peakInput { self.peakInput = i }
+        if o > self.peakOutput { self.peakOutput = o }
+        let inputRatio = Double(i) / Double(self.peakInput)
+        let outputRatio = Double(o) / Double(self.peakOutput)
+        self.setValue([[
+            ColorValue(inputRatio, color: NSColor.systemBlue),
+            ColorValue(outputRatio, color: NSColor.systemRed)
+        ]])
+    }
+
     public func setValue(_ newValue: [[ColorValue]]) {
         DispatchQueue.main.async(execute: {
             let tolerance: CGFloat = 0.01
@@ -268,7 +319,7 @@ public class BarChart: WidgetWrapper {
         )
         self.frameSettingsView = frame
         
-        view.addArrangedSubview(PreferencesSection([
+        var rows: [PreferencesRow] = [
             PreferencesRow(localizedString("Label"), component: switchView(
                 action: #selector(self.toggleLabel),
                 state: self.labelState
@@ -280,9 +331,23 @@ public class BarChart: WidgetWrapper {
             )),
             PreferencesRow(localizedString("Box"), component: box),
             PreferencesRow(localizedString("Frame"), component: frame)
-        ]))
-        
+        ]
+        if self.title == "Disk" || self.title == "Network" {
+            let label = self.title == "Network" ? "Split download/upload" : "Split read/write"
+            rows.append(PreferencesRow(localizedString(label), component: switchView(
+                action: #selector(self.toggleSplit),
+                state: self.splitState
+            )))
+        }
+        view.addArrangedSubview(PreferencesSection(rows))
+
         return view
+    }
+
+    @objc private func toggleSplit(_ sender: NSControl) {
+        self.splitState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_\(self.type.rawValue)_split", value: self.splitState)
+        self.redraw()
     }
     
     @objc private func toggleLabel(_ sender: NSControl) {

--- a/Modules/Disk/main.swift
+++ b/Modules/Disk/main.swift
@@ -300,7 +300,10 @@ public class Disk: Module {
         self.menuBar.widgets.filter{ $0.isActive }.forEach { (w: SWidget) in
             switch w.item {
             case let widget as Mini: widget.setValue(d.percentage)
-            case let widget as BarChart: widget.setValue([[ColorValue(d.percentage)]])
+            case let widget as BarChart:
+                if !widget.isSplitMode {
+                    widget.setValue([[ColorValue(d.percentage)]])
+                }
             case let widget as MemoryWidget:
                 widget.setValue((DiskSize(d.free).getReadableMemory(), DiskSize(d.size - d.free).getReadableMemory()), usedPercentage: d.percentage)
             case let widget as PieChart:
@@ -371,8 +374,10 @@ public class Disk: Module {
         
         self.menuBar.widgets.filter{ $0.isActive }.forEach { (w: SWidget) in
             switch w.item {
-            case let widget as SpeedWidget: 
+            case let widget as SpeedWidget:
                 widget.setValue(input: d.activity.read, output: d.activity.write)
+            case let widget as BarChart where widget.isSplitMode:
+                widget.setSplitValue(input: d.activity.read, output: d.activity.write)
             case let widget as NetworkChart:
                 widget.setValue(upload: Double(d.activity.write), download: Double(d.activity.read))
                 if self.capacityReader?.interval != 1 {

--- a/Modules/Net/config.plist
+++ b/Modules/Net/config.plist
@@ -51,12 +51,40 @@
 				<string>system</string>
 			</array>
 		</dict>
+		<key>bar_chart</key>
+		<dict>
+			<key>Default</key>
+			<false/>
+			<key>Label</key>
+			<false/>
+			<key>Box</key>
+			<true/>
+			<key>Color</key>
+			<string>systemAccent</string>
+			<key>Preview</key>
+			<dict>
+				<key>Label</key>
+				<false/>
+				<key>Box</key>
+				<true/>
+				<key>Value</key>
+				<string>0.36</string>
+			</dict>
+			<key>Unsupported colors</key>
+			<array>
+				<string>pressure</string>
+				<string>cluster</string>
+				<string>utilization</string>
+			</array>
+			<key>Order</key>
+			<integer>3</integer>
+		</dict>
 		<key>state</key>
 		<dict>
 			<key>Default</key>
 			<false/>
 			<key>Order</key>
-			<integer>3</integer>
+			<integer>4</integer>
 			<key>Preview</key>
 			<dict>
 				<key>Value</key>
@@ -68,7 +96,7 @@
 			<key>Default</key>
 			<false/>
 			<key>Order</key>
-			<integer>4</integer>
+			<integer>5</integer>
 			<key>Preview</key>
 			<dict>
 				<key>Value</key>

--- a/Modules/Net/main.swift
+++ b/Modules/Net/main.swift
@@ -263,6 +263,8 @@ public class Network: Module {
         self.menuBar.widgets.filter{ $0.isActive }.forEach { (w: SWidget) in
             switch w.item {
             case let widget as SpeedWidget: widget.setValue(input: download, output: upload)
+            case let widget as BarChart where widget.isSplitMode:
+                widget.setSplitValue(input: download, output: upload)
             case let widget as NetworkChart: widget.setValue(upload: Double(upload), download: Double(download))
             case let widget as TextWidget:
                 var text = self.textValue

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "تسمية";
 "Box" = "مربع";
 "Frame" = "إطار";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "قيمة";
 "Colorize" = "تلوين";
 "Colorize value" = "تلوين القيمة";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Етикет";
 "Box" = "Непрозрачен фон";
 "Frame" = "Рамка";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Стойност";
 "Colorize" = "Оцветяване";
 "Colorize value" = "Стойност на оцветяване";

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etiqueta";
 "Box" = "Caixa";
 "Frame" = "Marc";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valor";
 "Colorize" = "Acoloreix";
 "Colorize value" = "Valor de l'acoloriment";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Popisek";
 "Box" = "Výplň";
 "Frame" = "Okraj";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Hodnota";
 "Colorize" = "Obarvit";
 "Colorize value" = "Obarvit hodnotu";

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Tekstmærke";
 "Box" = "Boks";
 "Frame" = "Ramme";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Værdi";
 "Colorize" = "Farve";
 "Colorize value" = "Farve værdi";

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Beschriftung";
 "Box" = "Box";
 "Frame" = "Rahmen";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Wert";
 "Colorize" = "Einfärben";
 "Colorize value" = "Wert einfärben";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Ετικέτα";
 "Box" = "Κουτί";
 "Frame" = "Περίγραμμα";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Τιμή";
 "Colorize" = "Χρωματισμός";
 "Colorize value" = "Χρωματισμός Τιμής";

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Label";
 "Box" = "Box";
 "Frame" = "Frame";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Value";
 "Colorize" = "Colourise";
 "Colorize value" = "Colourise value";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Label";
 "Box" = "Box";
 "Frame" = "Frame";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Value";
 "Colorize" = "Colourise";
 "Colorize value" = "Colourise value";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Label";
 "Box" = "Box";
 "Frame" = "Frame";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Value";
 "Colorize" = "Colorize";
 "Colorize value" = "Colorize value";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etiqueta";
 "Box" = "Caja";
 "Frame" = "Borde";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valor";
 "Colorize" = "Colorear";
 "Colorize value" = "Colorear valor";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Silt";
 "Box" = "Kast";
 "Frame" = "Raam";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Väärtus";
 "Colorize" = "Värvi";
 "Colorize value" = "Värvi väärtus";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "لیبل";
 "Box" = "جعبه";
 "Frame" = "فریم";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "مقدار";
 "Colorize" = "رنگی";
 "Colorize value" = "مقدار رنگ";

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Tunniste";
 "Box" = "Laatikko";
 "Frame" = "Kehys";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Arvo";
 "Colorize" = "Värjää";
 "Colorize value" = "Värjää arvo";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Étiquette";
 "Box" = "Boîte";
 "Frame" = "Cadre";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valeur";
 "Colorize" = "Coloriser";
 "Colorize value" = "Coloriser la valeur";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "תווית";
 "Box" = "קופסא";
 "Frame" = "מסגרת";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "ערך";
 "Colorize" = "הוספת צבע";
 "Colorize value" = "הוספת ערך לצבע";

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "लेबल";
 "Box" = "बॉक्स";
 "Frame" = "फ्रेम";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "मूल्य";
 "Colorize" = "रंगांकित";
 "Colorize value" = "मूल्य को रंगीन करें";

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Oznaka";
 "Box" = "Pozadina";
 "Frame" = "Okvir";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Vrijednost";
 "Colorize" = "Oboji";
 "Colorize value" = "Oboji vrijednost";

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Címke megjelenítése";
 "Box" = "Háttér";
 "Frame" = "Keret";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Érték megjelenítése";
 "Colorize" = "Színezés";
 "Colorize value" = "Érték színezése";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Label";
 "Box" = "Kotak";
 "Frame" = "Bingkai";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Nilai";
 "Colorize" = "Warna"; // translategemma:4b
 "Colorize value" = "Nilai pewarnaan"; // translategemma:4b

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etichetta";
 "Box" = "Scatola";
 "Frame" = "Riquadro";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valore";
 "Colorize" = "Colora";
 "Colorize value" = "Valore colorato";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "ラベル";
 "Box" = "塗りつぶし";
 "Frame" = "枠線";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "数値";
 "Colorize" = "カラーで表示";
 "Colorize value" = "数値をカラーで表示";

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "레이블";
 "Box" = "상자";
 "Frame" = "테두리";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "값";
 "Colorize" = "색상화";
 "Colorize value" = "값 색상화";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Merkelapp";
 "Box" = "Boks";
 "Frame" = "Ramme";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Verdi";
 "Colorize" = "Fargelegg";
 "Colorize value" = "Fargelegg verdi";

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Label";
 "Box" = "Doos"; // translategemma:4b
 "Frame" = "Rand";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Waarde";
 "Colorize" = "Inkleuren";
 "Colorize value" = "Waarde inkleuren";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etykieta";
 "Box" = "Pudełko"; // translategemma:4b
 "Frame" = "Ramka";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Wartość";
 "Colorize" = "Kolorowanie";
 "Colorize value" = "Kolorowanie wartości";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Rótulo";
 "Box" = "Caixa";
 "Frame" = "Quadro";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valor";
 "Colorize" = "Colorir";
 "Colorize value" = "Valor colorido";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Rótulo";
 "Box" = "Caixa";
 "Frame" = "Quadro";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valor";
 "Colorize" = "Colorir";
 "Colorize value" = "Valor da colorização";

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etichetă";
 "Box" = "Cutie";
 "Frame" = "Cadru";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Valoare";
 "Colorize" = "Colorează";
 "Colorize value" = "Colorează valoarea";

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Метка";
 "Box" = "Коробка"; // translategemma:4b
 "Frame" = "Рамка";
+"Split download/upload" = "Разделить загрузка/выгрузка";
+"Split read/write" = "Разделить чтение/запись";
 "Value" = "Значение";
 "Colorize" = "Раскрасить";
 "Colorize value" = "Раскрасить значение";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Popis";
 "Box" = "Políčko";
 "Frame" = "Orámovanie";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Hodnota";
 "Colorize" = "Vyfarbiť";
 "Colorize value" = "Vyfarbiť hodnotu";

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Oznaka";
 "Box" = "Okno";
 "Frame" = "Okvir";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Vrednost";
 "Colorize" = "Obarvaj";
 "Colorize value" = "Obarvaj vrednost";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etikett";
 "Box" = "Låda";
 "Frame" = "Ram";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Värde";
 "Colorize" = "Färglägg";
 "Colorize value" = "Färglägg värde";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "ป้ายชื่อ";
 "Box" = "กล่อง";
 "Frame" = "เฟรม";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "ค่า";
 "Colorize" = "สีสัน";
 "Colorize value" = "สีสันค่า";

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Etiket";
 "Box" = "Kutu Görünüm";
 "Frame" = "Çerçeve";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Değer";
 "Colorize" = "Renklendir";
 "Colorize value" = "Değeri renklendir";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Етикетка";
 "Box" = "Коробка"; // translategemma:4b
 "Frame" = "Рамка";
+"Split download/upload" = "Розділити завантаження/висилання";
+"Split read/write" = "Розділити читання/запис";
 "Value" = "Значення";
 "Colorize" = "Розфарбувати";
 "Colorize value" = "Розфарбувати значення";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "Nhãn";
 "Box" = "Hộp";
 "Frame" = "Khung";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "Giá trị";
 "Colorize" = "Tô màu";
 "Colorize value" = "Tô màu giá trị";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "标签";
 "Box" = "底盒";
 "Frame" = "外框";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "数值";
 "Colorize" = "彩色";
 "Colorize value" = "数值颜色";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "Label" = "標籤";
 "Box" = "背景";
 "Frame" = "外框";
+"Split download/upload" = "Split download/upload";
+"Split read/write" = "Split read/write";
 "Value" = "數值";
 "Colorize" = "以色彩顯示";
 "Colorize value" = "以色彩顯示數值";


### PR DESCRIPTION
## What
Adds an opt-in **split rendering mode** to the shared `BarChart` widget. When enabled on the Disk or Network module, the bar is divided horizontally: the lower half fills bottom-up with input throughput (read / download) and the upper half stacks output throughput (write / upload) on top.

<p align="center"><img src="https://raw.githubusercontent.com/Serj92/stats/assets/pr-screenshots/widgets-final-2x.png" width="700" alt="Stats menu bar with split I/O on Network (download blue / upload red) and Disk (read blue / write red)" /></p>
<p align="center"><sub><strong>NET</strong> = split download/upload &nbsp;·&nbsp; <strong>SSD</strong> = split read/write &nbsp;·&nbsp; (RAM/CPU widgets show unrelated features from sibling PRs)</sub></p>

## Why
Today, getting both directions of I/O in the menu bar requires either two separate widgets (which doubles real-estate cost) or a `SpeedWidget` (which is text-only). For users who want a glanceable bar — one that shows *both* read & write activity in a single compact column — there's no option. Several requests touch this gap; #3233 is one.

## How it works
- Each half is scaled against half the widget height, so both at 100% exactly fill the bar.
- **Self-calibrating:** a rolling per-session peak (`peakInput`, `peakOutput`) drives the 100% reference, so the widget produces sensible visuals across spinning HDDs, NVMe drives, 100 Mbit links and 10 Gbit links without user-tuned thresholds.
- Hooked into Disk (`d.activity.read` / `d.activity.write`) and Network (`download` / `upload`) via a new `BarChart.setSplitValue(input:output:)` entry point.
- The toggle (`Split read/write` for Disk, `Split download/upload` for Network) is registered **only** in the Disk and Network widget settings — it does not appear in CPU, RAM, etc., where it has no meaning.

## Behavior unchanged unless opted in
The mode is off by default. Existing Disk/Network bar-chart users see no visual change until they enable the new toggle.

## Known trade-offs (honest list)
- **Peaks are session-local** — they reset on app restart. This was a deliberate simplicity choice (no persistence, no recalibration logic). Happy to add persistence or a user-configurable cap if you'd prefer.
- Colors are hardcoded to `systemBlue` (input) and `systemRed` (output) to match the existing `SpeedWidget` convention. Could be promoted to settings later.

## Localizations
Two new strings (`Split download/upload`, `Split read/write`) added to `en.lproj`, `ru.lproj`, `uk.lproj`. The remaining 28 language files received an English fallback via `Kit/scripts/i18n.py fix` so the i18n CI check passes — translators can fill these in later via the normal flow.

Refs #3233.