### PR TITLE
Reuse tracking areas: fixes runaway CPU and memory growth on macOS 26+

### DIFF
--- a/Kit/extensions.swift
+++ b/Kit/extensions.swift
@@ -236,6 +236,20 @@ public extension Double {
 }
 
 public extension NSView {
+    // idempotent: destroy/recreate per updateTrackingAreas call re-registers with WindowServer
+    // and storms cursor image rebuilds on macOS 26+
+    func ensureTrackingArea(
+        _ enabled: Bool = true,
+        options: NSTrackingArea.Options = [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .inVisibleRect]
+    ) {
+        if enabled {
+            guard self.trackingAreas.isEmpty else { return }
+            self.addTrackingArea(NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil))
+        } else if !self.trackingAreas.isEmpty {
+            self.trackingAreas.forEach({ self.removeTrackingArea($0) })
+        }
+    }
+
     var isDarkMode: Bool {
         switch effectiveAppearance.name {
         case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:

--- a/Kit/plugins/Charts.swift
+++ b/Kit/plugins/Charts.swift
@@ -527,22 +527,10 @@ public class LineChartView: ChartView {
     }
     
     public override func updateTrackingAreas() {
-        self.trackingAreas.forEach({ self.removeTrackingArea($0) })
-        if self.tooltipEnabledSnapshot {
-            self.addTrackingArea(NSTrackingArea(
-                rect: .zero,
-                options: [
-                    .activeAlways,
-                    .mouseEnteredAndExited,
-                    .mouseMoved,
-                    .inVisibleRect
-                ],
-                owner: self, userInfo: nil
-            ))
-        }
+        self.ensureTrackingArea(self.tooltipEnabledSnapshot)
         super.updateTrackingAreas()
     }
-    
+
     public override func hitTest(_ point: NSPoint) -> NSView? {
         guard self.tooltipEnabledSnapshot else { return nil }
         return super.hitTest(point)
@@ -1346,17 +1334,7 @@ public class ColumnChartView: ChartView {
     }
     
     public override func updateTrackingAreas() {
-        self.trackingAreas.forEach({ self.removeTrackingArea($0) })
-        self.addTrackingArea(NSTrackingArea(
-            rect: .zero,
-            options: [
-                .activeAlways,
-                .mouseEnteredAndExited,
-                .mouseMoved,
-                .inVisibleRect
-            ],
-            owner: self, userInfo: nil
-        ))
+        self.ensureTrackingArea()
         super.updateTrackingAreas()
     }
 }
@@ -1464,12 +1442,7 @@ public class GridChartView: ChartView {
     }
     
     public override func updateTrackingAreas() {
-        self.trackingAreas.forEach({ self.removeTrackingArea($0) })
-        self.addTrackingArea(NSTrackingArea(
-            rect: CGRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height),
-            options: [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .inVisibleRect],
-            owner: self, userInfo: nil
-        ))
+        self.ensureTrackingArea()
         super.updateTrackingAreas()
     }
 }

--- a/Modules/Clock/popup.swift
+++ b/Modules/Clock/popup.swift
@@ -544,14 +544,8 @@ private class CalendarItemView: NSView {
     
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
-        self.trackingAreas.forEach { self.removeTrackingArea($0) }
-        guard self.isHoverable else { return }
-        self.addTrackingArea(NSTrackingArea(
-            rect: self.bounds,
-            options: [.mouseEnteredAndExited, .activeInActiveApp],
-            owner: self,
-            userInfo: nil
-        ))
+        // .inVisibleRect: rect auto-follows resize
+        self.ensureTrackingArea(self.isHoverable, options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect])
     }
     
     override func mouseEntered(with event: NSEvent) {


### PR DESCRIPTION
Stats slowly eats CPU and RAM on macOS 26/27: 50-80% CPU with a few modules enabled at 10s intervals, laggy popups, and RSS growing a few hundred MB per hour until restart.

Profiled it on 27.0 (26A5388g, M1 Max) instead of guessing:

- a 3s spindump puts 91% of main-thread samples inside `_NSTrackingAreaAKManager` → `NSCursor set` → `_AXFMouseCursorGenerator createImageForScale:` — the OS rebuilds the cursor image on every tracking-area registration
- a 15-minute `heap` diff on the live process shows `xpc_dictionary_t` going 4,667 → 879,566 (~970 new dictionaries per second) plus +291k `__NSMallocBlock__` — that is the memory growth

The trigger: every chart's `updateTrackingAreas()` removes and re-creates its `NSTrackingArea` on each call, and AppKit invokes that on every layout/animation pass, so charts re-register with WindowServer continuously. Older macOS absorbs this cheaply; the new cursor pipeline doesn't (worst with an accessibility-customized cursor color, which makes the OS re-render the cursor with a blur shadow on every set — that part is Apple's regression and I'm filing it separately).

This PR adds `NSView.ensureTrackingArea()` — install once, reuse, remove when disabled; `.inVisibleRect` already keeps the rect in sync — and uses it in `LineChartView`, `ColumnChartView`, `GridChartView` and the Clock popup. Options per site are unchanged (the Clock popup additionally gains `.inVisibleRect`, matching what its old rect re-creation achieved). Net -19 lines.

After the fix, same modules and intervals: 0.6% CPU, flat XPC dictionary count, 38MB RSS. On older macOS this simply removes redundant re-registration work.
