### PR TITLE
feat: memory pressure bar indicator for RAM widget

### DIFF
--- a/Modules/RAM/main.swift
+++ b/Modules/RAM/main.swift
@@ -66,6 +66,52 @@ public class RAM: Module {
     private var splitValueState: Bool {
         return Store.shared.bool(key: "\(self.config.name)_splitValue", defaultValue: false)
     }
+    private var pressureFillState: Bool {
+        return Store.shared.bool(key: "\(self.config.name)_pressureFill", defaultValue: false)
+    }
+
+    // Mirror the Activity Monitor "Memory Pressure" indicator.
+    //   Fill height = (wired + compressed) / total — memory the system cannot
+    //   reclaim quickly. Wired pages are locked by the kernel; compressed pages
+    //   are already squeezed and can only leave via swap I/O.
+    //   Color is driven by the kernel's own pressure verdict so it matches
+    //   Activity Monitor's color transitions exactly.
+    private func pressureFill(_ value: RAM_Usage) -> (ratio: Double, color: NSColor) {
+        let total = value.total == 0 ? 1 : value.total
+        let ratio = max(0.0, min(1.0, (value.wired + value.compressed) / total))
+        let color: NSColor
+        switch value.pressure.value {
+        case .normal: color = self.pressureNormalColor
+        case .warning: color = self.pressureWarningColor
+        case .critical: color = self.pressureCriticalColor
+        }
+        return (ratio, color)
+    }
+    private var pressureNormalColor: NSColor {
+        let color = SColor.secondGreen
+        let key = Store.shared.string(key: "\(self.config.name)_pressureNormalColor", defaultValue: color.key)
+        if let c = SColor.fromString(key).additional as? NSColor {
+            return c
+        }
+        return color.additional as! NSColor
+    }
+    private var pressureWarningColor: NSColor {
+        let color = SColor.secondYellow
+        let key = Store.shared.string(key: "\(self.config.name)_pressureWarningColor", defaultValue: color.key)
+        if let c = SColor.fromString(key).additional as? NSColor {
+            return c
+        }
+        return color.additional as! NSColor
+    }
+    private var pressureCriticalColor: NSColor {
+        let color = SColor.secondRed
+        let key = Store.shared.string(key: "\(self.config.name)_pressureCriticalColor", defaultValue: color.key)
+        if let c = SColor.fromString(key).additional as? NSColor {
+            return c
+        }
+        return color.additional as! NSColor
+    }
+
     private var appColor: NSColor {
         let color = SColor.secondBlue
         let key = Store.shared.string(key: "\(self.config.name)_appColor", defaultValue: color.key)
@@ -164,7 +210,10 @@ public class RAM: Module {
                 widget.setValue(value.usage)
                 widget.setPressure(value.pressure.value)
             case let widget as BarChart:
-                if self.splitValueState {
+                if self.pressureFillState {
+                    let result = self.pressureFill(value)
+                    widget.setValue([[ColorValue(result.ratio, color: result.color)]])
+                } else if self.splitValueState {
                     widget.setValue([[
                         ColorValue(value.app/total, color: self.appColor),
                         ColorValue(value.wired/total, color: self.wiredColor),

--- a/Modules/RAM/settings.swift
+++ b/Modules/RAM/settings.swift
@@ -47,6 +47,10 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     private var updateTopIntervalValue: Int = 1
     private var numberOfProcesses: Int = 8
     private var splitValueState: Bool = false
+    private var pressureFillState: Bool = false
+    private var pressureNormalColorState: SColor = .secondGreen
+    private var pressureWarningColorState: SColor = .secondYellow
+    private var pressureCriticalColorState: SColor = .secondRed
     private var notificationLevel: String = "Disabled"
     private var textValue: String = "$mem.used/$mem.total ($pressure.value)"
     private var combinedProcessesState: Bool = false
@@ -66,6 +70,10 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
         self.updateTopIntervalValue = Store.shared.int(key: "\(self.title)_updateTopInterval", defaultValue: self.updateTopIntervalValue)
         self.numberOfProcesses = Store.shared.int(key: "\(self.title)_processes", defaultValue: self.numberOfProcesses)
         self.splitValueState = Store.shared.bool(key: "\(self.title)_splitValue", defaultValue: self.splitValueState)
+        self.pressureFillState = Store.shared.bool(key: "\(self.title)_pressureFill", defaultValue: self.pressureFillState)
+        self.pressureNormalColorState = SColor.fromString(Store.shared.string(key: "\(self.title)_pressureNormalColor", defaultValue: self.pressureNormalColorState.key))
+        self.pressureWarningColorState = SColor.fromString(Store.shared.string(key: "\(self.title)_pressureWarningColor", defaultValue: self.pressureWarningColorState.key))
+        self.pressureCriticalColorState = SColor.fromString(Store.shared.string(key: "\(self.title)_pressureCriticalColor", defaultValue: self.pressureCriticalColorState.key))
         self.notificationLevel = Store.shared.string(key: "\(self.title)_notificationLevel", defaultValue: self.notificationLevel)
         self.textValue = Store.shared.string(key: "\(self.title)_textWidgetValue", defaultValue: self.textValue)
         self.combinedProcessesState = Store.shared.bool(key: "\(self.title)_combinedProcesses", defaultValue: self.combinedProcessesState)
@@ -114,6 +122,25 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
                 PreferencesRow(localizedString("Split the value (App/Wired/Compressed)"), component: switchView(
                     action: #selector(toggleSplitValue),
                     state: self.splitValueState
+                )),
+                PreferencesRow(localizedString("Memory pressure indicator"), component: switchView(
+                    action: #selector(togglePressureFill),
+                    state: self.pressureFillState
+                )),
+                PreferencesRow(localizedString("Memory pressure normal color"), component: colorSelectView(
+                    action: #selector(togglePressureNormalColor),
+                    items: SColor.allColors,
+                    selected: self.pressureNormalColorState.key
+                )),
+                PreferencesRow(localizedString("Memory pressure warning color"), component: colorSelectView(
+                    action: #selector(togglePressureWarningColor),
+                    items: SColor.allColors,
+                    selected: self.pressureWarningColorState.key
+                )),
+                PreferencesRow(localizedString("Memory pressure critical color"), component: colorSelectView(
+                    action: #selector(togglePressureCriticalColor),
+                    items: SColor.allColors,
+                    selected: self.pressureCriticalColorState.key
                 ))
             ]))
         }
@@ -167,6 +194,29 @@ internal class Settings: NSStackView, Settings_v, NSTextFieldDelegate {
     @objc private func toggleSplitValue(_ sender: NSControl) {
         self.splitValueState = controlState(sender)
         Store.shared.set(key: "\(self.title)_splitValue", value: self.splitValueState)
+        self.callback()
+    }
+    @objc private func togglePressureFill(_ sender: NSControl) {
+        self.pressureFillState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_pressureFill", value: self.pressureFillState)
+        self.callback()
+    }
+    @objc private func togglePressureNormalColor(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        self.pressureNormalColorState = SColor.fromString(key, defaultValue: self.pressureNormalColorState)
+        Store.shared.set(key: "\(self.title)_pressureNormalColor", value: self.pressureNormalColorState.key)
+        self.callback()
+    }
+    @objc private func togglePressureWarningColor(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        self.pressureWarningColorState = SColor.fromString(key, defaultValue: self.pressureWarningColorState)
+        Store.shared.set(key: "\(self.title)_pressureWarningColor", value: self.pressureWarningColorState.key)
+        self.callback()
+    }
+    @objc private func togglePressureCriticalColor(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String else { return }
+        self.pressureCriticalColorState = SColor.fromString(key, defaultValue: self.pressureCriticalColorState)
+        Store.shared.set(key: "\(self.title)_pressureCriticalColor", value: self.pressureCriticalColorState.key)
         self.callback()
     }
     @objc private func toggleCombinedProcesses(_ sender: NSControl) {

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "لون التطبيق";
 "Wired color" = "لون المسلكة";
 "Compressed color" = "لون المضغوطة";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "لون الذاكرة المتبقية";
 "Free memory (less than)" = "الذاكرة المتبقية (أقل من)";
 "Swap size" = "حجم التبادل";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Цвят на приложението"; // translategemma:4b
 "Wired color" = "Цвят с проводник"; // translategemma:4b
 "Compressed color" = "Цвят на компресираната памет";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Цвят на свободната памет";
 "Free memory (less than)" = "Безплатно памет (по-малко от)"; // translategemma:4b
 "Swap size" = "Размер на размяната памет"; // translategemma:4b

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Color de l'aplicació";
 "Wired color" = "Color del Wired";
 "Compressed color" = "Color de la comprimida";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Color de la lliure";
 "Free memory (less than)" = "Memòria lliure (menys de)";
 "Swap size" = "Tamany del Swap";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Barva aplikační paměti";
 "Wired color" = "Barva pevné paměti";
 "Compressed color" = "Barva kompresované paměti";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Barva volné paměti";
 "Free memory (less than)" = "Volná paměť (méně než)"; // translategemma:4b
 "Swap size" = "Velikost paměti pro výměnu"; // translategemma:4b

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App farve";
 "Wired color" = "Brugt farve";
 "Compressed color" = "Komprimeret farve";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Fri farve";
 "Free memory (less than)" = "Gratis hukommelse (mindre end)"; // translategemma:4b
 "Swap size" = "Udvekslingsstørrelse"; // translategemma:4b

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App-Farbe";
 "Wired color" = "Reserviert-Farbe";
 "Compressed color" = "Komprimiert-Farbe";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Frei-Farbe";
 "Free memory (less than)" = "Freier Speicher (weniger als)";
 "Swap size" = "Swap-Größe";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Χρώμα Εφαρμογής";
 "Wired color" = "Χρώμα Δεσμευμένης";
 "Compressed color" = "Χρώμα Συμπίεσης";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Χρώμα Ελεύθερου";
 "Free memory (less than)" = "Δωρεάν μνήμη (λιγότερο από)"; // translategemma:4b
 "Swap size" = "Μέγεθος εναλλαγής"; // translategemma:4b

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App colour";
 "Wired color" = "Wired colour";
 "Compressed color" = "Compressed colour";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Free colour";
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App colour";
 "Wired color" = "Wired colour";
 "Compressed color" = "Compressed colour";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Free colour";
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App color";
 "Wired color" = "Wired color";
 "Compressed color" = "Compressed color";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Free color";
 "Free memory (less than)" = "Free memory (less than)";
 "Swap size" = "Swap size";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Color de app";
 "Wired color" = "Color física";
 "Compressed color" = "Color comprimida";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Color libre";
 "Free memory (less than)" = "Memoria libre (menos que)";
 "Swap size" = "Tamaño de swap";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Rakenduse värv";
 "Wired color" = "Juhtmega värv";
 "Compressed color" = "Tihendatud värv";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Vaba värv";
 "Free memory (less than)" = "Vaba mälu (vähem kui)";
 "Swap size" = "Saalemälu suurus";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "رنگ اپ";
 "Wired color" = "رنگ سیستم‌بندی";
 "Compressed color" = "رنگ فشرده شده";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "رنگ آزاد";
 "Free memory (less than)" = "حافظه آزاد (کمتر از)"; // translategemma:4b
 "Swap size" = "حجم حافظه فرعی"; // translategemma:4b

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Sovelluksen väri";
 "Wired color" = "Johdettujen väri";
 "Compressed color" = "Pakattujen väri";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Vapaan väri";
 "Free memory (less than)" = "Vapaa muisti (alle)";
 "Swap size" = "Välimuistin koko";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Couleur des applications";
 "Wired color" = "Couleur de la mémoire câblée";
 "Compressed color" = "Couleur de la mémoire compressée";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Couleur de la mémoire inactive";
 "Free memory (less than)" = "Mémoire disponible (moins de)";
 "Swap size" = "Taille du swap";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "צבע האפליקציה"; // translategemma:4b
 "Wired color" = "צבע מקושר"; // translategemma:4b
 "Compressed color" = "צבע דחוס"; // translategemma:4b
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "צבע בחינם"; // translategemma:4b
 "Free memory (less than)" = "זיכרון פנוי (פחות מ)"; // translategemma:4b
 "Swap size" = "גודל זיכרון וירטואלי"; // translategemma:4b

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "ऐप रंग";
 "Wired color" = "वायर्ड रंग";
 "Compressed color" = "संपीड़ित रंग";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "मुक्त रंग";
 "Free memory (less than)" = "मुफ्त मेमोरी (कम से कम)"; // translategemma:4b
 "Swap size" = "स्wap का आकार"; // translategemma:4b

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Boja aplikacije"; // translategemma:4b
 "Wired color" = "Boja s kabelom"; // translategemma:4b
 "Compressed color" = "Komprimirana boja"; // translategemma:4b
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Besplatna boja"; // translategemma:4b
 "Free memory (less than)" = "Besplatna memorija (manja od)"; // translategemma:4b
 "Swap size" = "Veličina za razmjenu"; // translategemma:4b

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Alkalmazás színe";
 "Wired color" = "Nem lapozható színe";
 "Compressed color" = "Tömörített színe";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Szabad színe";
 "Free memory (less than)" = "Szabad memória (kevesebb mint)";
 "Swap size" = "Swap mérete";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Warna aplikasi"; // translategemma:4b
 "Wired color" = "Warna kabel"; // translategemma:4b
 "Compressed color" = "Warna yang dikompres"; // translategemma:4b
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Warna gratis"; // translategemma:4b
 "Free memory (less than)" = "Memori gratis (kurang dari)"; // translategemma:4b
 "Swap size" = "Ukuran pertukaran"; // translategemma:4b

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Colore App";
 "Wired color" = "Colore Cablata";
 "Compressed color" = "Colore Compressa";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Colore Libera";
 "Free memory (less than)" = "Memoria libera (meno di)";
 "Swap size" = "Dimensione swap";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "アプリメモリの色";
 "Wired color" = "確保されているメモリの色";
 "Compressed color" = "圧縮メモリの色";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "空きメモリの色";
 "Free memory (less than)" = "空いているメモリ (以下参照)"; // translategemma:4b
 "Swap size" = "スワップサイズ"; // translategemma:4b

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "앱 색상";
 "Wired color" = "연결됨 색상";
 "Compressed color" = "압축됨 색상";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "여유 색상";
 "Free memory (less than)" = "여유 메모리 (설정값 아래로 떨어졌을 때)";
 "Swap size" = "스왑 크기"; // translategemma:4b

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App-farge";
 "Wired color" = "Bundet farge";
 "Compressed color" = "Komprimert farge";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Ledig farge";
 "Free memory (less than)" = "Gratis minne (mindre enn)"; // translategemma:4b
 "Swap size" = "Byttes størrelse"; // translategemma:4b

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Kleur voor app";
 "Wired color" = "Kleur voor bedraad";
 "Compressed color" = "Kleur voor gecomprimeerd";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Kleur voor vrij";
 "Free memory (less than)" = "Vrij geheugen (minder dan)"; // translategemma:4b
 "Swap size" = "Grootte van het swap";

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Kolor aplikacji";
 "Wired color" = "Kolor układowej przestrzeni";
 "Compressed color" = "Kolor skompresowanej przestrzeni";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Kolor wolnej przestrzeni";
 "Free memory (less than)" = "Wolna pamięć (mniej niż)";
 "Swap size" = "Rozmiar swap";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Cor do app";
 "Wired color" = "Cor para residente";
 "Compressed color" = "Cor para comprimido";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Cor livre";
 "Free memory (less than)" = "Memória livre (menor que)";
 "Swap size" = "Troca usada";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Cor da app";
 "Wired color" = "Cor por fio";
 "Compressed color" = "Cor comprimida";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Cor grátis";
 "Free memory (less than)" = "Memória livre (menos de)"; // translategemma:4b
 "Swap size" = "Tamanho do espaço de troca"; // translategemma:4b

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Culoarea aplicației"; // translategemma:4b
 "Wired color" = "Culori prin cablu"; // translategemma:4b
 "Compressed color" = "Culori comprimate"; // translategemma:4b
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Culoare gratuită"; // translategemma:4b
 "Free memory (less than)" = "Memorie disponibilă (mai puțin de)"; // translategemma:4b
 "Swap size" = "Dimensiunea spațiului de schimb"; // translategemma:4b

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Цвет приложения";
 "Wired color" = "Цвет зарезервированной памяти";
 "Compressed color" = "Цвет сжатой памяти";
+"Memory pressure indicator" = "Индикатор нагрузки памяти";
+"Memory pressure normal color" = "Цвет нормальной нагрузки";
+"Memory pressure warning color" = "Цвет предупреждения";
+"Memory pressure critical color" = "Цвет критической нагрузки";
 "Free color" = "Цвет свободной памяти";
 "Free memory (less than)" = "Свободная память (менее чем)";
 "Swap size" = "Размер swap";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Aplikačná";
 "Wired color" = "Pevná";
 "Compressed color" = "Komprimovaná";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Voľná";
 "Free memory (less than)" = "Voľná pamäť (menej ako)"; // translategemma:4b
 "Swap size" = "Veľkosť výmeny"; // translategemma:4b

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Aplikacijska barva";
 "Wired color" = "Žična barva";
 "Compressed color" = "Stisnjena barva";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Prosta barva";
 "Free memory (less than)" = "Prosti pomnilnik (manj kot)";
 "Swap size" = "Swap velikost";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Appfärg";
 "Wired color" = "Resident minnesfärg";
 "Compressed color" = "Komprimerat minnesfärg";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Ledigt minnesfärg";
 "Free memory (less than)" = "Ledigt minne (mindre än)";
 "Swap size" = "Växlingsstorlek";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "สีของแอพ";
 "Wired color" = "สี Wired";
 "Compressed color" = "สีที่บีบอัด";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "สีที่ว่าง";
 "Free memory (less than)" = "หน่วยความจำเหลือ (น้อยกว่า)"; // translategemma:4b
 "Swap size" = "ขนาดของการแลกเปลี่ยน"; // translategemma:4b

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Uygulama rengi";
 "Wired color" = "Bağlı rengi";
 "Compressed color" = "Sıkıştırılmış rengi";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Boş rengi";
 "Free memory (less than)" = "Boş hafıza (yüzdeden az ise)";
 "Swap size" = "Swap boyutu";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Колір програми";
 "Wired color" = "Колір постійної пам’яті";
 "Compressed color" = "Колір стисненої пам’яті";
+"Memory pressure indicator" = "Індикатор навантаження пам'яті";
+"Memory pressure normal color" = "Колір нормального навантаження";
+"Memory pressure warning color" = "Колір попередження";
+"Memory pressure critical color" = "Колір критичного навантаження";
 "Free color" = "Колір вільної пам’яті";
 "Free memory (less than)" = "Вільна пам'ять (менше ніж)";
 "Swap size" = "Розмір swap";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "Màu ứng dụng";
 "Wired color" = "Màu có dây";
 "Compressed color" = "Màu đã nén";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "Màu trống";
 "Free memory (less than)" = "Bộ nhớ trống (nhỏ hơn)";
 "Swap size" = "Dung lượng bộ nhớ ảo";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App内存颜色";
 "Wired color" = "联动内存颜色";
 "Compressed color" = "被压缩内存颜色";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "可用内存颜色";
 "Free memory (less than)" = "可用内存（小于）";
 "Swap size" = "已使用交换";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "App color" = "App色彩";
 "Wired color" = "連動記憶體色彩";
 "Compressed color" = "已壓縮記憶體色彩";
+"Memory pressure indicator" = "Memory pressure indicator";
+"Memory pressure normal color" = "Memory pressure normal color";
+"Memory pressure warning color" = "Memory pressure warning color";
+"Memory pressure critical color" = "Memory pressure critical color";
 "Free color" = "閒置記憶體色彩";
 "Free memory (less than)" = "可用記憶體 (小於)";
 "Swap size" = "已使用交換";


### PR DESCRIPTION
## What
Adds a new opt-in **"Memory pressure indicator"** mode to the RAM `bar_chart` widget that mirrors the Activity Monitor "Memory Pressure" graph.

<p align="center"><img src="https://raw.githubusercontent.com/Serj92/stats/assets/pr-screenshots/widgets-final-2x.png" width="700" alt="Stats menu bar showing RAM widget with green pressure-indicator fill at the bottom" /></p>
<p align="center"><sub><strong>RAM</strong> = green pressure-indicator fill (normal level) &nbsp;·&nbsp; (NET/SSD/CPU widgets show unrelated features from sibling PRs)</sub></p>

## Why
The current RAM bar shows *used memory* — but on modern macOS, used memory is a misleading proxy for actual memory pressure. macOS aggressively uses RAM for cache / buffers (memory shown as "used" may be reclaimable instantly), while a fraction of "real" pressure — wired + compressed pages, which the system *cannot* reclaim quickly — can hit critical levels even when the bar still looks half-empty. Activity Monitor exposes this with a dedicated Memory Pressure graph for exactly this reason. Stats users have asked for parity — #3234.

## How it works
- **Fill height** = `(wired + compressed) / total` — the fraction of RAM the kernel cannot reclaim quickly. Wired pages are locked by the kernel; compressed pages are already squeezed and can only leave via swap I/O.
- **Color** comes directly from the kernel's own pressure verdict (`RAMPressure.normal/warning/critical`), so transitions in the menu bar match Activity Monitor's color transitions exactly — not from a Stats-side heuristic.
- Three configurable color slots (`Memory pressure normal/warning/critical color`) let users theme it; defaults are the secondary green / yellow / red palette already used elsewhere in Stats.

## Behavior unchanged unless opted in
Off by default. Mutually exclusive with the existing `Split the value (App/Wired/Compressed)` toggle — only one of the two can be active at a time, so the bar's meaning is never ambiguous.

## Known trade-offs (honest list)
- `wired + compressed` is a reasonable proxy for "non-reclaimable" pressure, but it's not literally what `memory_pressure(8)` calculates internally. I chose it because (a) both values are already exposed in `RAM_Usage` so no new readers were needed, and (b) it's the same intuition Activity Monitor visualizes.
- The kernel verdict (`pressure.value`) is what drives the color, so even if the fill ratio diverges slightly from the kernel's internal calculation, the **color** stays authoritative.
- Three new color settings add some visual weight to the RAM settings panel — happy to collapse them into a single "Theme" submenu or similar if you prefer.

## Localizations
Four new strings (`Memory pressure indicator`, `Memory pressure normal/warning/critical color`) added to `en.lproj`, `ru.lproj`, `uk.lproj`. The remaining 28 language files received an English fallback via `Kit/scripts/i18n.py fix` so the i18n CI check passes.

Refs #3234.