### PR TITLE
Reduce menu bar chart redraw CPU

### DIFF
--- a/Kit/Widgets/LineChart.swift
+++ b/Kit/Widgets/LineChart.swift
@@ -26,7 +26,7 @@ public class LineChart: WidgetWrapper {
         y: 0,
         width: 32,
         height: Constants.Widget.height - (2*Constants.Widget.margin.y)
-    ), num: 60)
+    ), num: 60, animation: false)
     private var colors: [SColor] = SColor.allCases.filter({ $0 != SColor.cluster })
     private var _value: Double = 0
     private var _pressureLevel: RAMPressure = .normal
@@ -107,8 +107,6 @@ public class LineChart: WidgetWrapper {
             self.chart.reinit(self.historyCount)
         }
         
-        self.addSubview(self.chart)
-        
         if self.labelState {
             self.setFrameSize(NSSize(width: Constants.Widget.width + 6 + (Constants.Widget.margin.x*2), height: self.frame.size.height))
         }
@@ -134,8 +132,6 @@ public class LineChart: WidgetWrapper {
             let str = NSAttributedString.init(string: "\(char)", attributes: stringAttributes)
             self.NSLabelCharts.append(str)
         }
-        
-        self.chart.setTooltipEnabled(false)
     }
     
     required init?(coder: NSCoder) {
@@ -145,7 +141,7 @@ public class LineChart: WidgetWrapper {
     public override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         
-        guard NSGraphicsContext.current != nil else { return }
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
         
         var value: Double = 0
         var pressureLevel: RAMPressure = .normal
@@ -228,16 +224,18 @@ public class LineChart: WidgetWrapper {
         } else {
             self.chart.setTransparent(true)
         }
-        
+        context.saveGState()
+        context.translateBy(x: x+offset+lineWidth, y: offset)
+
         let chartSize = NSSize(
             width: box.bounds.width - (offset*2+lineWidth),
             height: box.bounds.height - offset
         )
         self.chart.setColor(color)
-        let chartFrame = NSRect(x: x+offset+lineWidth, y: offset, width: chartSize.width, height: chartSize.height)
-        if self.chart.frame != chartFrame {
-            self.chart.frame = chartFrame
-        }
+        self.chart.setFrameSize(chartSize)
+        self.chart.draw(NSRect(origin: .zero, size: chartSize))
+
+        context.restoreGState()
         
         if self.boxState || self.frameState {
             (isDarkMode ? NSColor.white : NSColor.black).set()

--- a/Kit/Widgets/PieChart.swift
+++ b/Kit/Widgets/PieChart.swift
@@ -22,7 +22,7 @@ public class PieChart: WidgetWrapper {
             width: Constants.Widget.height,
             height: Constants.Widget.height
         ),
-        segments: [], filled: true, drawValue: false
+        segments: [], filled: true, drawValue: false, animation: false
     )
     private var labelView: NSView? = nil
     

--- a/Kit/Widgets/Tachometer.swift
+++ b/Kit/Widgets/Tachometer.swift
@@ -21,7 +21,7 @@ public class Tachometer: WidgetWrapper {
             y: Constants.Widget.margin.y,
             width: Constants.Widget.height,
             height: Constants.Widget.height
-        ), segments: []
+        ), segments: [], animation: false
     )
     private var labelView: NSView? = nil
     


### PR DESCRIPTION
## Summary
- render compact menu bar line charts inline again instead of installing a live layer-backed `LineChartView` subview, removing the v3 smooth-slide redraw/compositing path from CPU/RAM line-chart widgets
- disable compact pie/tachometer fade transitions while keeping popup/preview chart animations enabled

Fixes #3298
Related #3294

## Testing
- `xcodebuild -scheme Stats -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/stats-cpu-after-inline build`
- Focused CPU/RAM line-chart A/B, 60 samples each at 2s updates: Stats process mean was unchanged at 0.63%; WindowServer median was 68.60% upstream vs 67.95% patched, with a high no-Stats baseline of 69.15%. The local desktop baseline is still too noisy to claim a precise CPU reduction from this benchmark.