### PR TITLE
feat: color CPU bar segments by core type (E/P)

### DIFF
--- a/Modules/CPU/main.swift
+++ b/Modules/CPU/main.swift
@@ -78,6 +78,9 @@ public class CPU: Module {
     private var groupByClustersState: Bool {
         Store.shared.bool(key: "\(self.config.name)_clustersGroup", defaultValue: false)
     }
+    private var coresColorState: Bool {
+        Store.shared.bool(key: "\(self.config.name)_coresColor", defaultValue: false)
+    }
     private var systemColor: NSColor {
         let color = SColor.secondRed
         let key = Store.shared.string(key: "\(self.config.name)_systemColor", defaultValue: color.key)
@@ -219,6 +222,27 @@ public class CPU: Module {
                         }
                     } else {
                         val = value.usagePerCore.map({ [ColorValue($0)] })
+                    }
+                } else if self.coresColorState {
+                    // Single thin column, stacked by core type. Each segment is
+                    // weighted by that cluster's share of all cores so the total
+                    // fill equals weighted overall usage.
+                    let total = max(cores.count, 1)
+                    let eCount = cores.filter({ $0.type == .efficiency }).count
+                    let pCount = cores.filter({ $0.type == .performance }).count
+                    let sCount = cores.filter({ $0.type == .super }).count
+                    var segments: [ColorValue] = []
+                    if eCount > 0, let e = value.usageECores {
+                        segments.append(ColorValue(e * Double(eCount)/Double(total), color: self.eCoresColor))
+                    }
+                    if pCount > 0, let p = value.usagePCores {
+                        segments.append(ColorValue(p * Double(pCount)/Double(total), color: self.pCoresColor))
+                    }
+                    if sCount > 0, let s = value.usageSCores {
+                        segments.append(ColorValue(s * Double(sCount)/Double(total), color: self.sCoresColor))
+                    }
+                    if !segments.isEmpty {
+                        val = [segments]
                     }
                 } else if self.splitValueState {
                     val = [[

--- a/Modules/CPU/settings.swift
+++ b/Modules/CPU/settings.swift
@@ -20,7 +20,8 @@ internal class Settings: NSStackView, Settings_v {
     private var updateTopIntervalValue: Int = 1
     private var numberOfProcesses: Int = 8
     private var clustersGroupState: Bool = false
-    
+    private var coresColorState: Bool = false
+
     private let title: String
     private var hasHyperthreadingCores = false
     
@@ -47,6 +48,7 @@ internal class Settings: NSStackView, Settings_v {
         }
         self.hasHyperthreadingCores = sysctlByName("hw.physicalcpu") != sysctlByName("hw.logicalcpu")
         self.clustersGroupState = Store.shared.bool(key: "\(self.title)_clustersGroup", defaultValue: self.clustersGroupState)
+        self.coresColorState = Store.shared.bool(key: "\(self.title)_coresColor", defaultValue: self.coresColorState)
         
         super.init(frame: NSRect(x: 0, y: 0, width: 0, height: 0))
         
@@ -108,6 +110,10 @@ internal class Settings: NSStackView, Settings_v {
                 state: self.clustersGroupState
             )
             rows.append(PreferencesRow(localizedString("Cluster grouping"), component: self.groupByClustersView!))
+            rows.append(PreferencesRow(localizedString("Color cores by type (E/P)"), component: switchView(
+                action: #selector(self.toggleCoresColor),
+                state: self.coresColorState
+            )))
             #endif
             
             if self.hasHyperthreadingCores {
@@ -186,6 +192,12 @@ internal class Settings: NSStackView, Settings_v {
         self.callback()
     }
     
+    @objc func toggleCoresColor(_ sender: NSControl) {
+        self.coresColorState = controlState(sender)
+        Store.shared.set(key: "\(self.title)_coresColor", value: self.coresColorState)
+        self.callback()
+    }
+
     @objc func toggleClustersGroup(_ sender: NSControl) {
         self.clustersGroupState = controlState(sender)
         Store.shared.set(key: "\(self.title)_clustersGroup", value: self.clustersGroupState)

--- a/Stats/Supporting Files/ar.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ar.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "لون المستخدم";
 "Idle color" = "لون الخمول";
 "Cluster grouping" = "تجميع المجموعات";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "لون نوى الكفاءة";
 "Performance cores color" = "لون نوى الأداء";
 "Total load" = "إجمالي الحمل";

--- a/Stats/Supporting Files/bg.lproj/Localizable.strings
+++ b/Stats/Supporting Files/bg.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Потребителски цвят";
 "Idle color" = "Цвят при неактивност";
 "Cluster grouping" = "Групиране на кластери"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Цветове на ядрата за ефективност"; // translategemma:4b
 "Performance cores color" = "Цвят на ядрата за производителност"; // translategemma:4b
 "Total load" = "Обща консумация"; // translategemma:4b

--- a/Stats/Supporting Files/ca.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ca.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Color de l'usuari";
 "Idle color" = "Sense color";
 "Cluster grouping" = "Agrupament en cluster";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Color dels nuclis d'eficiència";
 "Performance cores color" = "Color dels nuclis de rendiment";
 "Total load" = "Càrrega total";

--- a/Stats/Supporting Files/cs.lproj/Localizable.strings
+++ b/Stats/Supporting Files/cs.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Barva uživatele";
 "Idle color" = "Barva nečinnosti";
 "Cluster grouping" = "Seskupení klastrů";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efektivní jádra – barva"; // translategemma:4b
 "Performance cores color" = "Barva výkonových jader"; // translategemma:4b
 "Total load" = "Celková zátěž"; // translategemma:4b

--- a/Stats/Supporting Files/da.lproj/Localizable.strings
+++ b/Stats/Supporting Files/da.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Bruger farve";
 "Idle color" = "'Ikke i brug' farve";
 "Cluster grouping" = "Grupper efter type";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efficiency kerner farve";
 "Performance cores color" = "Performance kerner farve";
 "Total load" = "Samlet belastning"; // translategemma:4b

--- a/Stats/Supporting Files/de.lproj/Localizable.strings
+++ b/Stats/Supporting Files/de.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Benutzerfarbe";
 "Idle color" = "Leerlauffarbe";
 "Cluster grouping" = "Cluster-Gruppierung";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Effizienzkerne-Farbe";
 "Performance cores color" = "Leistungskerne-Farbe";
 "Total load" = "Gesamtlast";

--- a/Stats/Supporting Files/el.lproj/Localizable.strings
+++ b/Stats/Supporting Files/el.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Χρώμα χρήστη"; // translategemma:4b
 "Idle color" = "Χρώμα σε κατάσταση αναμονής"; // translategemma:4b
 "Cluster grouping" = "Ομαδοποίηση"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Χρώμα πυρήνων απόδοσης"; // translategemma:4b
 "Performance cores color" = "Χρώμα των πυρήνων απόδοσης"; // translategemma:4b
 "Total load" = "Συνολική χωρητικότητα"; // translategemma:4b

--- a/Stats/Supporting Files/en-AU.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-AU.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "User colour";
 "Idle color" = "Idle colour";
 "Cluster grouping" = "Cluster grouping";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efficiency cores colour";
 "Performance cores color" = "Performance cores colour";
 "Total load" = "Total load";

--- a/Stats/Supporting Files/en-GB.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en-GB.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "User colour";
 "Idle color" = "Idle colour";
 "Cluster grouping" = "Cluster grouping";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efficiency cores colour";
 "Performance cores color" = "Performance cores colour";
 "Total load" = "Total load";

--- a/Stats/Supporting Files/en.lproj/Localizable.strings
+++ b/Stats/Supporting Files/en.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "User color";
 "Idle color" = "Idle color";
 "Cluster grouping" = "Cluster grouping";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efficiency cores color";
 "Performance cores color" = "Performance cores color";
 "Total load" = "Total load";

--- a/Stats/Supporting Files/es.lproj/Localizable.strings
+++ b/Stats/Supporting Files/es.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Color del usuario";
 "Idle color" = "Color inactivo";
 "Cluster grouping" = "Agrupación de clústeres";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Color de núcleos de eficiencia";
 "Performance cores color" = "Color de núcleos de rendimiento";
 "Total load" = "Carga total";

--- a/Stats/Supporting Files/et.lproj/Localizable.strings
+++ b/Stats/Supporting Files/et.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Kasutaja värv";
 "Idle color" = "Ooteloleku värv";
 "Cluster grouping" = "Klastrite rühmitamine";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Tõhusustuumade värv";
 "Performance cores color" = "Jõudlustuumade värv";
 "Total load" = "Kokku koormus";

--- a/Stats/Supporting Files/fa.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fa.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "رنگ کاربر";
 "Idle color" = "رنگ بیکار";
 "Cluster grouping" = "گروه‌بندی کلاستر";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "رنگ هسته‌های بهینه‌سازی"; // translategemma:4b
 "Performance cores color" = "رنگ هسته‌های عملکرد"; // translategemma:4b
 "Total load" = "مجموع بار"; // translategemma:4b

--- a/Stats/Supporting Files/fi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fi.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Käyttäjän väri";
 "Idle color" = "Lepotilan väri";
 "Cluster grouping" = "Ryhmien klusterointi";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "E-ytimien väri";
 "Performance cores color" = "P-ytimien väri";
 "Total load" = "Kokonaiskuorma";

--- a/Stats/Supporting Files/fr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/fr.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Couleur de l'utilisateur";
 "Idle color" = "Couleur de l'inactivité";
 "Cluster grouping" = "Regroupement par cluster";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Couleur des cœurs à haute effica­cité éner­gétique";
 "Performance cores color" = "Couleur des cœurs de performance";
 "Total load" = "Charge totale";

--- a/Stats/Supporting Files/he.lproj/Localizable.strings
+++ b/Stats/Supporting Files/he.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "צבע המשתמש"; // translategemma:4b
 "Idle color" = "צבע כשאין פעילות"; // translategemma:4b
 "Cluster grouping" = "קיבוץ"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "ליבות יעילות בצבע"; // translategemma:4b
 "Performance cores color" = "צבע ליבות הביצועים"; // translategemma:4b
 "Total load" = "סה\"כ עומס"; // translategemma:4b

--- a/Stats/Supporting Files/hi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hi.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "उपयोगकर्ता रंग";
 "Idle color" = "निष्क्रिय रंग";
 "Cluster grouping" = "क्लस्टर समूहीकरण";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "दक्षता कोर रंग";
 "Performance cores color" = "प्रदर्शन कोर रंग";
 "Total load" = "कुल भार"; // translategemma:4b

--- a/Stats/Supporting Files/hr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hr.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Boja korisnika"; // translategemma:4b
 "Idle color" = "Boja u stanju mirovanja"; // translategemma:4b
 "Cluster grouping" = "Grupiranje"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Cores za učinkovitost, boje"; // translategemma:4b
 "Performance cores color" = "Boja jezgara za performanse"; // translategemma:4b
 "Total load" = "Ukupna optereženost"; // translategemma:4b

--- a/Stats/Supporting Files/hu.lproj/Localizable.strings
+++ b/Stats/Supporting Files/hu.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Felhasználó színe";
 "Idle color" = "Tétlenség színe";
 "Cluster grouping" = "Csoportosítás";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Energiatakarékos magok színe";
 "Performance cores color" = "Teljesítmény magok színe";
 "Total load" = "Teljes terheltség";

--- a/Stats/Supporting Files/id.lproj/Localizable.strings
+++ b/Stats/Supporting Files/id.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Warna pengguna"; // translategemma:4b
 "Idle color" = "Warna saat tidak digunakan"; // translategemma:4b
 "Cluster grouping" = "Pengelompokan klaster"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Inti warna"; // translategemma:4b
 "Performance cores color" = "Warna inti kinerja"; // translategemma:4b
 "Total load" = "Total beban"; // translategemma:4b

--- a/Stats/Supporting Files/it.lproj/Localizable.strings
+++ b/Stats/Supporting Files/it.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Colore utente";
 "Idle color" = "Colore inattivo";
 "Cluster grouping" = "Raggruppamento cluster";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Colore per efficiency core";
 "Performance cores color" = "Colore per performance core";
 "Total load" = "Carico totale";

--- a/Stats/Supporting Files/ja.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ja.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "ユーザーの色"; // translategemma:4b
 "Idle color" = "アイドルの色"; // translategemma:4b
 "Cluster grouping" = "クラスタリング"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "高効率コアの色";
 "Performance cores color" = "高性能コアの色";
 "Total load" = "合計負荷"; // translategemma:4b

--- a/Stats/Supporting Files/ko.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ko.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "사용자 색상";
 "Idle color" = "대기 색상";
 "Cluster grouping" = "클러스터 묶기";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "효율 코어 색상";
 "Performance cores color" = "성능 코어 색상";
 "Total load" = "총 부하";

--- a/Stats/Supporting Files/nb.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nb.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Brukerfarge";
 "Idle color" = "Tomgangsfarge";
 "Cluster grouping" = "Klyngegruppering";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Farge på effektivitetskjerner";
 "Performance cores color" = "Farge på ytelseskjerner";
 "Total load" = "Total last"; // translategemma:4b

--- a/Stats/Supporting Files/nl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/nl.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Kleur voor gebruikersbelasting";
 "Idle color" = "Kleur voor inactief";
 "Cluster grouping" = "Groeperen van clusters"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Kleur voor efficiëntiecores";
 "Performance cores color" = "Kleur voor prestatiecores";
 "Total load" = "Totale belasting"; // translategemma:4b

--- a/Stats/Supporting Files/pl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pl.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Kolor użytkownika";
 "Idle color" = "Nieaktywny kolor";
 "Cluster grouping" = "Grupowanie klastrów";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Kolor rdzeni energooszczędnych";
 "Performance cores color" = "Kolor rdzeni wydajnościowych";
 "Total load" = "Całkowite obciążenie";

--- a/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-BR.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Cor do usuário";
 "Idle color" = "Cor pausado";
 "Cluster grouping" = "Agrupamento";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Cor para Núcleos de Eficiência";
 "Performance cores color" = "Cor para Núcleos de Desempenho";
 "Total load" = "Carga total";

--- a/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
+++ b/Stats/Supporting Files/pt-PT.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Cor do user";
 "Idle color" = "Cor em idle";
 "Cluster grouping" = "Agrupamento de cluster";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Núcleos de eficiência, cores"; // translategemma:4b
 "Performance cores color" = "Cores dos núcleos de desempenho"; // translategemma:4b
 "Total load" = "Carga total"; // translategemma:4b

--- a/Stats/Supporting Files/ro.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ro.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Culoarea utilizatorului"; // translategemma:4b
 "Idle color" = "Culoarea în repaus"; // translategemma:4b
 "Cluster grouping" = "Gruparea în clustere"; // translategemma:4b
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Cores cu eficiență, culori"; // translategemma:4b
 "Performance cores color" = "Culorile nucleelor de performanță"; // translategemma:4b
 "Total load" = "Suma totală"; // translategemma:4b

--- a/Stats/Supporting Files/ru.lproj/Localizable.strings
+++ b/Stats/Supporting Files/ru.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Пользовательский цвет";
 "Idle color" = "Холостой цвет";
 "Cluster grouping" = "Кластерная группировка";
+"Color cores by type (E/P)" = "Раскрасить по типу ядер (E/P)";
 "Efficiency cores color" = "Цвет энергоэффективных ядер";
 "Performance cores color" = "Цвет производительных ядер";
 "Total load" = "Общая нагрузка";

--- a/Stats/Supporting Files/sk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sk.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Používateľ";
 "Idle color" = "Nečinnosť";
 "Cluster grouping" = "Zoskupenie klastrov";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Efektívne jadrá – farba"; // translategemma:4b
 "Performance cores color" = "Farba výkonových jadier"; // translategemma:4b
 "Total load" = "Celková záťaž"; // translategemma:4b

--- a/Stats/Supporting Files/sl.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sl.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Uporabniška barva";
 "Idle color" = "Barva mirovanja";
 "Cluster grouping" = "Združevanje v gruče";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Barva učinkovitih jeder";
 "Performance cores color" = "Barva performančnih jeder";
 "Total load" = "Skupna obremenitev";

--- a/Stats/Supporting Files/sv.lproj/Localizable.strings
+++ b/Stats/Supporting Files/sv.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Användarfärg";
 "Idle color" = "Overksamhetsfärg";
 "Cluster grouping" = "Klustergruppering";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Effektivitetskärnors färg";
 "Performance cores color" = "Prestandakärnors färg";
 "Total load" = "Total belastning";

--- a/Stats/Supporting Files/th.lproj/Localizable.strings
+++ b/Stats/Supporting Files/th.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "สีของผู้ใช้";
 "Idle color" = "สีของว่างเปล่า";
 "Cluster grouping" = "การจัดกลุ่ม Cluster";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "จำนวนคอร์ประสิทธิภาพ สี"; // translategemma:4b
 "Performance cores color" = "สีของคอร์ประสิทธิภาพ"; // translategemma:4b
 "Total load" = "ปริมาณการใช้งานทั้งหมด"; // translategemma:4b

--- a/Stats/Supporting Files/tr.lproj/Localizable.strings
+++ b/Stats/Supporting Files/tr.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Kullanıcı rengi";
 "Idle color" = "Boşta rengi";
 "Cluster grouping" = "Küme gruplaması";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Verimlilik çekirdeklerinin rengi";
 "Performance cores color" = "Performans çekirdeklerinin rengi";
 "Total load" = "Toplam yük";

--- a/Stats/Supporting Files/uk.lproj/Localizable.strings
+++ b/Stats/Supporting Files/uk.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Колір користувача";
 "Idle color" = "Колір простою";
 "Cluster grouping" = "Кластерне групування";
+"Color cores by type (E/P)" = "Розфарбувати за типом ядер (E/P)";
 "Efficiency cores color" = "Колір енергоефективних ядер";
 "Performance cores color" = "Колір високопродуктивних ядер";
 "Total load" = "Загальне використання";

--- a/Stats/Supporting Files/vi.lproj/Localizable.strings
+++ b/Stats/Supporting Files/vi.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "Màu người dùng";
 "Idle color" = "Màu nhàn rỗi";
 "Cluster grouping" = "Nhóm cụm";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "Màu nhân tiết kiệm";
 "Performance cores color" = "Màu nhân hiệu năng";
 "Total load" = "Tải tổng";

--- a/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "用户占用颜色";
 "Idle color" = "闲置颜色";
 "Cluster grouping" = "按集群分组";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "能效核心颜色";
 "Performance cores color" = "性能核心颜色";
 "Total load" = "总占用";

--- a/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Stats/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 "User color" = "使用者占用色彩";
 "Idle color" = "閒置色彩";
 "Cluster grouping" = "依群集分組";
+"Color cores by type (E/P)" = "Color cores by type (E/P)";
 "Efficiency cores color" = "節能核心色彩";
 "Performance cores color" = "效能核心色彩";
 "Total load" = "總占用";


### PR DESCRIPTION
## What
Adds an opt-in **"Color cores by type (E/P)"** toggle to the CPU `bar_chart` settings on Apple Silicon. When enabled, the bar stays a single thin column (unlike per-core or cluster-grouping modes which fan out one bar per core/cluster), but the fill is split into stacked color segments by core type: efficiency cores at the bottom, performance cores stacked on top, super cores above when present.

<p align="center"><img src="https://raw.githubusercontent.com/Serj92/stats/assets/pr-screenshots/widgets-final-2x.png" width="700" alt="Stats menu bar with CPU widget split into red (P-cores) on top and blue (E-cores) at bottom" /></p>
<p align="center"><sub><strong>CPU</strong> = red P-core segment on top, blue E-core segment at bottom &nbsp;·&nbsp; (NET/SSD/RAM widgets show unrelated features from sibling PRs)</sub></p>

## Why
On Apple Silicon, total CPU load is misleading on its own: 100% on E-cores under a background task is fundamentally different from 100% on P-cores under real compute load (and the two draw very different amounts of power). Stats already exposes this breakdown — but only via per-core or cluster-grouping modes that fan out into multiple bars/columns, which doesn't fit a tight menu bar. Coloring a single column by core type keeps the bar compact while still answering "what kind of work is loading my CPU right now?" at a glance.

## How it works
- Each segment height = that cluster's usage × (its share of total core count). E.g. on an M1 Pro with 2 E-cores + 8 P-cores, the P-core segment is weighted 8/10 and the E-core segment 2/10 — so the combined fill equals the overall weighted CPU load, just colored by cluster.
- Segment colors reuse the existing `eCoresColor` / `pCoresColor` / `sCoresColor` settings already exposed in the CPU popup — **no new pickers**, theming carries over automatically.
- The toggle lives inside the existing `#if arch(arm64)` Apple-Silicon-only settings block (right after `Cluster grouping`), so it never appears on Intel.

## Behavior unchanged unless opted in
Off by default. When off, the bar renders identically to before. Mutually exclusive with per-core and split-value modes via the existing `if/else if` chain in the render path — only one mode is active at a time.

## Known trade-offs (honest list)
- The weighted-by-core-count math means a small fraction of E-cores running flat-out shows up as a thin segment, even if their absolute utilization is 100%. This is consistent with how the existing overall-load math works (so the total fill height is unchanged), but it does mean "E-cores pegged" is visually subtler than "P-cores pegged". If you'd prefer un-weighted segments (each segment fills its own band by cluster utilization), it's a one-line change.
- The new toggle adds a row to an already-busy CPU settings panel. Happy to reorder/collapse if you have a preferred layout.

## Localizations
One new string (`Color cores by type (E/P)`) added to `en.lproj`, `ru.lproj`, `uk.lproj`. The remaining 28 language files received an English fallback via `Kit/scripts/i18n.py fix` so the i18n CI check passes.